### PR TITLE
Fix misleading Quick Note action in All Meetings

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -609,12 +609,12 @@ struct MeetingsView: View {
     private var browserHeaderActions: some View {
         HStack(spacing: MuesliTheme.spacing8) {
             Button {
-                controller.startQuickNoteMeeting()
+                controller.startForegroundMeetingRecording()
             } label: {
                 HStack(spacing: 6) {
-                    Image(systemName: "plus")
+                    Image(systemName: "record.circle")
                         .font(.system(size: 11, weight: .semibold))
-                    Text("Quick Note")
+                    Text("Record Meeting")
                         .font(.system(size: 12, weight: .semibold))
                         .lineLimit(1)
                 }
@@ -626,7 +626,7 @@ struct MeetingsView: View {
             }
             .buttonStyle(.plain)
             .disabled(appState.isMeetingRecording || appState.isMeetingStarting)
-            .help("Start a quick meeting note")
+            .help("Record a meeting with microphone and system audio")
             .fixedSize()
 
             Button {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4801,10 +4801,6 @@ final class MuesliController: NSObject {
         return true
     }
 
-    func startQuickNoteMeeting() {
-        startForegroundMeetingRecording(title: "Meeting")
-    }
-
     /// Whether a finished meeting can be resumed right now (used to gate the UI control too).
     func canResumeFinishedMeeting(_ meeting: MeetingRecord) -> Bool {
         MeetingResumePolicy.canResume(status: meeting.status)


### PR DESCRIPTION
## Problem

The primary action in All Meetings was labeled `Quick Note` even though it starts a full meeting recording with microphone and system audio. The label suggested a note-only workflow and obscured the action’s actual behavior.

## Fix

- Rename the primary action to `Record Meeting`.
- Use a recording icon instead of a generic plus icon.
- Route the action directly through the foreground meeting recording entry point.
- Remove the misleading `startQuickNoteMeeting` wrapper.

## Testing

- `bash scripts/run_ci_test_shard.sh meetings` — 337 tests across 21 suites passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787951713&installation_model_id=422865&pr_number=353&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F353&signature=f02eeb02f1851146ef3580832f97789160d05713bd2a33f6e452382c59c6ce10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Record Meeting” action to the browser header.
  - Meeting recording now captures microphone and system audio.
  - Updated the control’s label, icon, and help text to clearly describe recording functionality.

- **Changes**
  - Removed the previous “Quick Note” meeting action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->