### PR TITLE
Fix dashboard access after closing the main window

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -74,6 +74,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller?.handleICloudRemoteNotification(userInfo: userInfo)
     }
 
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows flag: Bool
+    ) -> Bool {
+        controller?.openHistoryWindow()
+        return true
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         if controller?.shouldTerminateApplication() == false {
             return .terminateCancel

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardWindowPresencePolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardWindowPresencePolicy.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+enum DashboardWindowPresencePolicy {
+    static func activationPolicy(
+        openWindowCount: Int,
+        closeBehavior: DashboardCloseBehavior
+    ) -> NSApplication.ActivationPolicy {
+        if openWindowCount > 0 || closeBehavior == .keepInDock {
+            return .regular
+        }
+        return .accessory
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1017,6 +1017,20 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
     }
 }
 
+enum DashboardCloseBehavior: String, Codable, CaseIterable, Sendable {
+    case menuBarOnly = "menu_bar_only"
+    case keepInDock = "keep_in_dock"
+
+    var label: String {
+        switch self {
+        case .menuBarOnly:
+            return "Menu bar only"
+        case .keepInDock:
+            return "Keep in Dock"
+        }
+    }
+}
+
 struct AppConfig: Codable {
     var dictationHotkey: HotkeyConfig = .default
     var computerUseHotkey: HotkeyConfig = .computerUseDefault
@@ -1056,6 +1070,7 @@ struct AppConfig: Codable {
     var meetingRecordingHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultMeetingThresholdMilliseconds
     var launchAtLogin: Bool = false
     var openDashboardOnLaunch: Bool = true
+    var dashboardCloseBehavior: DashboardCloseBehavior = .menuBarOnly
     var showFloatingIndicator: Bool = true
     var indicatorAnchor: IndicatorAnchor = .midTrailing
     var dashboardWindowFrame: WindowFrame? = nil
@@ -1176,6 +1191,7 @@ struct AppConfig: Codable {
         case meetingRecordingHotkeyTriggerThresholdMS = "meeting_recording_hotkey_trigger_threshold_ms"
         case launchAtLogin = "launch_at_login"
         case openDashboardOnLaunch = "open_dashboard_on_launch"
+        case dashboardCloseBehavior = "dashboard_close_behavior"
         case showFloatingIndicator = "show_floating_indicator"
         case indicatorAnchor = "indicator_anchor"
         case dashboardWindowFrame = "dashboard_window_frame"
@@ -1328,6 +1344,9 @@ struct AppConfig: Codable {
         )
         launchAtLogin = (try? c.decode(Bool.self, forKey: .launchAtLogin)) ?? defaults.launchAtLogin
         openDashboardOnLaunch = (try? c.decode(Bool.self, forKey: .openDashboardOnLaunch)) ?? defaults.openDashboardOnLaunch
+        dashboardCloseBehavior =
+            (try? c.decode(DashboardCloseBehavior.self, forKey: .dashboardCloseBehavior))
+            ?? defaults.dashboardCloseBehavior
         showFloatingIndicator = (try? c.decode(Bool.self, forKey: .showFloatingIndicator)) ?? defaults.showFloatingIndicator
         indicatorAnchor = (try? c.decode(IndicatorAnchor.self, forKey: .indicatorAnchor))
             ?? ((try? c.decodeIfPresent(CGPointCodable.self, forKey: .indicatorOrigin)) != nil ? .custom : .midTrailing)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -618,6 +618,7 @@ final class MuesliController: NSObject {
         statusBarController = StatusBarController(controller: self, runtime: runtime)
         preferencesWindowController = PreferencesWindowController(controller: self)
         historyWindowController = RecentHistoryWindowController(store: dictationStore, controller: self)
+        applyDashboardWindowPresencePolicy()
         let latestFeatureTour = FeatureTourCatalog.latest(
             includeCloudCleanup: chatGPTAuth.isAuthenticated
         )
@@ -1311,6 +1312,7 @@ final class MuesliController: NSObject {
         appState.selectedPostProcessorBackend = selectedPostProcessorBackend
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
+        applyDashboardWindowPresencePolicy()
         syncCalendarMonitor()
         syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
@@ -6472,16 +6474,23 @@ final class MuesliController: NSObject {
 
     func noteWindowOpened() {
         openWindowCount += 1
-        if NSApplication.shared.activationPolicy() != .regular {
-            NSApplication.shared.setActivationPolicy(.regular)
-        }
+        applyDashboardWindowPresencePolicy()
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     func noteWindowClosed() {
         openWindowCount = max(0, openWindowCount - 1)
-        if openWindowCount == 0 {
-            NSApplication.shared.setActivationPolicy(.accessory)
+        applyDashboardWindowPresencePolicy()
+    }
+
+    private func applyDashboardWindowPresencePolicy() {
+        let application = NSApplication.shared
+        let desiredPolicy = DashboardWindowPresencePolicy.activationPolicy(
+            openWindowCount: openWindowCount,
+            closeBehavior: config.dashboardCloseBehavior
+        )
+        if application.activationPolicy() != desiredPolicy {
+            application.setActivationPolicy(desiredPolicy)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -518,6 +518,21 @@ struct SettingsView: View {
                         controller.updateConfig { $0.openDashboardOnLaunch = newValue }
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow(
+                    "After closing the dashboard",
+                    description: "Muesli keeps running in both modes. Use Quit Muesli to exit."
+                ) {
+                    settingsMenu(
+                        selection: appState.config.dashboardCloseBehavior.label,
+                        options: DashboardCloseBehavior.allCases.map(\.label)
+                    ) { selection in
+                        guard let behavior = DashboardCloseBehavior.allCases.first(where: {
+                            $0.label == selection
+                        }) else { return }
+                        controller.updateConfig { $0.dashboardCloseBehavior = behavior }
+                    }
+                }
             }
 
             permissionsSection

--- a/native/MuesliNative/Tests/MuesliTests/DashboardWindowPresencePolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DashboardWindowPresencePolicyTests.swift
@@ -1,0 +1,63 @@
+import AppKit
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Dashboard window presence")
+struct DashboardWindowPresencePolicyTests {
+    @Test("Existing configurations keep the current menu-bar-only behavior")
+    func missingCloseBehaviorUsesMenuBarOnly() throws {
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+
+        #expect(config.dashboardCloseBehavior == .menuBarOnly)
+    }
+
+    @Test("Dock behavior round-trips through configuration JSON")
+    func dockBehaviorRoundTrip() throws {
+        var config = AppConfig()
+        config.dashboardCloseBehavior = .keepInDock
+
+        let data = try JSONEncoder().encode(config)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(json?["dashboard_close_behavior"] as? String == "keep_in_dock")
+        #expect(decoded.dashboardCloseBehavior == .keepInDock)
+    }
+
+    @Test("Unknown close behavior falls back safely")
+    func unknownCloseBehaviorUsesMenuBarOnly() throws {
+        let data = Data(#"{"dashboard_close_behavior":"unknown"}"#.utf8)
+        let config = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(config.dashboardCloseBehavior == .menuBarOnly)
+    }
+
+    @Test("An open dashboard always uses a regular Dock application")
+    func openDashboardUsesRegularPolicy() {
+        for behavior in DashboardCloseBehavior.allCases {
+            #expect(
+                DashboardWindowPresencePolicy.activationPolicy(
+                    openWindowCount: 1,
+                    closeBehavior: behavior
+                ) == .regular
+            )
+        }
+    }
+
+    @Test("Closed dashboard follows the configured presence")
+    func closedDashboardUsesConfiguredPolicy() {
+        #expect(
+            DashboardWindowPresencePolicy.activationPolicy(
+                openWindowCount: 0,
+                closeBehavior: .menuBarOnly
+            ) == .accessory
+        )
+        #expect(
+            DashboardWindowPresencePolicy.activationPolicy(
+                openWindowCount: 0,
+                closeBehavior: .keepInDock
+            ) == .regular
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- fix a recoverability issue where Muesli can become inaccessible after its last window closes and the menu bar item is hidden
- add an **After closing the dashboard** setting with **Menu bar only** (the current default) and **Keep in Dock** options
- reopen the dashboard when the running app is activated again from the Dock, Spotlight, or Finder
- preserve backward compatibility for existing and unknown configuration values

## Testing

- `swift test --package-path native/MuesliNative --scratch-path <cache-path>`
- 1,454 tests passed
- local release build completed and passed deep signature verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose whether closing the dashboard leaves the app menu-bar-only or keeps it in the Dock.
  * Reopening the app now opens the dashboard history window.
  * Improved app visibility and activation behavior as dashboard windows open and close.

* **Bug Fixes**
  * Ensured app activation state remains consistent after configuration changes and window lifecycle events.

* **Tests**
  * Added coverage for close behavior settings, persistence, defaults, and activation policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->