### PR TITLE
Add Anthropic as a first-class meeting summary backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Muesli is a **lightweight native macOS app** that combines **WisprFlow-style dic
 Hold your hotkey (or double-tap for hands-free mode) → speak → release → transcribed text is pasted at your cursor. **~0.13 second latency** via Parakeet TDT on the Apple Neural Engine.
 
 ### Meeting Transcription
-Start a meeting recording → Muesli captures your mic (You) and system audio (Others) simultaneously → VAD-driven chunked transcription happens during the meeting at natural speech boundaries → speaker diarization identifies individual remote speakers (Speaker 1, Speaker 2, etc.) → when you stop, the transcript is ready in seconds, not minutes. Generate structured meeting notes via OpenAI, free OpenRouter models, your ChatGPT Plus/Pro subscription, or local Ollama models.
+Start a meeting recording → Muesli captures your mic (You) and system audio (Others) simultaneously → VAD-driven chunked transcription happens during the meeting at natural speech boundaries → speaker diarization identifies individual remote speakers (Speaker 1, Speaker 2, etc.) → when you stop, the transcript is ready in seconds, not minutes. Generate structured meeting notes via OpenAI, Anthropic, free OpenRouter models, your ChatGPT Plus/Pro subscription, or local Ollama models.
 
 Live meeting transcripts have two explicit modes. **Nemotron 3.5** is a unified multilingual option: its continuous transcript is the normal final raw transcript before diarization and note generation, with the configured meeting model retained only for gap recovery. **Parakeet Realtime EOU** is a low-latency English preview: it powers the live floating transcript while a separately selected meeting model creates the final transcript. Settings always shows which model owns the final transcript.
 
@@ -60,7 +60,7 @@ Live transcription is off by default. Download Parakeet Realtime EOU or Nemotron
 - **Dismiss calendar events** — Hide irrelevant events from Coming Up, status bar, and menu bar. Dismissed events are pruned automatically.
 - **iCloud Text Sync & iPhone Bridge** — Privately sync dictation text, meeting transcripts, notes, summaries, and manual notes with Muesli for iPhone through iCloud. Audio recordings are never synced.
 - **Filler word removal** — Automatically strips "uh", "um", "er", "hmm" and verbal disfluencies.
-- **AI meeting notes** — BYOK with OpenAI or OpenRouter, sign in with your ChatGPT Plus/Pro subscription (no API key needed), or use local Ollama models. Auto-generated meeting titles. Re-summarize any meeting.
+- **AI meeting notes** — BYOK with OpenAI, Anthropic, or OpenRouter, sign in with your ChatGPT Plus/Pro subscription (no API key needed), or use local Ollama models. Auto-generated meeting titles. Re-summarize any meeting.
 - **ChatGPT OAuth** — Sign in with your existing ChatGPT subscription via browser-based OAuth (PKCE). Tokens stored in the app support directory with owner-only file permissions.
 - **Computer Use planner** — Optional voice-driven planner that can execute local app and browser actions from dictated commands with configurable model and timeout settings.
 - **Post-meeting hooks** — Run a user-supplied executable after completed meetings. Hooks receive a JSON payload on stdin and log results in the app support directory.
@@ -217,7 +217,7 @@ Generate markdown notes with the configured API/local summary backend when avail
 muesli-cli transcribe interview.mp4 --summarize --format markdown --output notes.md
 ```
 
-`--summarize` uses configured OpenAI, OpenRouter, Ollama, LM Studio, or Custom LLM settings. If the configured backend is unavailable in headless CLI mode, Muesli keeps the transcript and reports a warning instead of discarding the transcription.
+`--summarize` uses configured OpenAI, Anthropic, OpenRouter, Ollama, LM Studio, or Custom LLM settings. If the configured backend is unavailable in headless CLI mode, Muesli keeps the transcript and reports a warning instead of discarding the transcription.
 
 Save the import into Muesli as `source = audio_import`:
 
@@ -354,7 +354,7 @@ Muesli needs these macOS permissions (guided during onboarding):
 | Speaker diarization | pyannote via FluidAudio (CoreML on ANE) |
 | Camera detection | CoreMediaIO property listeners (event-driven) |
 | System audio | CoreAudio process tap by default; ScreenCaptureKit (`SCStream`) fallback |
-| Meeting notes | OpenAI / OpenRouter (BYOK), ChatGPT subscription (OAuth), or Ollama |
+| Meeting notes | OpenAI / Anthropic / OpenRouter (BYOK), ChatGPT subscription (OAuth), or Ollama |
 | Calendar | Google Calendar API (OAuth 2.0) |
 | Sync | CloudKit private database for text-only iCloud sync |
 | Automation | Computer Use planner and post-meeting executable hooks |

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -742,19 +742,22 @@ enum CLISummaryClient {
                 title: title
             )
         case "anthropic":
-            let key = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] ?? config.anthropicAPIKey
-            guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            let key = (ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] ?? config.anthropicAPIKey)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else {
                 throw CLISummaryError.unavailable("Anthropic summary settings are missing an API key.")
             }
-            let configuredURL = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"] ?? config.anthropicURL
+            let configuredURL = (ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"] ?? config.anthropicURL)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             guard let url = resolveEndpointURL(configuredURL.isEmpty ? "https://api.anthropic.com" : configuredURL, endpointSuffix: "v1/messages") else {
                 throw CLISummaryError.unavailable("Invalid Anthropic URL.")
             }
+            let model = config.anthropicModel.trimmingCharacters(in: .whitespacesAndNewlines)
             return try await anthropicSummary(
                 backend: "Anthropic",
                 url: url,
                 apiKey: key,
-                model: config.anthropicModel.isEmpty ? defaultAnthropicModel : config.anthropicModel,
+                model: model.isEmpty ? defaultAnthropicModel : model,
                 transcript: transcript,
                 title: title
             )

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -640,6 +640,9 @@ struct CLISummaryConfig: Decodable {
     var meetingSummaryBackend = "chatgpt"
     var openAIAPIKey = ""
     var openRouterAPIKey = ""
+    var anthropicAPIKey = ""
+    var anthropicURL = ""
+    var anthropicModel = ""
     var openAIModel = ""
     var openRouterModel = ""
     var ollamaURL = "http://localhost:11434"
@@ -651,20 +654,24 @@ struct CLISummaryConfig: Decodable {
     var customLLMModel = ""
     var customLLMFormat = "openai"
 
+    // config.json is written by ConfigStore with snake_case keys (see AppConfig.CodingKeys)
     enum CodingKeys: String, CodingKey {
-        case meetingSummaryBackend
-        case openAIAPIKey
-        case openRouterAPIKey
-        case openAIModel
-        case openRouterModel
-        case ollamaURL
-        case ollamaModel
-        case lmStudioURL
-        case lmStudioModel
-        case customLLMURL
-        case customLLMAPIKey
-        case customLLMModel
-        case customLLMFormat
+        case meetingSummaryBackend = "meeting_summary_backend"
+        case openAIAPIKey = "openai_api_key"
+        case openRouterAPIKey = "openrouter_api_key"
+        case anthropicAPIKey = "anthropic_api_key"
+        case anthropicURL = "anthropic_url"
+        case anthropicModel = "anthropic_model"
+        case openAIModel = "openai_model"
+        case openRouterModel = "openrouter_model"
+        case ollamaURL = "ollama_url"
+        case ollamaModel = "ollama_model"
+        case lmStudioURL = "lmstudio_url"
+        case lmStudioModel = "lmstudio_model"
+        case customLLMURL = "custom_llm_url"
+        case customLLMAPIKey = "custom_llm_api_key"
+        case customLLMModel = "custom_llm_model"
+        case customLLMFormat = "custom_llm_format"
     }
 
     init() {}
@@ -674,6 +681,9 @@ struct CLISummaryConfig: Decodable {
         meetingSummaryBackend = try container.decodeIfPresent(String.self, forKey: .meetingSummaryBackend) ?? meetingSummaryBackend
         openAIAPIKey = try container.decodeIfPresent(String.self, forKey: .openAIAPIKey) ?? openAIAPIKey
         openRouterAPIKey = try container.decodeIfPresent(String.self, forKey: .openRouterAPIKey) ?? openRouterAPIKey
+        anthropicAPIKey = try container.decodeIfPresent(String.self, forKey: .anthropicAPIKey) ?? anthropicAPIKey
+        anthropicURL = try container.decodeIfPresent(String.self, forKey: .anthropicURL) ?? anthropicURL
+        anthropicModel = try container.decodeIfPresent(String.self, forKey: .anthropicModel) ?? anthropicModel
         openAIModel = try container.decodeIfPresent(String.self, forKey: .openAIModel) ?? openAIModel
         openRouterModel = try container.decodeIfPresent(String.self, forKey: .openRouterModel) ?? openRouterModel
         ollamaURL = try container.decodeIfPresent(String.self, forKey: .ollamaURL) ?? ollamaURL
@@ -712,6 +722,7 @@ enum CLISummaryError: LocalizedError {
 enum CLISummaryClient {
     private static let defaultOpenAIModel = "gpt-5.4-mini"
     private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
+    private static let defaultAnthropicModel = "claude-haiku-4-5"
     private static let defaultSummaryMaxOutputTokens = 2500
 
     static func summarize(transcript: String, title: String, config: CLISummaryConfig) async throws -> String {
@@ -727,6 +738,23 @@ enum CLISummaryClient {
                 url: URL(string: "https://api.openai.com/v1/responses")!,
                 apiKey: key,
                 model: config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel,
+                transcript: transcript,
+                title: title
+            )
+        case "anthropic":
+            let key = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] ?? config.anthropicAPIKey
+            guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw CLISummaryError.unavailable("Anthropic summary settings are missing an API key.")
+            }
+            let configuredURL = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"] ?? config.anthropicURL
+            guard let url = resolveEndpointURL(configuredURL.isEmpty ? "https://api.anthropic.com" : configuredURL, endpointSuffix: "v1/messages") else {
+                throw CLISummaryError.unavailable("Invalid Anthropic URL.")
+            }
+            return try await anthropicSummary(
+                backend: "Anthropic",
+                url: url,
+                apiKey: key,
+                model: config.anthropicModel.isEmpty ? defaultAnthropicModel : config.anthropicModel,
                 transcript: transcript,
                 title: title
             )
@@ -778,7 +806,7 @@ enum CLISummaryClient {
                 guard let url = resolveEndpointURL(config.customLLMURL.isEmpty ? "https://api.anthropic.com" : config.customLLMURL, endpointSuffix: "v1/messages") else {
                     throw CLISummaryError.unavailable("Invalid Custom LLM URL.")
                 }
-                return try await anthropicSummary(url: url, apiKey: config.customLLMAPIKey, model: config.customLLMModel, transcript: transcript, title: title)
+                return try await anthropicSummary(backend: "Custom LLM", url: url, apiKey: config.customLLMAPIKey, model: config.customLLMModel, transcript: transcript, title: title)
             }
             guard let url = resolveEndpointURL(config.customLLMURL.isEmpty ? "http://localhost:8080" : config.customLLMURL, endpointSuffix: "v1/chat/completions") else {
                 throw CLISummaryError.unavailable("Invalid Custom LLM URL.")
@@ -792,7 +820,7 @@ enum CLISummaryClient {
                 title: title
             )
         default:
-            throw CLISummaryError.unavailable("The configured ChatGPT session summary backend is app-only in headless CLI mode. Select OpenAI, OpenRouter, Ollama, LM Studio, or Custom LLM in Muesli settings for `muesli-cli transcribe --summarize`.")
+            throw CLISummaryError.unavailable("The configured ChatGPT session summary backend is app-only in headless CLI mode. Select OpenAI, Anthropic, OpenRouter, Ollama, LM Studio, or Custom LLM in Muesli settings for `muesli-cli transcribe --summarize`.")
         }
     }
 
@@ -877,7 +905,7 @@ enum CLISummaryClient {
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static func anthropicSummary(url: URL, apiKey: String, model: String, transcript: String, title: String) async throws -> String {
+    private static func anthropicSummary(backend: String, url: URL, apiKey: String, model: String, transcript: String, title: String) async throws -> String {
         let body: [String: Any] = [
             "model": model,
             "max_tokens": defaultSummaryMaxOutputTokens,
@@ -893,14 +921,14 @@ enum CLISummaryClient {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        let data = try await send(request: request, backend: "Custom LLM")
+        let data = try await send(request: request, backend: backend)
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let content = json["content"] as? [[String: Any]] else {
-            throw CLISummaryError.emptyResponse("Custom LLM returned an empty summary response.")
+            throw CLISummaryError.emptyResponse("\(backend) returned an empty summary response.")
         }
         let text = content.compactMap { $0["text"] as? String }.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else {
-            throw CLISummaryError.emptyResponse("Custom LLM returned an empty summary response.")
+            throw CLISummaryError.emptyResponse("\(backend) returned an empty summary response.")
         }
         return text
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -122,10 +122,12 @@ enum MeetingSummaryClient {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingSummary")
     private static let openAIURL = URL(string: "https://api.openai.com/v1/responses")!
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
+    private static let anthropicURL = URL(string: "https://api.anthropic.com/v1/messages")!
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
     private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
     private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
+    private static let defaultAnthropicModel = "claude-haiku-4-5"
     private static let defaultChatGPTModel = "gpt-5.4-mini"
     private static let defaultOllamaModel = "qwen3.5"
     private static let defaultSummaryMaxOutputTokens = 2500
@@ -135,6 +137,8 @@ enum MeetingSummaryClient {
     private static let lmStudioTitleTimeout: TimeInterval = 120
     private static let customLLMSummaryTimeout: TimeInterval = 300
     private static let customLLMTitleTimeout: TimeInterval = 120
+    private static let anthropicSummaryTimeout: TimeInterval = 300
+    private static let anthropicTitleTimeout: TimeInterval = 120
 
     private static let titleInstructions = """
     Generate a short, descriptive meeting title (3-7 words) from these transcript excerpts. \
@@ -215,6 +219,19 @@ enum MeetingSummaryClient {
         let generatedNotes: String
         if backend == MeetingSummaryBackendOption.chatGPT.backend {
             generatedNotes = try await summarizeWithChatGPT(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext,
+                previousMeetingNotes: previousMeetingNotes
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
+        if backend == MeetingSummaryBackendOption.anthropic.backend {
+            generatedNotes = try await summarizeWithAnthropic(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -615,6 +632,43 @@ enum MeetingSummaryClient {
             fputs("[summary] ChatGPT summarization failed: \(error)\n", stderr)
             throw summaryRequestError(backend: "ChatGPT", error: error)
         }
+    }
+
+    private static func summarizeWithAnthropic(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil,
+        previousMeetingNotes: String? = nil
+    ) async throws -> String {
+        let apiKey = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] ?? config.anthropicAPIKey
+        guard !apiKey.isEmpty else {
+            return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+        }
+
+        guard let requestURL = resolveAnthropicURL(config: config) else {
+            throw MeetingSummaryError.backendFailed(backend: "Anthropic", statusCode: nil, message: "Invalid Anthropic URL: \(config.anthropicURL)")
+        }
+        let configuredModel = config.anthropicModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = configuredModel.isEmpty ? defaultAnthropicModel : configuredModel
+        return try await summarizeWithAnthropicMessages(
+            backend: "Anthropic",
+            requestURL: requestURL,
+            apiKey: apiKey,
+            model: model,
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            config: config,
+            template: template,
+            visualContext: visualContext,
+            previousMeetingNotes: previousMeetingNotes,
+            timeout: anthropicSummaryTimeout
+        )
     }
 
     private static func summarizeWithOllama(
@@ -1051,6 +1105,15 @@ enum MeetingSummaryClient {
         return resolveEndpointURL(rawURL.isEmpty ? defaultURL : rawURL, endpointSuffix: endpointSuffix)
     }
 
+    static func resolveAnthropicURL(config: AppConfig) -> URL? {
+        let configuredURL = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"] ?? config.anthropicURL
+        let rawURL = configuredURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        return resolveEndpointURL(
+            rawURL.isEmpty ? anthropicURL.absoluteString : rawURL,
+            endpointSuffix: "v1/messages"
+        )
+    }
+
     static func resolveLMStudioURL(config: AppConfig) -> URL? {
         let rawURL = config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
         return resolveEndpointURL(
@@ -1101,6 +1164,27 @@ enum MeetingSummaryClient {
 
         if backend == MeetingSummaryBackendOption.chatGPT.backend {
             return await generateTitleWithChatGPT(transcript: excerpt, config: config)
+        }
+
+        if backend == MeetingSummaryBackendOption.anthropic.backend {
+            let apiKey = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] ?? config.anthropicAPIKey
+            guard !apiKey.isEmpty else { return nil }
+            guard let requestURL = resolveAnthropicURL(config: config) else {
+                fputs("[summary] Anthropic title generation: invalid URL \(config.anthropicURL)\n", stderr)
+                return nil
+            }
+            let configuredModel = config.anthropicModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            let model = configuredModel.isEmpty ? defaultAnthropicModel : configuredModel
+            return await callAnthropicMessages(
+                backend: "Anthropic",
+                url: requestURL,
+                apiKey: apiKey,
+                model: model,
+                systemPrompt: titleInstructions,
+                userPrompt: excerpt,
+                maxTokens: 100,
+                timeout: anthropicTitleTimeout
+            )
         }
 
         if backend == MeetingSummaryBackendOption.openRouter.backend {
@@ -1231,6 +1315,7 @@ enum MeetingSummaryClient {
     }
 
     private static func callAnthropicMessages(
+        backend: String = "Custom LLM",
         url: URL,
         apiKey: String,
         model: String,
@@ -1262,7 +1347,7 @@ enum MeetingSummaryClient {
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            try validateHTTPResponse(response, data: data, backend: "Custom LLM")
+            try validateHTTPResponse(response, data: data, backend: backend)
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 fputs("[summary] Anthropic title generation: invalid JSON response\n", stderr)
                 return nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -367,6 +367,12 @@ struct SummaryModelPreset {
         SummaryModelPreset(id: "gpt-5.2", label: "GPT-5.2"),
     ]
 
+    static let anthropicModels: [SummaryModelPreset] = [
+        SummaryModelPreset(id: "claude-haiku-4-5", label: "Claude Haiku 4.5 (default)"),
+        SummaryModelPreset(id: "claude-sonnet-5", label: "Claude Sonnet 5"),
+        SummaryModelPreset(id: "claude-opus-5", label: "Claude Opus 5"),
+    ]
+
     static let openRouterModels: [SummaryModelPreset] = [
         SummaryModelPreset(id: "stepfun/step-3.5-flash:free", label: "Step 3.5 Flash (256k ctx)"),
         SummaryModelPreset(id: "nvidia/nemotron-3-super-120b-a12b:free", label: "Nemotron 3 Super 120B (262k ctx)"),
@@ -489,6 +495,11 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "OpenAI"
     )
 
+    static let anthropic = MeetingSummaryBackendOption(
+        backend: "anthropic",
+        label: "Anthropic"
+    )
+
     static let openRouter = MeetingSummaryBackendOption(
         backend: "openrouter",
         label: "OpenRouter"
@@ -514,7 +525,7 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "Custom LLM"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .lmStudio, .customLLM]
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .anthropic, .openRouter, .ollama, .lmStudio, .customLLM]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
@@ -1034,8 +1045,11 @@ struct AppConfig: Codable {
     var indicatorOrigin: CGPointCodable? = nil
     var openAIAPIKey: String = ""
     var openRouterAPIKey: String = ""
+    var anthropicAPIKey: String = ""
+    var anthropicURL: String = ""
     var openAIModel: String = ""
     var openRouterModel: String = ""
+    var anthropicModel: String = ""
     var chatGPTModel: String = ""
     var meetingSummaryRetryCount: Int = MeetingSummaryRetryPolicy.defaultRetryCount
     var ollamaURL: String = "http://localhost:11434"
@@ -1154,8 +1168,11 @@ struct AppConfig: Codable {
         case indicatorOrigin = "indicator_origin"
         case openAIAPIKey = "openai_api_key"
         case openRouterAPIKey = "openrouter_api_key"
+        case anthropicAPIKey = "anthropic_api_key"
+        case anthropicURL = "anthropic_url"
         case openAIModel = "openai_model"
         case openRouterModel = "openrouter_model"
+        case anthropicModel = "anthropic_model"
         case chatGPTModel = "chatgpt_model"
         case meetingSummaryRetryCount = "meeting_summary_retry_count"
         case ollamaURL = "ollama_url"
@@ -1305,8 +1322,11 @@ struct AppConfig: Codable {
         indicatorOrigin = try? c.decode(CGPointCodable.self, forKey: .indicatorOrigin)
         openAIAPIKey = (try? c.decode(String.self, forKey: .openAIAPIKey)) ?? defaults.openAIAPIKey
         openRouterAPIKey = (try? c.decode(String.self, forKey: .openRouterAPIKey)) ?? defaults.openRouterAPIKey
+        anthropicAPIKey = (try? c.decode(String.self, forKey: .anthropicAPIKey)) ?? defaults.anthropicAPIKey
+        anthropicURL = (try? c.decode(String.self, forKey: .anthropicURL)) ?? defaults.anthropicURL
         openAIModel = (try? c.decode(String.self, forKey: .openAIModel)) ?? defaults.openAIModel
         openRouterModel = (try? c.decode(String.self, forKey: .openRouterModel)) ?? defaults.openRouterModel
+        anthropicModel = (try? c.decode(String.self, forKey: .anthropicModel)) ?? defaults.anthropicModel
         chatGPTModel = SummaryModelPreset.supportedChatGPTModel(
             (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3545,6 +3545,8 @@ final class MuesliController: NSObject {
             if let apiKey, !apiKey.isEmpty {
                 if summaryBackend == .openAI {
                     config.openAIAPIKey = apiKey
+                } else if summaryBackend == .anthropic {
+                    config.anthropicAPIKey = apiKey
                 } else if summaryBackend == .openRouter {
                     config.openRouterAPIKey = apiKey
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1411,6 +1411,10 @@ struct OnboardingView: View {
                     summaryBackend = .openAI
                     apiKey = ""
                 }
+                providerTab("Anthropic", selected: summaryBackend == .anthropic) {
+                    summaryBackend = .anthropic
+                    apiKey = ""
+                }
                 providerTab("OpenRouter", selected: summaryBackend == .openRouter) {
                     summaryBackend = .openRouter
                     apiKey = ""
@@ -1521,7 +1525,7 @@ struct OnboardingView: View {
 
                     PastableSecureField(
                         text: apiKey,
-                        placeholder: summaryBackend == .openAI ? "sk-..." : "sk-or-...",
+                        placeholder: onboardingAPIKeyPlaceholder,
                         onChange: { apiKey = $0 }
                     )
                     .frame(width: 320, height: 28)
@@ -1540,6 +1544,14 @@ struct OnboardingView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var onboardingAPIKeyPlaceholder: String {
+        switch summaryBackend {
+        case .openAI: return "sk-..."
+        case .anthropic: return "sk-ant-..."
+        default: return "sk-or-..."
+        }
     }
 
     private func providerTab(_ title: String, selected: Bool, action: @escaping () -> Void) -> some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1080,6 +1080,32 @@ struct SettingsView: View {
                     ) { val in controller.updateConfig { $0.openAIModel = val } }
                 }
                 keyStatusRow(key: appState.config.openAIAPIKey)
+            } else if appState.selectedMeetingSummaryBackend == .anthropic {
+                settingsRow("Anthropic URL", controlWidth: meetingControlWidth) {
+                    PastableTextField(
+                        text: appState.config.anthropicURL,
+                        placeholder: "https://api.anthropic.com",
+                        onChange: { val in controller.updateConfig { $0.anthropicURL = val } }
+                    )
+                    .frame(height: 22)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("API Key", controlWidth: meetingControlWidth) {
+                    PastableSecureField(
+                        text: appState.config.anthropicAPIKey,
+                        placeholder: "sk-ant-...",
+                        onChange: { val in controller.updateConfig { $0.anthropicAPIKey = val } }
+                    )
+                    .frame(height: 22)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Model", controlWidth: meetingControlWidth) {
+                    settingsModelMenu(
+                        currentModel: appState.config.anthropicModel,
+                        presets: SummaryModelPreset.anthropicModels
+                    ) { val in controller.updateConfig { $0.anthropicModel = val } }
+                }
+                keyStatusRow(key: appState.config.anthropicAPIKey)
             } else if appState.selectedMeetingSummaryBackend == .ollama {
                 settingsRow("Ollama URL", controlWidth: meetingControlWidth) {
                     PastableTextField(

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1099,10 +1099,17 @@ struct SettingsView: View {
                     .frame(height: 22)
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Model", controlWidth: meetingControlWidth) {
+                settingsRow("Model preset", controlWidth: meetingControlWidth) {
                     settingsModelMenu(
                         currentModel: appState.config.anthropicModel,
                         presets: SummaryModelPreset.anthropicModels
+                    ) { val in controller.updateConfig { $0.anthropicModel = val } }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
+                    settingsModelTextField(
+                        currentModel: appState.config.anthropicModel,
+                        placeholder: "claude-haiku-4-5"
                     ) { val in controller.updateConfig { $0.anthropicModel = val } }
                 }
                 keyStatusRow(key: appState.config.anthropicAPIKey)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -327,6 +327,22 @@ struct MeetingSummaryClientTests {
         #expect(prompt.contains("Raw transcript:\nTranscript body"))
     }
 
+    @Test("summarize routes to Anthropic when configured")
+    func routesToAnthropic() async throws {
+        var config = AppConfig()
+        config.anthropicAPIKey = ""
+        config.meetingSummaryBackend = "anthropic"
+
+        let result = try await MeetingSummaryClient.summarize(
+            transcript: "Test transcript",
+            meetingTitle: "My Meeting",
+            config: config
+        )
+
+        // No key → falls back to raw transcript
+        #expect(result.contains("## Raw Transcript"))
+    }
+
     @Test("summarize routes to OpenRouter when configured")
     func routesToOpenRouter() async throws {
         var config = AppConfig()
@@ -749,6 +765,35 @@ struct MeetingSummaryClientTests {
         #expect(
             MeetingSummaryClient.resolveLMStudioURL(config: config)?.absoluteString ==
                 "http://localhost:1234/v1/chat/completions"
+        )
+    }
+
+    @Test("resolveAnthropicURL expands Messages endpoints")
+    func resolveAnthropicURLExpansion() {
+        var config = AppConfig()
+
+        config.anthropicURL = ""
+        #expect(
+            MeetingSummaryClient.resolveAnthropicURL(config: config)?.absoluteString ==
+                "https://api.anthropic.com/v1/messages"
+        )
+
+        config.anthropicURL = "https://proxy.example.com"
+        #expect(
+            MeetingSummaryClient.resolveAnthropicURL(config: config)?.absoluteString ==
+                "https://proxy.example.com/v1/messages"
+        )
+
+        config.anthropicURL = "https://proxy.example.com/v1"
+        #expect(
+            MeetingSummaryClient.resolveAnthropicURL(config: config)?.absoluteString ==
+                "https://proxy.example.com/v1/messages"
+        )
+
+        config.anthropicURL = "https://proxy.example.com/v1/messages"
+        #expect(
+            MeetingSummaryClient.resolveAnthropicURL(config: config)?.absoluteString ==
+                "https://proxy.example.com/v1/messages"
         )
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -552,6 +552,23 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.resolved(nil) == .chatGPT)
     }
 
+    @Test("Anthropic config persistence defaults and round trips")
+    func anthropicConfigPersistence() throws {
+        let defaults = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+        #expect(defaults.anthropicAPIKey.isEmpty)
+        #expect(defaults.anthropicURL.isEmpty)
+        #expect(defaults.anthropicModel.isEmpty)
+
+        var config = AppConfig()
+        config.anthropicAPIKey = "sk-ant-test"
+        config.anthropicURL = "https://proxy.example.com"
+        config.anthropicModel = "claude-custom-model"
+        let restored = try JSONDecoder().decode(AppConfig.self, from: JSONEncoder().encode(config))
+        #expect(restored.anthropicAPIKey == config.anthropicAPIKey)
+        #expect(restored.anthropicURL == config.anthropicURL)
+        #expect(restored.anthropicModel == config.anthropicModel)
+    }
+
     @Test("Custom LLM format labels")
     func customLLMFormatLabels() {
         #expect(CustomLLMFormat.openAI.label == "OpenAI-compatible")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -520,8 +520,9 @@ struct MeetingSummaryBackendTests {
 
     @Test("all options listed")
     func allOptions() {
-        #expect(MeetingSummaryBackendOption.all.count == 6)
+        #expect(MeetingSummaryBackendOption.all.count == 7)
         #expect(MeetingSummaryBackendOption.all.contains(.openAI))
+        #expect(MeetingSummaryBackendOption.all.contains(.anthropic))
         #expect(MeetingSummaryBackendOption.all.contains(.openRouter))
         #expect(MeetingSummaryBackendOption.all.contains(.chatGPT))
         #expect(MeetingSummaryBackendOption.all.contains(.ollama))
@@ -532,6 +533,7 @@ struct MeetingSummaryBackendTests {
     @Test("backend strings are lowercase")
     func backendStrings() {
         #expect(MeetingSummaryBackendOption.openAI.backend == "openai")
+        #expect(MeetingSummaryBackendOption.anthropic.backend == "anthropic")
         #expect(MeetingSummaryBackendOption.openRouter.backend == "openrouter")
         #expect(MeetingSummaryBackendOption.ollama.backend == "ollama")
         #expect(MeetingSummaryBackendOption.lmStudio.backend == "lmstudio")
@@ -541,6 +543,7 @@ struct MeetingSummaryBackendTests {
     @Test("configured values resolve with ChatGPT fallback")
     func resolvedValues() {
         #expect(MeetingSummaryBackendOption.resolved("chatgpt") == .chatGPT)
+        #expect(MeetingSummaryBackendOption.resolved("anthropic") == .anthropic)
         #expect(MeetingSummaryBackendOption.resolved("openrouter") == .openRouter)
         #expect(MeetingSummaryBackendOption.resolved("ollama") == .ollama)
         #expect(MeetingSummaryBackendOption.resolved("lmstudio") == .lmStudio)


### PR DESCRIPTION
## Summary

Muesli already speaks the Anthropic Messages format through the Custom LLM backend (`summarizeWithAnthropicMessages`, `extractAnthropicText`). This PR promotes Anthropic to a dedicated option in the summary backend picker, following the same conventions as the OpenAI/OpenRouter backends:

- **"Anthropic" backend option** in Settings with an API key field (`anthropic_api_key`); the `ANTHROPIC_API_KEY` environment variable takes precedence, and with no key configured summaries fall back to the raw transcript, matching OpenAI/OpenRouter behavior.
- **Model presets** — Claude Haiku 4.5 (default), Claude Sonnet 5, Claude Opus 5 — with custom model IDs supported through the existing `menuPresets` affordance.
- **Configurable base URL** (`anthropic_url`, or `ANTHROPIC_BASE_URL` env override) for Anthropic-compatible proxies, resolved through the existing `resolveEndpointURL` expansion so bare hosts gain the `v1/messages` suffix (mirrors LM Studio/Custom LLM).
- **Summaries and titles** reuse the existing `summarizeWithAnthropicMessages` / `callAnthropicMessages` request paths; `callAnthropicMessages` gains a backend label parameter (default `"Custom LLM"`, unchanged for the existing caller) so HTTP errors attribute to the right backend.
- **Onboarding**: an Anthropic tab in the Meeting Summaries step, reusing the shared API key field and storing the key on completion.
- README backend lists updated.

Intentionally out of scope: the transcript-cleanup backend list (`LLMBackendOption`) — happy to follow up if you'd like parity there.

## Testing

- `MeetingSummaryBackendOption` suite updated (registration, backend string, resolution) and a `routesToAnthropic` no-key fallback test added, mirroring `routesToOpenRouter`.
- New `resolveAnthropicURL` expansion test mirroring the LM Studio/Custom LLM resolver tests.
- Verified the request/response shape end-to-end against `v1/messages` (HTTP 200, `content[].text` parsed by `extractAnthropicText`).
- `swift build` of `MuesliNativeApp` passes locally; full `swift test` deferred to CI (local machine has Command Line Tools only, no Xcode toolchain for swift-testing).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787737532&installation_model_id=422865&pr_number=340&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F340&signature=69029ba622ff5765bc955cc0da4c5bf75ac1ee74545fa7723398d883cab0b5bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Anthropic as a selectable provider for meeting summaries and title generation across the app, onboarding, and CLI.
  * Added Anthropic configuration for API key, endpoint URL, and model selection, with persisted settings.
* **Bug Fixes**
  * Fixed Anthropic backend handling to consistently use the correct `/v1/messages` endpoint and improved unsupported-backend/headless messaging.
* **Documentation**
  * Updated README to include Anthropic for structured meeting notes and CLI/offline summarization.
* **Tests**
  * Added/extended tests for Anthropic backend routing, endpoint normalization, and config persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
