### PR TITLE
Remember manual export format and make open-after-export optional

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -847,18 +847,29 @@ struct MeetingDetailView: View {
         .help(label)
     }
 
+    private func exportMeeting(_ meeting: MeetingRecord, content: MeetingExportContent) {
+        MeetingExporter.export(
+            meeting: meeting,
+            content: content,
+            preferredFormat: appState.config.resolvedManualExportFormat,
+            openAfterSaving: appState.config.openFileAfterManualExport
+        ) { confirmedFormat in
+            controller.updateConfig { $0.manualExportFormat = confirmedFormat.rawValue }
+        }
+    }
+
     @ViewBuilder
     private func exportMenu(for meeting: MeetingRecord) -> some View {
         let currentContent: MeetingExportContent = documentMode == .transcript ? .transcript : .notes
         let currentLabel = documentMode == .transcript ? "Export Transcript" : "Export Notes"
         Menu {
             Button {
-                MeetingExporter.export(meeting: meeting, content: currentContent)
+                exportMeeting(meeting, content: currentContent)
             } label: {
                 Label(currentLabel, systemImage: documentMode == .transcript ? "text.quote" : "doc.text")
             }
             Button {
-                MeetingExporter.export(meeting: meeting, content: .fullMeeting)
+                exportMeeting(meeting, content: .fullMeeting)
             } label: {
                 Label("Export Full Meeting", systemImage: "doc.on.doc")
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingExporter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingExporter.swift
@@ -46,34 +46,139 @@ enum MeetingAutoExportFileFormat: String, CaseIterable {
     }
 }
 
+enum MeetingManualExportFormat: String, CaseIterable {
+    case pdf
+    case markdown
+
+    var displayName: String {
+        switch self {
+        case .pdf: return "PDF"
+        case .markdown: return "Markdown"
+        }
+    }
+
+    var fileExtension: String {
+        switch self {
+        case .pdf: return "pdf"
+        case .markdown: return "md"
+        }
+    }
+
+    static func resolved(_ rawValue: String) -> MeetingManualExportFormat {
+        MeetingManualExportFormat(rawValue: rawValue) ?? .pdf
+    }
+}
+
 struct MeetingExporter {
 
     static let mdType = UTType(filenameExtension: "md") ?? .plainText
     static let pdfType = UTType.pdf
 
-    static func export(meeting: MeetingRecord, content: MeetingExportContent) {
+    static func export(
+        meeting: MeetingRecord,
+        content: MeetingExportContent,
+        preferredFormat: MeetingManualExportFormat = .pdf,
+        openAfterSaving: Bool = true,
+        onFormatConfirmed: ((MeetingManualExportFormat) -> Void)? = nil
+    ) {
         DispatchQueue.main.async {
             let markdown = buildMarkdown(meeting: meeting, content: content)
-            let filename = suggestedFilename(meeting: meeting, content: content)
+            let filename = suggestedFilename(
+                meeting: meeting,
+                content: content,
+                fileExtension: preferredFormat.fileExtension
+            )
 
             let panel = NSSavePanel()
             panel.nameFieldStringValue = filename
-            panel.allowedContentTypes = [pdfType]
+            panel.allowedContentTypes = [contentType(for: preferredFormat)]
             panel.canCreateDirectories = true
 
-            let formatPicker = ExportFormatAccessory(panel: panel)
+            let formatPicker = ExportFormatAccessory(panel: panel, initialFormat: preferredFormat)
             panel.accessoryView = formatPicker.view
 
             presentSavePanel(panel) { url in
-                if formatPicker.selectedFormat == .pdf {
-                    do {
-                        try writePDF(attributed: buildAttributedString(from: markdown), to: url)
-                        NSWorkspace.shared.open(url)
-                    } catch {
-                        showError("Export Failed", error.localizedDescription)
-                    }
+                let outcome: ManualExportOutcome
+                if let url {
+                    outcome = .confirmed(url: url, format: formatPicker.selectedFormat)
                 } else {
-                    writeMarkdown(markdown, to: url)
+                    outcome = .cancelled
+                }
+                processManualExport(
+                    outcome: outcome,
+                    markdown: markdown,
+                    openAfterSaving: openAfterSaving,
+                    onFormatConfirmed: onFormatConfirmed
+                )
+            }
+        }
+    }
+
+    static func contentType(for format: MeetingManualExportFormat) -> UTType {
+        format == .pdf ? pdfType : mdType
+    }
+
+    // MARK: - Export outcome handling
+
+    enum ManualExportOutcome {
+        case cancelled
+        case confirmed(url: URL, format: MeetingManualExportFormat)
+    }
+
+    struct ManualExportIO {
+        var writePDF: (String, URL) throws -> Void
+        var writeMarkdown: (String, URL, @escaping (Error?) -> Void) -> Void
+        var openFile: (URL) -> Void
+        var showError: (String, String) -> Void
+
+        static let live = ManualExportIO(
+            writePDF: { markdown, url in
+                try MeetingExporter.writePDF(attributed: MeetingExporter.buildAttributedString(from: markdown), to: url)
+            },
+            writeMarkdown: { text, url, completion in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        try text.write(to: url, atomically: true, encoding: .utf8)
+                        completion(nil)
+                    } catch {
+                        completion(error)
+                    }
+                }
+            },
+            openFile: { url in
+                DispatchQueue.main.async { NSWorkspace.shared.open(url) }
+            },
+            showError: { title, message in
+                DispatchQueue.main.async { MeetingExporter.showError(title, message) }
+            }
+        )
+    }
+
+    static func processManualExport(
+        outcome: ManualExportOutcome,
+        markdown: String,
+        openAfterSaving: Bool,
+        onFormatConfirmed: ((MeetingManualExportFormat) -> Void)? = nil,
+        io: ManualExportIO = .live
+    ) {
+        guard case let .confirmed(url, format) = outcome else { return }
+        onFormatConfirmed?(format)
+        switch format {
+        case .pdf:
+            do {
+                try io.writePDF(markdown, url)
+                if openAfterSaving {
+                    io.openFile(url)
+                }
+            } catch {
+                io.showError("Export Failed", error.localizedDescription)
+            }
+        case .markdown:
+            io.writeMarkdown(markdown, url) { error in
+                if let error {
+                    io.showError("Export Failed", error.localizedDescription)
+                } else if openAfterSaving {
+                    io.openFile(url)
                 }
             }
         }
@@ -130,17 +235,6 @@ struct MeetingExporter {
 
     // MARK: - Write files
 
-    private static func writeMarkdown(_ text: String, to url: URL) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            do {
-                try text.write(to: url, atomically: true, encoding: .utf8)
-                DispatchQueue.main.async { NSWorkspace.shared.open(url) }
-            } catch {
-                DispatchQueue.main.async { showError("Export Failed", error.localizedDescription) }
-            }
-        }
-    }
-
     static func writePDF(attributed: NSAttributedString, to url: URL) throws {
         let pageWidth: CGFloat = 612   // US Letter
         let pageHeight: CGFloat = 792
@@ -181,17 +275,15 @@ struct MeetingExporter {
 
     // MARK: - Save panel
 
-    private static func presentSavePanel(_ panel: NSSavePanel, onSave: @escaping (URL) -> Void) {
+    private static func presentSavePanel(_ panel: NSSavePanel, completion: @escaping (URL?) -> Void) {
         NSApp.activate()
         if let window = NSApp.keyWindow {
             panel.beginSheetModal(for: window) { response in
-                guard response == .OK, let url = panel.url else { return }
-                onSave(url)
+                completion(response == .OK ? panel.url : nil)
             }
         } else {
             panel.begin { response in
-                guard response == .OK, let url = panel.url else { return }
-                onSave(url)
+                completion(response == .OK ? panel.url : nil)
             }
         }
     }
@@ -411,13 +503,13 @@ private class ExportFormatAccessory: NSObject {
     private let popup: NSPopUpButton
     private weak var panel: NSSavePanel?
 
-    enum Format { case pdf, markdown }
-
-    var selectedFormat: Format {
-        popup.indexOfSelectedItem == 0 ? .pdf : .markdown
+    var selectedFormat: MeetingManualExportFormat {
+        let index = popup.indexOfSelectedItem
+        guard index >= 0, index < MeetingManualExportFormat.allCases.count else { return .pdf }
+        return MeetingManualExportFormat.allCases[index]
     }
 
-    init(panel: NSSavePanel) {
+    init(panel: NSSavePanel, initialFormat: MeetingManualExportFormat) {
         self.panel = panel
 
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 260, height: 32))
@@ -427,8 +519,8 @@ private class ExportFormatAccessory: NSObject {
         label.frame = NSRect(x: 0, y: 6, width: 55, height: 20)
 
         let button = NSPopUpButton(frame: NSRect(x: 60, y: 2, width: 190, height: 28), pullsDown: false)
-        button.addItems(withTitles: ["PDF", "Markdown"])
-        button.selectItem(at: 0)
+        button.addItems(withTitles: MeetingManualExportFormat.allCases.map(\.displayName))
+        button.selectItem(at: MeetingManualExportFormat.allCases.firstIndex(of: initialFormat) ?? 0)
 
         container.addSubview(label)
         container.addSubview(button)
@@ -447,12 +539,8 @@ private class ExportFormatAccessory: NSObject {
         let currentName = panel.nameFieldStringValue
         let stem = (currentName as NSString).deletingPathExtension
 
-        if selectedFormat == .pdf {
-            panel.allowedContentTypes = [MeetingExporter.pdfType]
-            panel.nameFieldStringValue = "\(stem).pdf"
-        } else {
-            panel.allowedContentTypes = [MeetingExporter.mdType]
-            panel.nameFieldStringValue = "\(stem).md"
-        }
+        let format = selectedFormat
+        panel.allowedContentTypes = [MeetingExporter.contentType(for: format)]
+        panel.nameFieldStringValue = "\(stem).\(format.fileExtension)"
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1239,6 +1239,8 @@ struct AppConfig: Codable {
     var autoExportMarkdownFolderPath: String = ""
     var autoExportMarkdownContent: String = MeetingExportContent.notes.rawValue
     var autoExportFileFormat: String = MeetingAutoExportFileFormat.markdown.rawValue
+    var manualExportFormat: String = MeetingManualExportFormat.pdf.rawValue
+    var openFileAfterManualExport: Bool = true
     var iCloudSyncEnabled: Bool = false
     var showIOSCompanionPrompt: Bool = true
     var contributionPromptNextWordCount: Int?
@@ -1359,6 +1361,8 @@ struct AppConfig: Codable {
         case autoExportMarkdownFolderPath = "auto_export_markdown_folder_path"
         case autoExportMarkdownContent = "auto_export_markdown_content"
         case autoExportFileFormat = "auto_export_file_format"
+        case manualExportFormat = "manual_export_format"
+        case openFileAfterManualExport = "open_file_after_manual_export"
         case iCloudSyncEnabled = "icloud_sync_enabled"
         case showIOSCompanionPrompt = "show_ios_companion_prompt"
         case contributionPromptNextWordCount = "contribution_prompt_next_word_count"
@@ -1559,6 +1563,9 @@ struct AppConfig: Codable {
         autoExportMarkdownContent = MeetingExportContent(rawValue: decodedAutoExportMarkdownContent)?.rawValue ?? defaults.autoExportMarkdownContent
         let decodedAutoExportFileFormat = (try? c.decode(String.self, forKey: .autoExportFileFormat)) ?? defaults.autoExportFileFormat
         autoExportFileFormat = MeetingAutoExportFileFormat(rawValue: decodedAutoExportFileFormat)?.rawValue ?? defaults.autoExportFileFormat
+        let decodedManualExportFormat = (try? c.decode(String.self, forKey: .manualExportFormat)) ?? defaults.manualExportFormat
+        manualExportFormat = MeetingManualExportFormat(rawValue: decodedManualExportFormat)?.rawValue ?? defaults.manualExportFormat
+        openFileAfterManualExport = (try? c.decode(Bool.self, forKey: .openFileAfterManualExport)) ?? defaults.openFileAfterManualExport
         contributionPromptNextWordCount = try? c.decode(Int.self, forKey: .contributionPromptNextWordCount)
         contributionPromptNextMeetingCount = try? c.decode(Int.self, forKey: .contributionPromptNextMeetingCount)
         contributionGitHubStarClicked = (try? c.decode(Bool.self, forKey: .contributionGitHubStarClicked)) ?? defaults.contributionGitHubStarClicked
@@ -1601,6 +1608,10 @@ struct AppConfig: Codable {
 
     var resolvedAutoExportFileFormat: MeetingAutoExportFileFormat {
         MeetingAutoExportFileFormat.resolved(autoExportFileFormat)
+    }
+
+    var resolvedManualExportFormat: MeetingManualExportFormat {
+        MeetingManualExportFormat.resolved(manualExportFormat)
     }
 
     var resolvedMeetingRecordingFileFormat: MeetingRecordingFileFormat {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1426,6 +1426,18 @@ struct SettingsView: View {
                     .padding(.horizontal, MuesliTheme.spacing16)
             }
 
+            settingsSection("Manual Export") {
+                settingsRow("Open file after exporting") {
+                    settingsSwitch(isOn: appState.config.openFileAfterManualExport) { newValue in
+                        controller.updateConfig { $0.openFileAfterManualExport = newValue }
+                    }
+                }
+                Text("Opens the exported file in its default app after saving from the Export menu. The Export menu also remembers your last-used format.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.horizontal, MuesliTheme.spacing16)
+            }
+
             settingsSection("Meeting Notifications") {
                 settingsRow("Scheduled meetings") {
                     settingsSwitch(isOn: appState.config.showScheduledMeetingNotifications) { newValue in

--- a/native/MuesliNative/Tests/MuesliTests/MeetingExporterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingExporterTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import MuesliNativeApp
 import MuesliCore
 
@@ -231,6 +232,149 @@ struct MeetingExporterTests {
         let name = MeetingExporter.suggestedFilename(meeting: meeting, content: .notes)
 
         #expect(name == "meeting-notes.pdf")
+    }
+
+    @Test("Filename uses the preferred manual export format extension")
+    func filenameUsesPreferredFormatExtension() {
+        let meeting = makeMeeting(title: "Q2 Planning")
+        let name = MeetingExporter.suggestedFilename(
+            meeting: meeting,
+            content: .notes,
+            fileExtension: MeetingManualExportFormat.markdown.fileExtension
+        )
+
+        #expect(name == "q2-planning-notes.md")
+    }
+
+    // MARK: - Manual export format
+
+    @Test("Manual export format resolves known and unknown raw values")
+    func manualExportFormatResolution() {
+        #expect(MeetingManualExportFormat.resolved("pdf") == .pdf)
+        #expect(MeetingManualExportFormat.resolved("markdown") == .markdown)
+        #expect(MeetingManualExportFormat.resolved("docx") == .pdf)
+        #expect(MeetingManualExportFormat.resolved("") == .pdf)
+    }
+
+    @Test("Manual export formats declare file extensions and content types")
+    func manualExportFormatExtensions() {
+        #expect(MeetingManualExportFormat.pdf.fileExtension == "pdf")
+        #expect(MeetingManualExportFormat.markdown.fileExtension == "md")
+        #expect(MeetingExporter.contentType(for: .pdf) == MeetingExporter.pdfType)
+        #expect(MeetingExporter.contentType(for: .markdown) == MeetingExporter.mdType)
+    }
+
+    // MARK: - Export outcome handling
+
+    private final class ExportIOSpy {
+        var pdfWrites: [URL] = []
+        var markdownWrites: [URL] = []
+        var openedFiles: [URL] = []
+        var errors: [String] = []
+        var writeError: Error?
+
+        var io: MeetingExporter.ManualExportIO {
+            MeetingExporter.ManualExportIO(
+                writePDF: { [self] _, url in
+                    if let writeError { throw writeError }
+                    pdfWrites.append(url)
+                },
+                writeMarkdown: { [self] _, url, completion in
+                    if let writeError {
+                        completion(writeError)
+                    } else {
+                        markdownWrites.append(url)
+                        completion(nil)
+                    }
+                },
+                openFile: { [self] url in openedFiles.append(url) },
+                showError: { [self] title, _ in errors.append(title) }
+            )
+        }
+    }
+
+    private let exportURL = URL(fileURLWithPath: "/tmp/muesli-export-test.out")
+
+    @Test("Cancelled export confirms no format and writes nothing")
+    func cancelledExportConfirmsNothing() {
+        let spy = ExportIOSpy()
+        var confirmedFormat: MeetingManualExportFormat?
+
+        MeetingExporter.processManualExport(
+            outcome: .cancelled,
+            markdown: "# Notes",
+            openAfterSaving: true,
+            onFormatConfirmed: { confirmedFormat = $0 },
+            io: spy.io
+        )
+
+        #expect(confirmedFormat == nil)
+        #expect(spy.pdfWrites.isEmpty)
+        #expect(spy.markdownWrites.isEmpty)
+        #expect(spy.openedFiles.isEmpty)
+    }
+
+    @Test("Confirmed save reports the selected format", arguments: MeetingManualExportFormat.allCases)
+    func confirmedSaveReportsFormat(format: MeetingManualExportFormat) {
+        let spy = ExportIOSpy()
+        var confirmedFormat: MeetingManualExportFormat?
+
+        MeetingExporter.processManualExport(
+            outcome: .confirmed(url: exportURL, format: format),
+            markdown: "# Notes",
+            openAfterSaving: true,
+            onFormatConfirmed: { confirmedFormat = $0 },
+            io: spy.io
+        )
+
+        #expect(confirmedFormat == format)
+        #expect(spy.pdfWrites == (format == .pdf ? [exportURL] : []))
+        #expect(spy.markdownWrites == (format == .markdown ? [exportURL] : []))
+    }
+
+    @Test("Open after saving enabled opens the file", arguments: MeetingManualExportFormat.allCases)
+    func openAfterSavingEnabledOpensFile(format: MeetingManualExportFormat) {
+        let spy = ExportIOSpy()
+
+        MeetingExporter.processManualExport(
+            outcome: .confirmed(url: exportURL, format: format),
+            markdown: "# Notes",
+            openAfterSaving: true,
+            io: spy.io
+        )
+
+        #expect(spy.openedFiles == [exportURL])
+    }
+
+    @Test("Open after saving disabled still writes but does not open", arguments: MeetingManualExportFormat.allCases)
+    func openAfterSavingDisabledDoesNotOpen(format: MeetingManualExportFormat) {
+        let spy = ExportIOSpy()
+
+        MeetingExporter.processManualExport(
+            outcome: .confirmed(url: exportURL, format: format),
+            markdown: "# Notes",
+            openAfterSaving: false,
+            io: spy.io
+        )
+
+        #expect(spy.pdfWrites.count + spy.markdownWrites.count == 1)
+        #expect(spy.openedFiles.isEmpty)
+    }
+
+    @Test("Write failure shows an error and does not open the file", arguments: MeetingManualExportFormat.allCases)
+    func writeFailureShowsErrorAndDoesNotOpen(format: MeetingManualExportFormat) {
+        let spy = ExportIOSpy()
+        spy.writeError = CocoaError(.fileWriteUnknown)
+
+        MeetingExporter.processManualExport(
+            outcome: .confirmed(url: exportURL, format: format),
+            markdown: "# Notes",
+            openAfterSaving: true,
+            io: spy.io
+        )
+
+        #expect(spy.errors == ["Export Failed"])
+        #expect(spy.openedFiles.isEmpty)
     }
 
     @Test("Truncates long titles in filename")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -856,6 +856,9 @@ struct AppConfigTests {
         #expect(config.resolvedAutoExportMarkdownContent == .notes)
         #expect(config.autoExportFileFormat == MeetingAutoExportFileFormat.markdown.rawValue)
         #expect(config.resolvedAutoExportFileFormat == .markdown)
+        #expect(config.manualExportFormat == MeetingManualExportFormat.pdf.rawValue)
+        #expect(config.resolvedManualExportFormat == .pdf)
+        #expect(config.openFileAfterManualExport == true)
         #expect(config.contributionPromptNextWordCount == nil)
         #expect(config.contributionPromptNextMeetingCount == nil)
         #expect(config.contributionGitHubStarClicked == false)
@@ -1008,6 +1011,8 @@ struct AppConfigTests {
         config.autoExportMarkdownFolderPath = "/tmp/muesli-auto-export"
         config.autoExportMarkdownContent = MeetingExportContent.fullMeeting.rawValue
         config.autoExportFileFormat = MeetingAutoExportFileFormat.markdownAndPDF.rawValue
+        config.manualExportFormat = MeetingManualExportFormat.markdown.rawValue
+        config.openFileAfterManualExport = false
         config.showScheduledMeetingNotifications = false
         config.scheduledMeetingNotificationLeadTime = .threeMinutes
         config.showMeetingDetectionNotification = false
@@ -1088,6 +1093,9 @@ struct AppConfigTests {
         #expect(decoded.resolvedAutoExportMarkdownContent == .fullMeeting)
         #expect(decoded.autoExportFileFormat == MeetingAutoExportFileFormat.markdownAndPDF.rawValue)
         #expect(decoded.resolvedAutoExportFileFormat == .markdownAndPDF)
+        #expect(decoded.manualExportFormat == MeetingManualExportFormat.markdown.rawValue)
+        #expect(decoded.resolvedManualExportFormat == .markdown)
+        #expect(decoded.openFileAfterManualExport == false)
         #expect(decoded.showScheduledMeetingNotifications == false)
         #expect(decoded.scheduledMeetingNotificationLeadTime == .threeMinutes)
         #expect(decoded.showMeetingDetectionNotification == false)
@@ -1186,6 +1194,8 @@ struct AppConfigTests {
         #expect(json["auto_export_markdown_folder_path"] != nil)
         #expect(json["auto_export_markdown_content"] != nil)
         #expect(json["auto_export_file_format"] != nil)
+        #expect(json["manual_export_format"] != nil)
+        #expect(json["open_file_after_manual_export"] != nil)
         #expect(json["contribution_prompt_next_word_count"] != nil)
         #expect(json["contribution_prompt_next_meeting_count"] != nil)
         #expect(json["contribution_github_star_clicked"] != nil)
@@ -1464,6 +1474,37 @@ struct AppConfigTests {
         #expect(config.hasCompletedOnboarding)
         #expect(config.resolvedOnboardingUseCase == .dictationAndMeetings)
         #expect(config.resolvedOnboardingUseCase.includesMeetings)
+    }
+
+    @Test("manual export preferences default when missing from legacy config")
+    func manualExportPreferencesDefaultWhenMissing() throws {
+        let json = """
+        {
+          "has_completed_onboarding": true
+        }
+        """
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.manualExportFormat == MeetingManualExportFormat.pdf.rawValue)
+        #expect(config.resolvedManualExportFormat == .pdf)
+        #expect(config.openFileAfterManualExport == true)
+    }
+
+    @Test("malformed manual export format falls back to PDF")
+    func malformedManualExportFormatFallsBackToPDF() throws {
+        let json = """
+        {
+          "manual_export_format": "docx",
+          "open_file_after_manual_export": false
+        }
+        """
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.manualExportFormat == MeetingManualExportFormat.pdf.rawValue)
+        #expect(config.resolvedManualExportFormat == .pdf)
+        #expect(config.openFileAfterManualExport == false)
     }
 
     @Test("legacy completed onboarding enables meetings when use case is malformed")


### PR DESCRIPTION
The export save panel always reset to PDF and unconditionally opened the exported file. Remember the last format confirmed in the save panel (canceling changes nothing) and add an "Open file after exporting" setting, enabled by default, in a Manual Export section alongside Auto Export. Manual export preferences are stored separately from auto-export settings, which have multi-format semantics.

Panel-outcome handling is extracted into processManualExport with injected file/open/error effects so the confirm, cancel, and open-gating branches are unit-tested for both formats.

_Screenshot of manual export options in Settings > Meetings_
<img width="890" height="259" alt="Screenshot 2026-07-10 at 9 05 55 PM" src="https://github.com/user-attachments/assets/fc0492d1-aee7-4194-9994-60848bf069d2" />

Fixes #293

## AI assistance
This contribution was developed with AI assistance (Anthropic's Claude Code Fable).
I reviewed and tested all resulting changes myself, ran the native test suite
and an isolated dev build, and take responsibility for the contribution. No
third-party code, models, or datasets were introduced; the change uses only
existing project and Foundation APIs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786336674&installation_id=136549638&pr_number=308&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F308&signature=63909b2f010b61114b14299539b27ea4f2560b66ef1ed5323a120f5ef9d2b5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Manual meeting exports now support PDF or Markdown formats.
  - Export preferences are saved and restored for future exports.
  - Export actions use format-appropriate file extensions and save dialog options.
  - Added a Manual Export settings section with an option to open files after exporting.
- **Bug Fixes**
  - Cancelled or failed exports no longer create or open files unexpectedly.
- **Tests**
  - Expanded coverage for export formats, preferences, outcomes, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->