### PR TITLE
Fix meeting detail overflow caused by long titles

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -197,48 +197,22 @@ struct MeetingDetailView: View {
                 .buttonStyle(.plain)
             }
 
-            HStack(alignment: .top, spacing: MuesliTheme.spacing24) {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                    MarqueeTitleTextField(
-                        text: $editableTitle,
-                        onSubmit: {
-                            controller.updateMeetingTitle(id: meeting.id, title: editableTitle)
-                        },
-                        onTextChange: {
-                            debounceSaveTitle(meetingID: meeting.id)
-                        }
-                    )
-
-                    HStack(spacing: MuesliTheme.spacing8) {
-                        Text(formatMeta(meeting))
-                            .font(MuesliTheme.callout())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                        if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: meeting.source) {
-                            SyncOriginBadge(label: label)
-                        }
-                        templateChip(for: appliedTemplate)
-                    }
-
-                    folderPill(for: meeting)
-
-                    threadBreadcrumb
+            ExpandableMeetingTitleField(
+                text: $editableTitle,
+                onSubmit: {
+                    controller.updateMeetingTitle(id: meeting.id, title: editableTitle)
+                },
+                onTextChange: {
+                    debounceSaveTitle(meetingID: meeting.id)
                 }
+            )
+            .id(meeting.id)
 
-                Spacer(minLength: MuesliTheme.spacing16)
+            meetingMetadata(for: meeting, appliedTemplate: appliedTemplate)
 
-                VStack(alignment: .trailing, spacing: 10) {
-                    if showsManualNotesEditor(for: meeting) {
-                        recordingControlGroup(for: meeting)
-                        if meeting.status == .recording {
-                            recordingModePicker
-                        }
-                    } else {
-                        documentModePicker
+            threadBreadcrumb
 
-                        headerActions(for: meeting, appliedTemplate: appliedTemplate)
-                    }
-                }
-            }
+            meetingToolbar(for: meeting, appliedTemplate: appliedTemplate)
 
             if let savedRecordingPath = meeting.savedRecordingPath,
                FileManager.default.fileExists(atPath: savedRecordingPath) {
@@ -251,10 +225,60 @@ struct MeetingDetailView: View {
                 transcriptCTA
             }
         }
-        .frame(maxWidth: 980, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 40)
         .padding(.vertical, 24)
-        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder
+    private func meetingMetadata(
+        for meeting: MeetingRecord,
+        appliedTemplate: MeetingTemplateSnapshot
+    ) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                meetingMetadataFacts(for: meeting)
+                if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: meeting.source) {
+                    SyncOriginBadge(label: label)
+                }
+                templateChip(for: appliedTemplate)
+                folderPill(for: meeting)
+            }
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                HStack(spacing: MuesliTheme.spacing12) {
+                    meetingMetadataFacts(for: meeting)
+                    if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: meeting.source) {
+                        SyncOriginBadge(label: label)
+                    }
+                }
+                HStack(spacing: MuesliTheme.spacing8) {
+                    templateChip(for: appliedTemplate)
+                    folderPill(for: meeting)
+                }
+            }
+        }
+    }
+
+    private func meetingMetadataFacts(for meeting: MeetingRecord) -> some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            metadataFact(MeetingBrowserLogic.formatStartTime(meeting.startTime))
+            metadataFact(formatDuration(meeting.durationSeconds))
+            metadataFact("\(meeting.wordCount) words")
+        }
+    }
+
+    private func metadataFact(_ text: String) -> some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(MuesliTheme.textTertiary)
+                .frame(width: 5, height: 5)
+            Text(text)
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .lineLimit(1)
+        }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     @ViewBuilder
@@ -449,10 +473,79 @@ struct MeetingDetailView: View {
     }
 
     @ViewBuilder
+    private func meetingToolbar(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
+        Group {
+            if showsManualNotesEditor(for: meeting) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: MuesliTheme.spacing12) {
+                        recordingControlGroup(for: meeting)
+                        Spacer(minLength: MuesliTheme.spacing16)
+                        if meeting.status == .recording {
+                            recordingModePicker
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                        recordingControlGroup(for: meeting)
+                        if meeting.status == .recording {
+                            recordingModePicker
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                    }
+                }
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: MuesliTheme.spacing12) {
+                        headerActions(for: meeting, appliedTemplate: appliedTemplate)
+                        Spacer(minLength: MuesliTheme.spacing16)
+                        documentModePicker
+                    }
+
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                        HStack(spacing: MuesliTheme.spacing12) {
+                            if shouldShowResumeChooser(for: meeting) {
+                                resumeRecordingButton(for: meeting)
+                            }
+                            Spacer(minLength: MuesliTheme.spacing16)
+                            documentModePicker
+                        }
+                        compactHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, MuesliTheme.spacing12)
+        .padding(.vertical, MuesliTheme.spacing8)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
     private func headerActions(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            if shouldShowResumeChooser(for: meeting) {
+                resumeRecordingButton(for: meeting)
+
+                Divider()
+                    .background(MuesliTheme.surfaceBorder)
+                    .frame(height: 24)
+                    .padding(.horizontal, MuesliTheme.spacing4)
+            }
+
+            templateMenu(for: meeting, appliedTemplate: appliedTemplate)
+            exportMenu(for: meeting)
+            summaryAction(for: meeting)
+            editButton(for: meeting)
+            moreActionsMenu(for: meeting)
+        }
+    }
+
+    private func compactHeaderActions(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: MuesliTheme.spacing8) {
-                resumeChooserIfAvailable(for: meeting)
                 templateMenu(for: meeting, appliedTemplate: appliedTemplate)
                 exportMenu(for: meeting)
                 summaryAction(for: meeting)
@@ -462,7 +555,6 @@ struct MeetingDetailView: View {
 
             VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
                 HStack(spacing: MuesliTheme.spacing8) {
-                    resumeChooserIfAvailable(for: meeting)
                     templateMenu(for: meeting, appliedTemplate: appliedTemplate)
                     exportMenu(for: meeting)
                     summaryAction(for: meeting)
@@ -482,12 +574,12 @@ struct MeetingDetailView: View {
                 ProgressView()
                     .controlSize(.small)
                 Text("Summarizing...")
-                    .font(.system(size: 11))
-                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
             }
             .padding(.horizontal, MuesliTheme.spacing8)
         } else {
-            iconButton("sparkles", label: primarySummaryActionLabel(for: meeting)) {
+            toolbarActionButton("sparkles", label: primarySummaryActionLabel(for: meeting)) {
                 isSummarizing = true
                 let completion: (Result<Void, Error>) -> Void = { [meeting] result in
                     isSummarizing = false
@@ -514,7 +606,7 @@ struct MeetingDetailView: View {
 
     @ViewBuilder
     private func editButton(for meeting: MeetingRecord) -> some View {
-        iconButton(
+        toolbarActionButton(
             isEditingNotes || isEditingTranscript ? "checkmark.circle" : "pencil",
             label: editButtonLabel
         ) {
@@ -639,25 +731,23 @@ struct MeetingDetailView: View {
                 controller.showMeetingTemplatesManager()
             }
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: 6) {
                 Image(systemName: iconName(forSelectionOn: meeting, appliedTemplate: appliedTemplate))
-                    .font(.system(size: 10))
+                    .font(.system(size: 11, weight: .semibold))
                 Text(labelForSelection(on: meeting, appliedTemplate: appliedTemplate))
-                    .font(.system(size: 11, weight: .medium))
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 9))
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
             }
             .foregroundStyle(MuesliTheme.textSecondary)
             .padding(.horizontal, MuesliTheme.spacing8)
-            .padding(.vertical, 5)
-            .background(MuesliTheme.surfacePrimary)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-            )
+            .frame(height: 30)
+            .contentShape(Rectangle())
         }
         .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
         .fixedSize()
     }
 
@@ -783,17 +873,14 @@ struct MeetingDetailView: View {
 
     /// The resume control only makes sense on a finished meeting when no other
     /// recording/editing workflow is active.
-    @ViewBuilder
-    private func resumeChooserIfAvailable(for meeting: MeetingRecord) -> some View {
-        if controller.canResumeFinishedMeeting(meeting),
-           !appState.isMeetingRecording,
-           !appState.isMeetingStarting,
-           !isEditingNotes,
-           !isEditingTranscript,
-           !isSummarizing,
-           !isRetranscribing {
-            resumeRecordingButton(for: meeting)
-        }
+    private func shouldShowResumeChooser(for meeting: MeetingRecord) -> Bool {
+        controller.canResumeFinishedMeeting(meeting)
+            && !appState.isMeetingRecording
+            && !appState.isMeetingStarting
+            && !isEditingNotes
+            && !isEditingTranscript
+            && !isSummarizing
+            && !isRetranscribing
     }
 
     @ViewBuilder
@@ -852,24 +939,21 @@ struct MeetingDetailView: View {
             }
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: "square.and.arrow.up")
-                    .font(.system(size: 10, weight: .semibold))
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 11, weight: .semibold))
                 Text("Export")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: 12, weight: .medium))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
             }
-            .foregroundStyle(MuesliTheme.textPrimary)
-            .padding(.horizontal, MuesliTheme.spacing12)
-            .padding(.vertical, 7)
-            .background(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .fill(MuesliTheme.accent.opacity(0.18))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(MuesliTheme.accent.opacity(0.35), lineWidth: 1)
-            )
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.horizontal, MuesliTheme.spacing8)
+            .frame(height: 30)
+            .contentShape(Rectangle())
         }
         .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
         .fixedSize()
         .disabled(isEditingNotes || isEditingTranscript)
     }
@@ -897,20 +981,14 @@ struct MeetingDetailView: View {
                     }
                 }
             } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 12, weight: .semibold))
-                }
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuesliTheme.textSecondary)
                 .frame(width: 30, height: 28)
-                .background(MuesliTheme.surfacePrimary)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                )
+                .contentShape(Rectangle())
             }
             .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
             .fixedSize()
             .help("More actions")
         }
@@ -947,6 +1025,29 @@ struct MeetingDetailView: View {
             )
         }
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func toolbarActionButton(
+        _ systemImage: String,
+        label: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.horizontal, MuesliTheme.spacing8)
+            .frame(height: 30)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private var deleteButton: some View {
@@ -1101,7 +1202,7 @@ struct MeetingDetailView: View {
         HStack(spacing: 5) {
             Image(systemName: iconName(for: snapshot))
                 .font(.system(size: 10))
-            Text(snapshot.name)
+            Text(templateChipLabel(for: snapshot))
                 .font(.system(size: 11, weight: .medium))
         }
         .foregroundStyle(MuesliTheme.accent)
@@ -1109,6 +1210,15 @@ struct MeetingDetailView: View {
         .padding(.vertical, 4)
         .background(MuesliTheme.accentSubtle)
         .clipShape(Capsule())
+    }
+
+    private func templateChipLabel(for snapshot: MeetingTemplateSnapshot) -> String {
+        switch snapshot.kind {
+        case .auto:
+            return "Auto summary"
+        case .builtin, .custom:
+            return snapshot.name
+        }
     }
 
     /// Breadcrumb strip shown when this meeting is part of a follow-up thread:
@@ -1184,7 +1294,7 @@ struct MeetingDetailView: View {
             showFolderPopover.toggle()
         } label: {
             HStack(spacing: 5) {
-                Image(systemName: hasFolder ? "folder.fill" : "folder.badge.plus")
+                Image(systemName: hasFolder ? "folder.fill" : "plus")
                     .font(.system(size: 10))
                 Text(currentFolder?.name ?? "Add to folder")
                     .font(.system(size: 11, weight: .medium))
@@ -1196,7 +1306,10 @@ struct MeetingDetailView: View {
             .clipShape(Capsule())
             .overlay(
                 Capsule()
-                    .strokeBorder(hasFolder ? Color.clear : MuesliTheme.surfaceBorder, lineWidth: 1)
+                    .strokeBorder(
+                        hasFolder ? Color.clear : MuesliTheme.textTertiary.opacity(0.55),
+                        style: StrokeStyle(lineWidth: 1, dash: hasFolder ? [] : [3, 2])
+                    )
             )
         }
         .buttonStyle(.plain)
@@ -1587,23 +1700,19 @@ struct MeetingDetailView: View {
         manualNotesSaveStatus = .saved
     }
 
-    private func formatMeta(_ meeting: MeetingRecord) -> String {
-        let time = MeetingBrowserLogic.formatStartTime(meeting.startTime)
-        let duration = formatDuration(meeting.durationSeconds)
-        return "\(time)  \u{2022}  \(duration)  \u{2022}  \(meeting.wordCount) words"
-    }
-
     private func formatDuration(_ seconds: Double) -> String {
         let rounded = Int(seconds.rounded())
         if rounded >= 3600 {
-            return "\(rounded / 3600)h \((rounded % 3600) / 60)m"
+            let hours = rounded / 3600
+            let minutes = (rounded % 3600) / 60
+            return minutes == 0 ? "\(hours) hr" : "\(hours) hr \(minutes) min"
         }
         if rounded >= 60 {
             let m = rounded / 60
             let s = rounded % 60
-            return s == 0 ? "\(m)m" : "\(m)m \(s)s"
+            return s == 0 ? "\(m) min" : "\(m) min \(s) sec"
         }
-        return "\(rounded)s"
+        return "\(rounded) sec"
     }
 }
 
@@ -1619,137 +1728,67 @@ private extension View {
     }
 }
 
-private struct MarqueeTitleTextField: View {
+private struct ExpandableMeetingTitleField: View {
     @Binding var text: String
     let onSubmit: () -> Void
     let onTextChange: () -> Void
 
-    @State private var isHovering = false
-    @State private var contentWidth: CGFloat = 0
-    @State private var containerWidth: CGFloat = 0
-    @State private var marqueeOffset: CGFloat = 0
-    @State private var marqueeRunID = UUID()
+    @State private var isEditing = false
     @FocusState private var isTitleFocused: Bool
 
     private let titleFont = Font.system(size: 30, weight: .bold)
 
     var body: some View {
-        ZStack(alignment: .leading) {
-            TextField("Meeting Title", text: $text)
-                .font(titleFont)
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .textFieldStyle(.plain)
-                .lineLimit(1)
-                .opacity(shouldShowMarquee ? 0 : 1)
-                .focused($isTitleFocused)
-                .onSubmit(onSubmit)
-                .onChange(of: text) { _, _ in
-                    onTextChange()
-                    restartMarqueeIfNeeded()
-                }
-                .onChange(of: isTitleFocused) { _, _ in
-                    restartMarqueeIfNeeded()
-                }
-
-            Text(text.isEmpty ? "Meeting Title" : text)
-                .font(titleFont)
-                .fontWeight(.bold)
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                .offset(x: marqueeOffset)
-                .opacity(shouldShowMarquee ? 1 : 0)
-                .allowsHitTesting(false)
-        }
-        .frame(maxWidth: .infinity, minHeight: 38, alignment: .leading)
-        .clipped()
-        .contentShape(Rectangle())
-        .background(
-            GeometryReader { proxy in
-                Color.clear.preference(key: TitleContainerWidthPreferenceKey.self, value: proxy.size.width)
-            }
-        )
-        .overlay(
-            Text(text.isEmpty ? "Meeting Title" : text)
-                .font(titleFont)
-                .fontWeight(.bold)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                .hidden()
-                .background(
-                    GeometryReader { proxy in
-                        Color.clear.preference(key: TitleContentWidthPreferenceKey.self, value: proxy.size.width)
+        Group {
+            if isEditing {
+                TextField("Meeting Title", text: $text, axis: .vertical)
+                    .font(titleFont)
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .textFieldStyle(.plain)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .focused($isTitleFocused)
+                    .onSubmit {
+                        finishEditing()
                     }
-                )
-                .allowsHitTesting(false)
-        )
-        .onTapGesture {
-            isTitleFocused = true
-        }
-        .onPreferenceChange(TitleContainerWidthPreferenceKey.self) { width in
-            guard abs(containerWidth - width) > 0.5 else { return }
-            containerWidth = width
-            restartMarqueeIfNeeded()
-        }
-        .onPreferenceChange(TitleContentWidthPreferenceKey.self) { width in
-            guard abs(contentWidth - width) > 0.5 else { return }
-            contentWidth = width
-            restartMarqueeIfNeeded()
-        }
-        .onHover { hovering in
-            isHovering = hovering
-            restartMarqueeIfNeeded()
-        }
-    }
-
-    private var overflowDistance: CGFloat {
-        max(contentWidth - containerWidth, 0)
-    }
-
-    private var shouldShowMarquee: Bool {
-        containerWidth > 0 && isHovering && !isTitleFocused && overflowDistance > 24
-    }
-
-    private func restartMarqueeIfNeeded() {
-        guard shouldShowMarquee else {
-            if marqueeOffset != 0 {
-                let runID = UUID()
-                marqueeRunID = runID
-                withAnimation(.easeOut(duration: 0.18)) {
-                    marqueeOffset = 0
+                    .onChange(of: text) { _, _ in
+                        onTextChange()
+                    }
+                    .onChange(of: isTitleFocused) { _, focused in
+                        if !focused {
+                            finishEditing()
+                        }
+                    }
+                    .accessibilityLabel("Meeting title")
+            } else {
+                Button {
+                    isEditing = true
+                    DispatchQueue.main.async {
+                        isTitleFocused = true
+                    }
+                } label: {
+                    Text(text.isEmpty ? "Meeting Title" : text)
+                        .font(titleFont)
+                        .fontWeight(.bold)
+                        .foregroundStyle(text.isEmpty ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
                 }
-            }
-            return
-        }
-
-        let runID = UUID()
-        marqueeRunID = runID
-
-        marqueeOffset = 0
-        let distance = overflowDistance + 28
-        let duration = min(max(Double(distance) / 42.0, 3.0), 12.0)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-            guard marqueeRunID == runID, shouldShowMarquee else { return }
-            withAnimation(.linear(duration: duration).repeatForever(autoreverses: false)) {
-                marqueeOffset = -distance
+                .buttonStyle(.plain)
+                .help("Click to edit the full title")
             }
         }
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 38, alignment: .leading)
     }
-}
 
-private struct TitleContainerWidthPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-private struct TitleContentWidthPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
+    private func finishEditing() {
+        guard isEditing else { return }
+        isEditing = false
+        isTitleFocused = false
+        onSubmit()
     }
 }
 


### PR DESCRIPTION
## Problem

Long meeting titles could impose their intrinsic width on the meeting detail view. In constrained windows, this made the split layout wider than the available space, clipping the sidebar on the left and meeting actions on the right.

The single-line title was also cut off without indicating that more text was available.

## Fix

- Remove the title’s unbounded width contribution to the detail layout.
- Display long titles on up to two lines with trailing truncation.
- Open the full title in a multiline editor on click.
- Move meeting actions into a responsive toolbar.
- Fall back to stacked controls when the available width is limited.
- Keep metadata, template, folder controls, and the Notes/Transcript picker within the window bounds.

## Testing

- `bash scripts/run_ci_test_shard.sh meetings` — 337 tests across 21 suites passed
- `MUESLI_SKIP_SIGN=1 ./scripts/build_native_app.sh release`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787951047&installation_model_id=422865&pr_number=352&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F352&signature=9db4e4f584e0995fa508e1a1b314fa2812cd432b59d0e71ab29c3f11e574dbce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refined the meeting detail header, metadata, and toolbar layouts for clearer presentation across screen sizes.
  * Introduced an expandable meeting title editor for easier title updates.
  * Updated template, export, summary, and editing controls with a more consistent appearance.
  * Improved folder indicators and template labels, including clearer states when no folder is selected.
  * Made meeting duration displays more readable using hours, minutes, and seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->