### PR TITLE
Add configurable dictation paste shortcut

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseExecutor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseExecutor.swift
@@ -78,7 +78,8 @@ enum ComputerUseToolExecutor {
 
     static func execute(
         _ toolCall: ComputerUseToolCall,
-        registry: ComputerUseElementRegistry?
+        registry: ComputerUseElementRegistry?,
+        pasteShortcut: PasteShortcut
     ) async -> ComputerUseExecutionResult {
         if let failure = toolCall.validationFailure() {
             return .unsupported(failure)
@@ -115,9 +116,9 @@ enum ComputerUseToolExecutor {
                 key: toolCall.key ?? ""
             ))
         case .typeText:
-            return await enterText(toolCall, registry: registry, mode: .keyboard)
+            return await enterText(toolCall, registry: registry, mode: .keyboard, pasteShortcut: pasteShortcut)
         case .pasteText:
-            return await enterText(toolCall, registry: registry, mode: .paste)
+            return await enterText(toolCall, registry: registry, mode: .paste, pasteShortcut: pasteShortcut)
         case .scroll:
             return scroll(toolCall, registry: registry)
         case .listBrowserTabs:
@@ -496,7 +497,8 @@ enum ComputerUseToolExecutor {
     private static func enterText(
         _ toolCall: ComputerUseToolCall,
         registry: ComputerUseElementRegistry?,
-        mode: TextEntryMode
+        mode: TextEntryMode,
+        pasteShortcut: PasteShortcut
     ) async -> ComputerUseExecutionResult {
         let targetApp = await prepareTextEntryApp(toolCall)
         if case let .failure(message) = targetApp {
@@ -532,7 +534,7 @@ enum ComputerUseToolExecutor {
                 return .failed(error.localizedDescription)
             }
         case .paste:
-            PasteController.paste(text: toolCall.text ?? "")
+            PasteController.paste(text: toolCall.text ?? "", shortcut: pasteShortcut)
             do {
                 try await Task.sleep(nanoseconds: 700_000_000)
             } catch is CancellationError {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
@@ -52,9 +52,7 @@ final class ComputerUsePlannerRuntime {
             )
         },
         plan: PlanHandler? = nil,
-        execute: @escaping ExecuteHandler = { toolCall, registry in
-            await ComputerUseToolExecutor.execute(toolCall, registry: registry)
-        }
+        execute: ExecuteHandler? = nil
     ) {
         self.config = config
         self.maxSteps = maxSteps
@@ -64,7 +62,13 @@ final class ComputerUsePlannerRuntime {
         self.plan = plan ?? { request in
             try await ComputerUsePlannerClient.planNextTool(request: request, config: config)
         }
-        self.execute = execute
+        self.execute = execute ?? { toolCall, registry in
+            await ComputerUseToolExecutor.execute(
+                toolCall,
+                registry: registry,
+                pasteShortcut: config.pasteShortcut
+            )
+        }
     }
 
     func run(command: String) async -> ComputerUsePlannerRuntimeResult {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -724,6 +724,7 @@ struct AppConfig: Codable {
     var meetingRecordingSavePolicy: MeetingRecordingSavePolicy = .never
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
+    var pasteShortcut: PasteShortcut = .commandV
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var computerUseHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var meetingRecordingHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultMeetingThresholdMilliseconds
@@ -804,6 +805,7 @@ struct AppConfig: Codable {
         case meetingRecordingSavePolicy = "meeting_recording_save_policy"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
+        case pasteShortcut = "paste_shortcut"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case computerUseHotkeyTriggerThresholdMS = "computer_use_hotkey_trigger_threshold_ms"
         case meetingRecordingHotkeyTriggerThresholdMS = "meeting_recording_hotkey_trigger_threshold_ms"
@@ -897,6 +899,7 @@ struct AppConfig: Codable {
         meetingRecordingSavePolicy = (try? c.decode(MeetingRecordingSavePolicy.self, forKey: .meetingRecordingSavePolicy)) ?? defaults.meetingRecordingSavePolicy
         darkMode = (try? c.decode(Bool.self, forKey: .darkMode)) ?? defaults.darkMode
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
+        pasteShortcut = (try? c.decode(PasteShortcut.self, forKey: .pasteShortcut)) ?? defaults.pasteShortcut
         hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
             (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1482,6 +1482,7 @@ struct AppConfig: Codable {
     var waveformCacheOrphanCleanupMigrationApplied: Bool = false
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
+    var pasteShortcut: PasteShortcut = .commandV
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var quilHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var computerUseHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
@@ -1620,6 +1621,7 @@ struct AppConfig: Codable {
         case waveformCacheOrphanCleanupMigrationApplied = "waveform_cache_orphan_cleanup_migration_applied"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
+        case pasteShortcut = "paste_shortcut"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case quilHotkeyTriggerThresholdMS = "quil_hotkey_trigger_threshold_ms"
         case computerUseHotkeyTriggerThresholdMS = "computer_use_hotkey_trigger_threshold_ms"
@@ -1786,6 +1788,7 @@ struct AppConfig: Codable {
         iCloudSyncEnabled = (try? c.decode(Bool.self, forKey: .iCloudSyncEnabled)) ?? defaults.iCloudSyncEnabled
         showIOSCompanionPrompt = (try? c.decode(Bool.self, forKey: .showIOSCompanionPrompt)) ?? defaults.showIOSCompanionPrompt
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
+        pasteShortcut = (try? c.decode(PasteShortcut.self, forKey: .pasteShortcut)) ?? defaults.pasteShortcut
         hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
             (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5631,7 +5631,7 @@ final class MuesliController: NSObject {
                     self.historyWindowController?.reload()
                     self.syncAppState()
                     if outputMode != .voiceNote {
-                        PasteController.paste(text: text)
+                        PasteController.paste(text: text, shortcut: self.config.pasteShortcut)
                     }
                     self.resetDictationOutputMode()
                     self.setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8802,6 +8802,7 @@ public final class MuesliController: NSObject {
                     var pasteLifecycleEvents: [PasteController.LifecycleEvent] = []
                     PasteController.paste(
                         text: replacement,
+                        shortcut: configSnapshot.pasteShortcut,
                         requireStagedClipboardOwnership: true,
                         targetApplicationProvider: { snapshot.application },
                         shouldDispatchPaste: { snapshot.isTargetStillFocused() },
@@ -8839,7 +8840,7 @@ public final class MuesliController: NSObject {
                                 deliveryStatus = "needs_attention"
                                 deliveryMessage = "Generated text is ready for manual paste"
                                 deliveryTraceBody = "Automatic paste was not accepted; generated text was retained on the clipboard"
-                                userMessage = "Generated — press ⌘V to paste"
+                                userMessage = "Generated — press \(configSnapshot.pasteShortcut.chordLabel) to paste"
                             } else {
                                 deliveryStatus = "needs_attention"
                                 deliveryMessage = "Automatic paste could not be completed"
@@ -10777,6 +10778,7 @@ public final class MuesliController: NSObject {
                         var completionTargetApp: DictationCorrectionTargetApp?
                         PasteController.paste(
                             text: text,
+                            shortcut: self.config.pasteShortcut,
                             requireStagedClipboardOwnership: true,
                             onPasteFinished: { [weak self] targetApplication in
                                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -41,9 +41,11 @@ enum PasteController {
     static func paste(
         text: String,
         pasteboard: NSPasteboard = .general,
-        simulatePasteAction: @escaping () -> Void = PasteController.simulatePaste
+        shortcut: PasteShortcut = .commandV,
+        simulatePasteAction: (() -> Void)? = nil
     ) {
         guard !text.isEmpty else { return }
+        let simulate = simulatePasteAction ?? { simulatePaste(shortcut: shortcut) }
 
         // Save current clipboard contents (all types) so we can restore after paste.
         let savedItems = saveClipboard(pasteboard)
@@ -53,7 +55,7 @@ enum PasteController {
         let pasteChangeCount = pasteboard.changeCount
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            simulatePasteAction()
+            simulate()
 
             // Restore the original clipboard contents after the receiving app has consumed the paste.
             DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
@@ -87,16 +89,25 @@ enum PasteController {
 
     // MARK: - Private
 
-    private static func simulatePaste() {
+    /// CGEvent modifier flags for the paste chord the user selected.
+    static func eventFlags(for shortcut: PasteShortcut) -> CGEventFlags {
+        switch shortcut {
+        case .commandV: return .maskCommand
+        case .commandShiftV: return [.maskCommand, .maskShift]
+        }
+    }
+
+    static func simulatePaste(shortcut: PasteShortcut = .commandV) {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             fputs("[muesli-native] failed to create event source for paste\n", stderr)
             return
         }
         let keyCode: CGKeyCode = 9 // V
+        let flags = eventFlags(for: shortcut)
         let commandDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
-        commandDown?.flags = .maskCommand
+        commandDown?.flags = flags
         let commandUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
-        commandUp?.flags = .maskCommand
+        commandUp?.flags = flags
         commandDown?.post(tap: .cghidEventTap)
         commandUp?.post(tap: .cghidEventTap)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -68,10 +68,12 @@ enum PasteController {
     /// For nonempty text, completion receives the target app only when the selected Paste
     /// command was accepted. When staged-clipboard ownership is required, a failed write or
     /// intervening clipboard change also completes with `nil` attribution and skips dispatch.
+    /// `shortcut` applies only to `.keyboardShortcut`; target-app Paste commands are invoked directly.
     @MainActor
     static func paste(
         text: String,
         pasteboard: NSPasteboard = .general,
+        shortcut: PasteShortcut = .commandV,
         requireStagedClipboardOwnership: Bool = false,
         targetApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
             NSWorkspace.shared.frontmostApplication
@@ -82,13 +84,16 @@ enum PasteController {
         targetPasteAction: @escaping @MainActor (NSRunningApplication) -> Bool? = {
             PasteController.performTargetPasteCommand(in: $0)
         },
-        simulatePasteAction: @escaping @MainActor () -> Bool = PasteController.simulatePaste,
+        simulatePasteAction: (@MainActor (PasteShortcut) -> Bool)? = nil,
         onPasteDispatched: @escaping @MainActor () -> Void = {},
         onPasteFinished: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in },
         onClipboardSettled: @escaping @MainActor () -> Void = {},
         onLifecycleEvent: @escaping @MainActor (LifecycleEvent) -> Void = { _ in }
     ) {
         guard !text.isEmpty else { return }
+        let simulatePasteAction = simulatePasteAction ?? {
+            PasteController.simulatePaste(shortcut: $0)
+        }
 
         // Save current clipboard contents (all types) so we can restore after paste.
         let savedItems = saveClipboard(pasteboard)
@@ -148,7 +153,7 @@ enum PasteController {
             let didDispatchPaste: Bool
             switch dispatchStrategy {
             case .keyboardShortcut:
-                didDispatchPaste = simulatePasteAction()
+                didDispatchPaste = simulatePasteAction(shortcut)
             case .targetApplicationPasteCommand:
                 guard let targetApplication else {
                     onLifecycleEvent(.targetPasteCommandUnavailable)
@@ -273,7 +278,15 @@ enum PasteController {
         return true
     }
 
-    private static func simulatePaste() -> Bool {
+    /// CGEvent modifier flags for the paste chord the user selected.
+    static func eventFlags(for shortcut: PasteShortcut) -> CGEventFlags {
+        switch shortcut {
+        case .commandV: return .maskCommand
+        case .commandShiftV: return [.maskCommand, .maskShift]
+        }
+    }
+
+    private static func simulatePaste(shortcut: PasteShortcut) -> Bool {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             fputs("[muesli-native] failed to create event source for paste\n", stderr)
             return false
@@ -287,8 +300,9 @@ enum PasteController {
         }
         MuesliSyntheticKeyboardEvent.mark(commandDown)
         MuesliSyntheticKeyboardEvent.mark(commandUp)
-        commandDown.flags = .maskCommand
-        commandUp.flags = .maskCommand
+        let flags = eventFlags(for: shortcut)
+        commandDown.flags = flags
+        commandUp.flags = flags
         commandDown.post(tap: .cghidEventTap)
         commandUp.post(tap: .cghidEventTap)
         return true

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteShortcut.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteShortcut.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The keyboard chord Muesli simulates to paste dictated text into the focused app.
+///
+/// Muesli inserts dictation by writing the transcript to the clipboard and posting a
+/// synthetic paste keystroke. Most apps treat ⌘V as paste, but terminals and editors
+/// that remap ⌘V (e.g. a Ghostty config binding `cmd+v` to a control character and
+/// moving paste to `cmd+shift+v`) drop the default chord. Picking the chord that
+/// matches the target app's paste binding keeps insertion reliable.
+enum PasteShortcut: String, Codable, CaseIterable {
+    case commandV = "command_v"
+    case commandShiftV = "command_shift_v"
+
+    var displayName: String {
+        switch self {
+        case .commandV: return "⌘V (default)"
+        case .commandShiftV: return "⌘⇧V"
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteShortcut.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteShortcut.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// The keyboard chord Muesli simulates to paste dictated text into the focused app.
+///
+/// Muesli inserts dictation by writing the transcript to the clipboard and posting a
+/// synthetic paste keystroke. Most apps treat ⌘V as paste, but terminals and editors
+/// that remap ⌘V (e.g. a Ghostty config binding `cmd+v` to a control character and
+/// moving paste to `cmd+shift+v`) drop the default chord. Picking the chord that
+/// matches the target app's paste binding keeps insertion reliable.
+enum PasteShortcut: String, Codable, CaseIterable {
+    case commandV = "command_v"
+    case commandShiftV = "command_shift_v"
+
+    var chordLabel: String {
+        switch self {
+        case .commandV: return "⌘V"
+        case .commandShiftV: return "⌘⇧V"
+        }
+    }
+
+    var displayName: String {
+        self == .commandV ? "\(chordLabel) (default)" : chordLabel
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -470,6 +470,18 @@ struct SettingsView: View {
                         controller.updateConfig { $0.muteSystemAudioDuringDictation = newValue }
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Paste shortcut") {
+                    settingsMenu(
+                        selection: appState.config.pasteShortcut.displayName,
+                        options: PasteShortcut.allCases.map(\.displayName)
+                    ) { label in
+                        if let choice = PasteShortcut.allCases.first(where: { $0.displayName == label }) {
+                            controller.updateConfig { $0.pasteShortcut = choice }
+                        }
+                    }
+                }
+                settingsDescription("Use ⌘⇧V for terminals or apps that remap ⌘V.")
                 screenContextRow("App context")
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1881,6 +1881,18 @@ struct SettingsView: View {
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Paste shortcut") {
+                    settingsMenu(
+                        selection: appState.config.pasteShortcut.displayName,
+                        options: PasteShortcut.allCases.map(\.displayName)
+                    ) { label in
+                        if let choice = PasteShortcut.allCases.first(where: { $0.displayName == label }) {
+                            controller.updateConfig { $0.pasteShortcut = choice }
+                        }
+                    }
+                }
+                settingsDescription("Applies to keyboard paste actions in every app, including Computer Use. Browser app Paste commands are unaffected.")
+                Divider().background(MuesliTheme.surfaceBorder)
                 screenContextRow("App context")
                 Divider().background(MuesliTheme.surfaceBorder)
                 dictationOCRContextRow

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUseExecutorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUseExecutorTests.swift
@@ -36,7 +36,8 @@ struct ComputerUseExecutorTests {
         let registry = ComputerUseElementRegistry()
         let result = await ComputerUseToolExecutor.execute(
             ComputerUseToolCall(tool: .click, elementIndex: 9, label: "Search"),
-            registry: registry
+            registry: registry,
+            pasteShortcut: .commandV
         )
 
         #expect(result.status == .failed)
@@ -49,7 +50,8 @@ struct ComputerUseExecutorTests {
         let registry = ComputerUseElementRegistry()
         let result = await ComputerUseToolExecutor.execute(
             ComputerUseToolCall(tool: .performSecondaryAction, elementIndex: 9, actionName: "AXShowMenu", label: "More"),
-            registry: registry
+            registry: registry,
+            pasteShortcut: .commandV
         )
 
         #expect(result.status == .failed)
@@ -62,7 +64,8 @@ struct ComputerUseExecutorTests {
         let registry = ComputerUseElementRegistry()
         let result = await ComputerUseToolExecutor.execute(
             ComputerUseToolCall(tool: .scroll, elementIndex: 9, direction: .down),
-            registry: registry
+            registry: registry,
+            pasteShortcut: .commandV
         )
 
         #expect(result.status == .failed)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1318,6 +1318,43 @@ struct AppConfigTests {
         #expect(json["show_meeting_transcript_on_indicator_hover"] != nil)
     }
 
+    @Test("missing paste shortcut defaults to Command-V")
+    func missingPasteShortcutDefaultsToCommandV() throws {
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+
+        #expect(config.pasteShortcut == .commandV)
+    }
+
+    @Test("unknown paste shortcut defaults to Command-V")
+    func unknownPasteShortcutDefaultsToCommandV() throws {
+        let data = Data(#"{"paste_shortcut":"future_chord"}"#.utf8)
+        let config = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(config.pasteShortcut == .commandV)
+    }
+
+    @Test("paste shortcut encodes with its snake_case key and value")
+    func pasteShortcutEncodesWithSnakeCaseKeyAndValue() throws {
+        var config = AppConfig()
+        config.pasteShortcut = .commandShiftV
+
+        let data = try JSONEncoder().encode(config)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["paste_shortcut"] as? String == "command_shift_v")
+    }
+
+    @Test("Command-Shift-V paste shortcut round-trips through JSON")
+    func commandShiftVPasteShortcutRoundTrips() throws {
+        var config = AppConfig()
+        config.pasteShortcut = .commandShiftV
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.pasteShortcut == .commandShiftV)
+    }
+
     @Test("decodes screen context flags from snake_case")
     func decodesScreenContextFlagsFromSnakeCase() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -62,6 +62,37 @@ struct PasteControllerTests {
         }
     }
 
+    // MARK: - paste shortcut flags
+
+    @Test("⌘V maps to the command modifier only")
+    func commandVFlags() {
+        #expect(PasteController.eventFlags(for: .commandV) == .maskCommand)
+    }
+
+    @Test("⌘⇧V maps to command + shift modifiers")
+    func commandShiftVFlags() {
+        #expect(PasteController.eventFlags(for: .commandShiftV) == [.maskCommand, .maskShift])
+    }
+
+    @Test("paste honors a non-default shortcut and still stages text on the clipboard")
+    func pasteWithShortcutStagesText() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        var simulated = false
+        PasteController.paste(
+            text: "dictated text",
+            pasteboard: pasteboard,
+            shortcut: .commandShiftV,
+            simulatePasteAction: { simulated = true }
+        )
+
+        #expect(pasteboard.string(forType: .string) == "dictated text")
+        _ = await waitForClipboardString(in: pasteboard, expected: "original")
+        #expect(simulated)
+    }
+
     // MARK: - paste() clipboard restoration
 
     @Test("paste with empty string is a no-op")

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -103,6 +103,40 @@ struct PasteControllerTests {
         }
     }
 
+    // MARK: - paste shortcut flags
+
+    @Test("⌘V maps to the command modifier only")
+    func commandVFlags() {
+        #expect(PasteController.eventFlags(for: .commandV) == .maskCommand)
+    }
+
+    @Test("⌘⇧V maps to command + shift modifiers")
+    func commandShiftVFlags() {
+        #expect(PasteController.eventFlags(for: .commandShiftV) == [.maskCommand, .maskShift])
+    }
+
+    @Test("paste honors a non-default shortcut and still stages text on the clipboard")
+    func pasteWithShortcutStagesText() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        var simulatedShortcut: PasteShortcut?
+        PasteController.paste(
+            text: "dictated text",
+            pasteboard: pasteboard,
+            shortcut: .commandShiftV,
+            simulatePasteAction: { shortcut in
+                simulatedShortcut = shortcut
+                return true
+            }
+        )
+
+        #expect(pasteboard.string(forType: .string) == "dictated text")
+        _ = await waitForClipboardString(in: pasteboard, expected: "original")
+        #expect(simulatedShortcut == .commandShiftV)
+    }
+
     // MARK: - paste() clipboard restoration
 
     @Test("paste with empty string is a no-op")
@@ -111,7 +145,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("original", forType: .string)
 
-        PasteController.paste(text: "", pasteboard: pasteboard, simulatePasteAction: { true })
+        PasteController.paste(text: "", pasteboard: pasteboard, simulatePasteAction: { _ in true })
 
         #expect(pasteboard.string(forType: .string) == "original")
     }
@@ -122,7 +156,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("original", forType: .string)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { _ in true })
 
         // Immediately after paste(), the clipboard holds the dictation text
         // (restoration happens asynchronously after ~500ms)
@@ -143,7 +177,7 @@ struct PasteControllerTests {
                 pasteboard: pasteboard,
                 requireStagedClipboardOwnership: true,
                 shouldDispatchPaste: { false },
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     didSimulatePaste = true
                     return true
                 },
@@ -198,7 +232,7 @@ struct PasteControllerTests {
                     events.append("snapshot")
                     return expectedApplication
                 },
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     events.append("command")
                     return true
                 },
@@ -222,7 +256,7 @@ struct PasteControllerTests {
             PasteController.paste(
                 text: "Quill replacement",
                 pasteboard: successfulPasteboard,
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     events.append("command")
                     return true
                 },
@@ -243,7 +277,7 @@ struct PasteControllerTests {
             PasteController.paste(
                 text: "Quill replacement",
                 pasteboard: failedPasteboard,
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     events.append("command")
                     return false
                 },
@@ -281,7 +315,7 @@ struct PasteControllerTests {
                     #expect(application.processIdentifier == expectedApplication.processIdentifier)
                     return true
                 },
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     didPostKeyboardShortcut = true
                     return true
                 },
@@ -339,7 +373,7 @@ struct PasteControllerTests {
                 dispatchStrategy: .targetApplicationPasteCommand,
                 retainStagedTextOnFailure: true,
                 targetPasteAction: { _ in false },
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     didPostKeyboardShortcut = true
                     return true
                 },
@@ -375,7 +409,7 @@ struct PasteControllerTests {
                 text: "dictated text",
                 pasteboard: pasteboard,
                 targetApplicationProvider: { nil },
-                simulatePasteAction: { true },
+                simulatePasteAction: { _ in true },
                 onPasteFinished: { _ in
                     events.append("completion_bookkeeping")
                 },
@@ -439,7 +473,7 @@ struct PasteControllerTests {
                     pasteboard.setString("user-copied-during-delay", forType: .string)
                     return NSRunningApplication.current
                 },
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     events.append("command")
                     return true
                 },
@@ -472,7 +506,7 @@ struct PasteControllerTests {
                     pasteboard.setString("newer-clipboard-content", forType: .string)
                     return NSRunningApplication.current
                 },
-                simulatePasteAction: {
+                simulatePasteAction: { _ in
                     events.append("command")
                     return true
                 },
@@ -498,7 +532,7 @@ struct PasteControllerTests {
                 text: "dictated text",
                 pasteboard: pasteboard,
                 targetApplicationProvider: { NSRunningApplication.current },
-                simulatePasteAction: { false },
+                simulatePasteAction: { _ in false },
                 onPasteFinished: { continuation.resume(returning: $0) }
             )
         }
@@ -514,7 +548,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("user-copied-text", forType: .string)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { _ in true })
 
         let restored = await waitForClipboardString(in: pasteboard, expected: "user-copied-text")
 
@@ -526,7 +560,7 @@ struct PasteControllerTests {
         let pasteboard = makePasteboard()
         pasteboard.clearContents()
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { _ in true })
 
         let restored = await waitForClipboardString(in: pasteboard, expected: nil)
 
@@ -548,7 +582,7 @@ struct PasteControllerTests {
         let countBefore = pasteboard.pasteboardItems?.count ?? 0
         #expect(countBefore == 2)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { _ in true })
 
         let (countAfter, texts) = await waitForClipboardItems(
             in: pasteboard,
@@ -566,7 +600,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("original", forType: .string)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { _ in true })
         try await Task.sleep(nanoseconds: 100_000_000)
 
         pasteboard.clearContents()


### PR DESCRIPTION
## Summary

(Updating PR desc to more current template)

- Add a persisted Dictation paste-shortcut setting with ⌘V as the default and ⌘⇧V as the alternative.
- Apply the selected chord to keyboard-based paste actions in standard dictation, Quill, and Computer Use.
- Preserve the existing clipboard ownership, restoration, target-app attribution, lifecycle diagnostics, and browser Accessibility Paste behavior.
- Show the configured chord in Quill's manual-paste fallback.
- Keep existing installations and behavior unchanged unless the user selects ⌘⇧V.

## Validation

- Rebased onto current `main` as one signed-off commit.
- Release `MuesliNativeApp` and `muesli-cli` SwiftPM builds passed.
- Ad-hoc app packaging passed with the complete 13-file LocalVQE runtime.
- Deep signature verification passed for the packaged app.
- `./scripts/test_classify_changed_files.sh` passed.
- `./scripts/test_ci_test_shards.sh` passed.
- `./scripts/verify_update_flow.sh --skip-dmg` passed.
- Added coverage for config defaults, unknown-value fallback, snake_case encoding, config round-trip, exact event flags, and propagation of the non-default chord into paste dispatch.
- Full Swift tests could not run locally because the selected Command Line Tools installation does not provide the Swift `Testing` module. GitHub Actions is awaiting maintainer approval for this fork PR.
- Manual behavior previously verified with Ghostty configured to use `cmd+shift+v=paste_from_clipboard`; please recheck this on the rebased head before merge.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

Created all or in part with the use of multiple LLMs. All changes reviewed by a human mk. 1 eyeballs.
