### PR TITLE
Fix Whisper multilingual transcription defaulting to English

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -7,6 +7,14 @@ actor WhisperKitTranscriber {
     private var whisperKit: WhisperKit?
     private var loadedModel: String?
 
+    static var transcriptionDecodingOptions: DecodingOptions {
+        DecodingOptions(
+            task: .transcribe,
+            language: nil,
+            detectLanguage: true
+        )
+    }
+
     enum TranscriberError: Error, LocalizedError {
         case notLoaded
         case transcriptionFailed(String)
@@ -92,7 +100,10 @@ actor WhisperKitTranscriber {
         guard let whisperKit else { throw TranscriberError.notLoaded }
 
         let start = CFAbsoluteTimeGetCurrent()
-        let results = try await whisperKit.transcribe(audioPath: wavURL.path)
+        let results = try await whisperKit.transcribe(
+            audioPath: wavURL.path,
+            decodeOptions: Self.transcriptionDecodingOptions
+        )
         let elapsed = CFAbsoluteTimeGetCurrent() - start
 
         let text = results.map(\.text).joined(separator: " ")

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -6,6 +6,15 @@ import MuesliCore
 @Suite("WhisperKitTranscriber")
 struct WhisperKitTranscriberTests {
 
+    @Test("multilingual Whisper transcription detects the source language")
+    func multilingualTranscriptionOptions() {
+        let options = WhisperKitTranscriber.transcriptionDecodingOptions
+
+        #expect(options.task == .transcribe)
+        #expect(options.language == nil)
+        #expect(options.detectLanguage)
+    }
+
     @Test("whisper models use whisper backend")
     func whisperModelsBackend() {
         let whisperOptions = BackendOption.all.filter { $0.backend == "whisper" }


### PR DESCRIPTION
Fixes a bug where multilingual Whisper models could produce English output for non-English speech.

WhisperKit was called without explicit decoding options. Its defaults leave the language unset while language detection is disabled, causing the decoder prompt to fall back to English.

This change:
- keeps the decoding task explicitly set to transcription
- enables source-language detection for multilingual Whisper models
- adds a regression test for the decoding options

Tests:
- swift test --package-path native/MuesliNative --filter MuesliTests.WhisperKitTranscriberTests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription by explicitly enabling automatic language detection and multilingual transcription.
  * Applied consistent transcription settings for WhisperKit processing.

* **Tests**
  * Added coverage verifying transcription uses the correct task and language-detection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->