### PR TITLE
fix: Prevent detected meetings from timing out

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -17,7 +17,14 @@ enum MeetingRecordingStartOrigin: Equatable {
     }
 
     var signalLossResponse: MeetingSignalLossResponse {
-        enablesMeetingAutoStop ? .autoStopAfterWarning : .none
+        switch self {
+        case .manual:
+            return .none
+        case .detectedPrompt:
+            return .warnOnly
+        case .calendarAutoRecord, .scheduledMeetingPrompt, .joinAndRecord:
+            return .autoStopAfterWarning
+        }
     }
 
     func signalLossSource(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -157,12 +157,29 @@ struct MeetingAutoStopPolicyTests {
         ) == nil)
     }
 
-    @Test("source-backed start origins can auto-stop after warning")
-    func sourceBackedStartOriginsCanAutoStopAfterWarning() {
+    @Test("detected prompt tracks source and only warns on signal loss")
+    func detectedPromptTracksSourceAndOnlyWarnsOnSignalLoss() {
+        let explicitSource = MeetingAutoStopSource(candidate: teamsCandidate())
+        let recentSource = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let origin = MeetingRecordingStartOrigin.detectedPrompt
+
+        #expect(origin.enablesMeetingAutoStop)
+        #expect(origin.signalLossResponse == .warnOnly)
+        #expect(origin.signalLossSource(
+            explicitSource: explicitSource,
+            recentSource: recentSource
+        ) == explicitSource)
+        #expect(origin.signalLossSource(
+            explicitSource: nil,
+            recentSource: recentSource
+        ) == recentSource)
+    }
+
+    @Test("remaining source-backed start origins can auto-stop after warning")
+    func remainingSourceBackedStartOriginsCanAutoStopAfterWarning() {
         let explicitSource = MeetingAutoStopSource(candidate: googleMeetCandidate())
         let recentSource = MeetingAutoStopSource(candidate: teamsCandidate())
         let origins: [MeetingRecordingStartOrigin] = [
-            .detectedPrompt,
             .calendarAutoRecord,
             .scheduledMeetingPrompt,
             .joinAndRecord,

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -76,8 +76,14 @@ struct MeetingAutoStopPolicyTests {
         let explicit = MeetingAutoStopSource(candidate: candidate())
         let recent = MeetingAutoStopSource(candidate: candidate(id: "recent", url: nil))
         let enabled = origin != .manual
+        // A detected meeting is a guess, so losing its signal only warns; the
+        // origins the user actually asked for still auto-stop (#303).
+        let expectedSignalLoss: MeetingSignalLossResponse =
+            origin == .manual
+                ? .none
+                : (origin == .detectedPrompt ? .warnOnly : .autoStopAfterWarning)
         #expect(origin.enablesMeetingAutoStop == enabled)
-        #expect(origin.signalLossResponse == (enabled ? .autoStopAfterWarning : .none))
+        #expect(origin.signalLossResponse == expectedSignalLoss)
         #expect(origin.signalLossSource(explicitSource: explicit, recentSource: recent) == (enabled ? explicit : nil))
         #expect(origin.signalLossSource(explicitSource: nil, recentSource: recent) == (enabled ? recent : nil))
     }


### PR DESCRIPTION
## Summary

Change the start-origin policy so `.detectedPrompt` continues tracking its meeting source but resolves signal loss to the existing `.warnOnly` response instead of `.autoStopAfterWarning`. This reuses the shipped controller path that presents a "Meeting signal lost" notification with an explicit Stop Recording action, dismisses it when the source recovers, and only performs timeout/fallback stops for `.autoStopAfterWarning`. Preserve automatic stopping for calendar auto-record, scheduled-meeting prompt, and join-and-record origins, whose lifecycle semantics are outside this issue.

Recordings started from the "Meeting detected" notification are tied to the detected meeting signal, unlike manually started recordings. When Teams briefly loses its microphone/camera signal during silence or a transient USB device reconfiguration, that source disappears long enough for Muesli to warn and then automatically stop the still-active recording. The session is finalized and summarized even though the call continues, and later activity is presented as a new meeting. The desired behavior is to keep recording until the user explicitly stops this notification-started session while still surfacing a signal-loss warning.

Fixes #303

## Validation

Starting from a detected Teams candidate retains source tracking but maps signal loss to `.warnOnly`, so a transient disappearance cannot trigger timeout-based finalization.
Calendar auto-record, scheduled-meeting prompt, and join-and-record origins continue to map signal loss to `.autoStopAfterWarning` and keep both explicit-source and recent-source fallback behavior.
Manual meeting starts remain untracked with a `.none` signal-loss response, preserving their existing user-controlled lifecycle.
A recovered detected source remains eligible for the existing prompt-recovery behavior without splitting or finalizing the active meeting session.

## Contribution certification

- [ ] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [ ] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [ ] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

Not applicable to this change.

### AI assistance

Not applicable to this change.

AI was used for assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788254320&installation_model_id=422865&pr_number=368&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F368&signature=6272f1bec9d6469aa58758fd9de62de9f19c50901df71b0ba0418f358d2ea071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting auto-stop behavior when a recording loses its signal.
  * Manually started meetings no longer trigger an automatic stop.
  * Detected prompts now show a warning without immediately stopping.
  * Calendar, scheduled, and join-and-record meetings continue to stop automatically after a warning.

* **Tests**
  * Added coverage to verify signal-loss behavior for detected prompts and other meeting start types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->