### PR TITLE
Fix media never resuming after dictation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -537,8 +537,12 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     private func restoreSessionAudioState(completion: (() -> Void)? = nil) {
-        duckingController.restoreDictationDucking { [self] in
-            self.mediaPlaybackController.restoreDictationMediaPause()
+        // Resuming the user's media is independent of ducking cleanup and must
+        // not queue behind it. Nesting it inside the ducking completion delayed
+        // the resume by however long ducking restore took — including when
+        // ducking was disabled for the session and had nothing to undo.
+        mediaPlaybackController.restoreDictationMediaPause()
+        duckingController.restoreDictationDucking {
             completion?()
         }
         routingController.refreshRouteAfterDictationSession()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -7,12 +7,30 @@ protocol MediaPlaybackManaging: AnyObject {
     func restoreDictationMediaPause()
 }
 
+/// What we are trying to achieve, not how it is delivered. The only transport
+/// that works across every player is the hardware play/pause key, which is a
+/// *toggle*; the intent is what decides whether that toggle should be sent at
+/// all, and what state we then verify against.
+enum MediaPlaybackCommand: String, Equatable, CustomStringConvertible {
+    case pause
+    case play
+
+    var description: String { rawValue }
+
+    var targetState: MediaPlaybackState {
+        switch self {
+        case .pause: return .notPlaying
+        case .play: return .playing
+        }
+    }
+}
+
 /// Actual playback state of the system now-playing application, as opposed to
 /// `AudioOutputActivityStatus`, which only reflects whether an app's audio
 /// output pipeline is running. Browsers and most video players keep their
 /// audio engine/IO alive while a video is *paused*, so `IsRunningOutput` (and
 /// therefore `AudioOutputActivityStatus`) reports "active" for paused media
-/// and cannot be used to decide whether to send a play/pause toggle.
+/// and cannot be used to decide whether to send a media command.
 enum MediaPlaybackState: Equatable, CustomStringConvertible {
     case playing
     case notPlaying
@@ -31,51 +49,81 @@ protocol MediaPlaybackClient {
     /// Whether the current now-playing application is actually producing audio.
     /// `.unknown` is returned when the signal cannot be obtained.
     func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void)
-    func sendMediaPlayPauseToggle()
+
+    /// Sends one hardware-equivalent play/pause toggle. `intent` is diagnostic
+    /// only — the delivered event is identical in both directions, which is why
+    /// callers must confirm the resulting state rather than assume it.
+    func sendPlayPauseToggle(intent: MediaPlaybackCommand)
 }
 
+/// Pauses whatever is playing for the duration of a dictation and puts it back
+/// afterwards.
+///
+/// Every transition is *verified*: query the now-playing state, send a toggle
+/// only if the state disagrees with the goal, then poll until the system
+/// confirms the new state, retrying the toggle once if it was dropped. Media
+/// commands on macOS report success far more readily than they take effect, so
+/// an unverified send is indistinguishable from a no-op. See
+/// `SystemMediaPlaybackClient` for why the toggle is the only usable transport.
 final class MediaPlaybackController: MediaPlaybackManaging {
+    struct VerificationPolicy {
+        /// Total toggles per transition, including the first.
+        var maxToggleAttempts: Int
+        /// State polls per toggle before that toggle is considered lost.
+        var pollsPerAttempt: Int
+        var pollInterval: DispatchTimeInterval
+
+        static let `default` = VerificationPolicy(
+            maxToggleAttempts: 2,
+            pollsPerAttempt: 12,
+            pollInterval: .milliseconds(80)
+        )
+    }
+
     private enum PauseState: Equatable {
         case idle
+        /// Query in flight; we have not yet touched playback.
         case checkingBegin(Int)
-        case paused
-        case checkingRestore(Int)
+        /// We sent a pause for this session and owe a resume.
+        case paused(Int)
     }
 
     private let client: MediaPlaybackClient
     private let queue: DispatchQueue
+    private let policy: VerificationPolicy
     private var pauseState: PauseState = .idle
     private var generation = 0
+    private var inFlight = 0
 
     init(
         client: MediaPlaybackClient = SystemMediaPlaybackClient(),
-        queue: DispatchQueue = DispatchQueue(label: "com.muesli.media-playback")
+        queue: DispatchQueue = DispatchQueue(label: "com.muesli.media-playback"),
+        policy: VerificationPolicy = .default
     ) {
         self.client = client
         self.queue = queue
+        self.policy = policy
     }
 
     func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind) {
         queue.async { [self] in
             guard enabled else { return }
             guard routeKind == .speakerLike else { return }
+
             switch pauseState {
-            case .idle:
-                generation += 1
-                let token = generation
-                pauseState = .checkingBegin(token)
-                client.nowPlayingPlaybackState { [weak self] playbackState in
-                    self?.queue.async {
-                        self?.handleBeginPlaybackState(playbackState, token: token)
-                    }
-                }
-            case .checkingRestore:
-                // A new dictation began before the previous restore query
-                // completed. Keep the media paused and let this new session own
-                // the eventual restore instead of briefly resuming playback.
-                pauseState = .paused
-            case .checkingBegin, .paused:
+            case .checkingBegin:
+                // A query for this session is already in flight.
                 return
+            case .paused:
+                // A previous session never got its restore — a cancelled or
+                // errored dictation, or a release we never saw. Without this,
+                // the controller would sit in `.paused` forever and silently
+                // stop pausing for every future dictation.
+                MediaPlaybackLogging.log("begin found stale paused state; re-arming")
+                pauseState = .idle
+                startBeginPlaybackCheck()
+            case .idle:
+                startBeginPlaybackCheck()
             }
         }
     }
@@ -83,63 +131,210 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     func restoreDictationMediaPause() {
         queue.async { [self] in
             switch pauseState {
-            case .checkingBegin:
+            case let .checkingBegin(token):
                 // The user released before we confirmed active playback. Cancel
                 // the pending pause so a late callback cannot start media.
+                guard token == generation else { return }
+                MediaPlaybackLogging.log("restore cancelled pending pause")
                 pauseState = .idle
-            case .paused:
                 generation += 1
-                let token = generation
-                pauseState = .checkingRestore(token)
-                client.nowPlayingPlaybackState { [weak self] playbackState in
-                    self?.queue.async {
-                        self?.handleRestorePlaybackState(playbackState, token: token)
-                    }
-                }
-            case .idle, .checkingRestore:
+            case let .paused(token):
+                guard token == generation else { return }
+                pauseState = .idle
+                ensure(.play, token: token)
+            case .idle:
                 return
             }
         }
     }
 
-    func waitForIdle() {
-        queue.sync {}
-        queue.sync {}
+    private func startBeginPlaybackCheck() {
+        generation += 1
+        let token = generation
+        pauseState = .checkingBegin(token)
+        beginOperation()
+        client.nowPlayingPlaybackState { [weak self] playbackState in
+            self?.queue.async {
+                self?.handleBeginPlaybackState(playbackState, token: token)
+                self?.endOperation()
+            }
+        }
     }
 
     private func handleBeginPlaybackState(_ playbackState: MediaPlaybackState, token: Int) {
-        guard pauseState == .checkingBegin(token) else { return }
-        // The media key is a blind global toggle: sending it to already-paused
-        // media would start playback. Only pause when we can positively confirm
-        // something is actually playing. Unknown is also a no-op.
+        guard pauseState == .checkingBegin(token), token == generation else { return }
+        // Only pause when we can positively confirm something is actually
+        // playing. Unknown is also a no-op so an unavailable state signal cannot
+        // toggle already-paused media into playing.
         guard playbackState == .playing else {
+            MediaPlaybackLogging.log("begin skipped state=\(playbackState)")
             pauseState = .idle
             return
         }
-        client.sendMediaPlayPauseToggle()
-        pauseState = .paused
+        pauseState = .paused(token)
+        ensure(.pause, token: token)
     }
 
-    private func handleRestorePlaybackState(_ playbackState: MediaPlaybackState, token: Int) {
-        guard pauseState == .checkingRestore(token) else { return }
-        pauseState = .idle
-        // We only paused media we confirmed was playing, so resume it unless
-        // something is actively playing again. Unknown still restores to avoid
-        // leaving media stranded after Muesli paused it.
-        guard playbackState != .playing else { return }
-        client.sendMediaPlayPauseToggle()
+    /// Drives playback to `command.targetState`, verifying and retrying.
+    private func ensure(_ command: MediaPlaybackCommand, token: Int) {
+        beginOperation()
+        attempt(command, token: token, attemptsRemaining: policy.maxToggleAttempts) { [weak self] settled in
+            guard let self else { return }
+            MediaPlaybackLogging.log("\(command) settled=\(settled)")
+            self.endOperation()
+        }
+    }
+
+    private func attempt(
+        _ command: MediaPlaybackCommand,
+        token: Int,
+        attemptsRemaining: Int,
+        completion: @escaping (Bool) -> Void
+    ) {
+        guard token == generation else {
+            completion(false)
+            return
+        }
+        client.nowPlayingPlaybackState { [weak self] state in
+            self?.queue.async {
+                guard let self, token == self.generation else {
+                    completion(false)
+                    return
+                }
+                if state == command.targetState {
+                    completion(true)
+                    return
+                }
+                // Never toggle on an unreadable state: a blind toggle would be
+                // as likely to start silent media as to stop playing media.
+                guard state != .unknown else {
+                    MediaPlaybackLogging.log("\(command) abandoned state=unknown")
+                    completion(false)
+                    return
+                }
+                guard attemptsRemaining > 0 else {
+                    completion(false)
+                    return
+                }
+                self.client.sendPlayPauseToggle(intent: command)
+                self.poll(
+                    command,
+                    token: token,
+                    attemptsRemaining: attemptsRemaining - 1,
+                    pollsRemaining: self.policy.pollsPerAttempt,
+                    completion: completion
+                )
+            }
+        }
+    }
+
+    private func poll(
+        _ command: MediaPlaybackCommand,
+        token: Int,
+        attemptsRemaining: Int,
+        pollsRemaining: Int,
+        completion: @escaping (Bool) -> Void
+    ) {
+        guard pollsRemaining > 0 else {
+            // The toggle never landed. Re-read and try once more.
+            MediaPlaybackLogging.log("\(command) toggle unconfirmed; retrying")
+            attempt(command, token: token, attemptsRemaining: attemptsRemaining, completion: completion)
+            return
+        }
+        queue.asyncAfter(deadline: .now() + policy.pollInterval) { [weak self] in
+            guard let self, token == self.generation else {
+                completion(false)
+                return
+            }
+            self.client.nowPlayingPlaybackState { state in
+                self.queue.async {
+                    guard token == self.generation else {
+                        completion(false)
+                        return
+                    }
+                    if state == command.targetState {
+                        completion(true)
+                        return
+                    }
+                    self.poll(
+                        command,
+                        token: token,
+                        attemptsRemaining: attemptsRemaining,
+                        pollsRemaining: pollsRemaining - 1,
+                        completion: completion
+                    )
+                }
+            }
+        }
+    }
+
+    private func beginOperation() {
+        inFlight += 1
+    }
+
+    private func endOperation() {
+        inFlight -= 1
+    }
+
+    /// Test hook: blocks until no verification work remains outstanding.
+    func waitForIdle(timeout: TimeInterval = 5) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            var busy = true
+            queue.sync { busy = inFlight > 0 }
+            if !busy { return }
+            usleep(1_000)
+        }
     }
 }
 
+/// Reads playback state through MediaRemote and changes it with the hardware
+/// play/pause key.
+///
+/// The asymmetry is deliberate and was measured on macOS 26.5.2:
+///
+/// - *Reading* now-playing state through MediaRemote works, but only from an
+///   Apple-signed host process. Called directly from this (third-party signed)
+///   app the C entry points return success and deliver nothing, so the query is
+///   shelled out through `osascript`.
+/// - *Writing* through MediaRemote is not usable at all.
+///   `MRNowPlayingController.localRouteController` accepts `pause` but silently
+///   ignores `play` and `togglePlayPause`, and `MRMediaRemoteSendCommand`
+///   returns `true` for every command while doing nothing. A media client that
+///   trusts those return values pauses fine and then never resumes.
+/// - The one transport every player honours — native and Electron alike — is
+///   the `NX_KEYTYPE_PLAY` HID event the physical F8 key produces. Electron
+///   apps such as Plexamp bind media keys via `globalShortcut` and register no
+///   MediaRemote command handlers at all, so this is the only path that reaches
+///   them.
+///
+/// That key is a toggle with no acknowledgement, which is why
+/// `MediaPlaybackController` verifies every transition rather than assuming it.
 final class SystemMediaPlaybackClient: MediaPlaybackClient {
+    private let jxa = MediaRemoteJXAClient()
     private let nowPlaying = NowPlayingMediaRemoteClient()
 
     func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void) {
-        nowPlaying.playbackState(completion: completion)
+        jxa.playbackState { [weak self] result in
+            switch result {
+            case let .available(state, appName):
+                MediaPlaybackLogging.log("query backend=jxa state=\(state) app=\(appName ?? "unknown")")
+                completion(state)
+            case let .unavailable(reason):
+                self?.nowPlaying.playbackState { state in
+                    MediaPlaybackLogging.log("query backend=media-remote state=\(state) fallback_reason=\(reason)")
+                    completion(state)
+                }
+            }
+        }
     }
 
-    func sendMediaPlayPauseToggle() {
-        postAuxKey(keyCode: 16)
+    /// `NX_KEYTYPE_PLAY` from IOKit's `ev_keymap.h`.
+    private static let nxKeyTypePlay = 16
+
+    func sendPlayPauseToggle(intent: MediaPlaybackCommand) {
+        MediaPlaybackLogging.log("toggle intent=\(intent) backend=hid-key")
+        postAuxKey(keyCode: Self.nxKeyTypePlay)
     }
 
     private func postAuxKey(keyCode: Int) {
@@ -164,11 +359,160 @@ final class SystemMediaPlaybackClient: MediaPlaybackClient {
     }
 }
 
-/// Reads the system now-playing playback state through the private MediaRemote
-/// framework, loaded lazily via `dlsym`. MediaRemote tracks the application
-/// that owns the current "now playing" info and exposes whether it is actually
-/// playing — the signal that `kAudioProcessPropertyIsRunningOutput` cannot
-/// provide (an app's audio engine stays running while media is paused).
+private enum MediaPlaybackLogging {
+    static func log(_ message: String) {
+        fputs("[media-playback] \(message)\n", stderr)
+    }
+}
+
+private enum MediaRemoteJXAPlaybackStateResult {
+    case available(MediaPlaybackState, appName: String?)
+    case unavailable(String)
+}
+
+/// Reads the now-playing state through the Objective-C MediaRemote classes
+/// hosted in `osascript`. The framework gates its clients on the host binary,
+/// so an Apple-signed interpreter can read state that this app cannot read
+/// in-process.
+private final class MediaRemoteJXAClient {
+    private struct PlaybackPayload: Decodable {
+        let available: Bool
+        let state: String?
+        let appName: String?
+        let reason: String?
+    }
+
+    private enum ExecutionResult {
+        case success(String)
+        case failure(String)
+    }
+
+    private let queue = DispatchQueue(label: "com.muesli.media-playback.jxa")
+    private let queryTimeout: DispatchTimeInterval = .milliseconds(750)
+
+    func playbackState(completion: @escaping (MediaRemoteJXAPlaybackStateResult) -> Void) {
+        run(script: Self.queryScript) { result in
+            switch result {
+            case let .failure(reason):
+                completion(.unavailable(reason))
+            case let .success(output):
+                guard let data = output.data(using: .utf8) else {
+                    completion(.unavailable("output_encoding"))
+                    return
+                }
+                do {
+                    let payload = try JSONDecoder().decode(PlaybackPayload.self, from: data)
+                    guard payload.available else {
+                        completion(.unavailable(payload.reason ?? "media-remote_unavailable"))
+                        return
+                    }
+                    let state: MediaPlaybackState
+                    switch payload.state {
+                    case "playing":
+                        state = .playing
+                    case "not-playing":
+                        state = .notPlaying
+                    default:
+                        state = .unknown
+                    }
+                    completion(.available(state, appName: payload.appName))
+                } catch {
+                    completion(.unavailable("invalid_output=\(error.localizedDescription)"))
+                }
+            }
+        }
+    }
+
+    private func run(
+        script: String,
+        arguments: [String] = [],
+        completion: @escaping (ExecutionResult) -> Void
+    ) {
+        queue.async { [self] in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = ["-l", "JavaScript", "-e", script, "--"] + arguments
+            let outputPipe = Pipe()
+            let errorPipe = Pipe()
+            process.standardOutput = outputPipe
+            process.standardError = errorPipe
+
+            let terminationSemaphore = DispatchSemaphore(value: 0)
+            var terminationStatus: Int32 = -1
+            process.terminationHandler = { terminatedProcess in
+                terminationStatus = terminatedProcess.terminationStatus
+                terminationSemaphore.signal()
+            }
+
+            do {
+                try process.run()
+            } catch {
+                completion(.failure("launch=\(error.localizedDescription)"))
+                return
+            }
+
+            if terminationSemaphore.wait(timeout: .now() + queryTimeout) == .timedOut {
+                if process.isRunning {
+                    process.terminate()
+                }
+                if terminationSemaphore.wait(timeout: .now() + .milliseconds(250)) == .timedOut,
+                   process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                    _ = terminationSemaphore.wait(timeout: .now() + .milliseconds(250))
+                }
+                completion(.failure("timeout"))
+                return
+            }
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard terminationStatus == 0 else {
+                let detail = errorOutput.isEmpty ? "exit=\(terminationStatus)" : errorOutput
+                completion(.failure(detail))
+                return
+            }
+            completion(.success(output))
+        }
+    }
+
+    private static let queryScript = """
+    ObjC.import('Foundation');
+
+    function run() {
+      const framework = $.NSBundle.bundleWithPath('/System/Library/PrivateFrameworks/MediaRemote.framework/');
+      if (!framework || !framework.load) return JSON.stringify({available: false, reason: 'framework'});
+      framework.load;
+      const request = $.NSClassFromString('MRNowPlayingRequest');
+      if (!request) return JSON.stringify({available: false, reason: 'request-class'});
+
+      const playerPath = request.localNowPlayingPlayerPath;
+      const item = request.localNowPlayingItem;
+      if (!playerPath || !item) return JSON.stringify({available: true, state: 'unknown', appName: null});
+
+      const info = item.nowPlayingInfo;
+      const rateObject = info && info.objectForKey
+        ? info.objectForKey('kMRMediaRemoteNowPlayingInfoPlaybackRate')
+        : null;
+      const rate = rateObject ? rateObject.js : null;
+      let appName = null;
+      try {
+        const client = playerPath.client;
+        if (client && client.displayName) appName = client.displayName.js;
+      } catch (_) {}
+
+      const state = typeof rate === 'number'
+        ? (rate > 0 ? 'playing' : 'not-playing')
+        : 'unknown';
+      return JSON.stringify({available: true, state: state, appName: appName});
+    }
+    """
+}
+
+/// In-process MediaRemote read, used only when the `osascript` route is
+/// unavailable. On macOS releases that gate MediaRemote on the host binary this
+/// returns `.unknown` rather than a wrong answer.
 ///
 /// MediaRemote replies asynchronously. Results are delivered through
 /// `DispatchQueue.main` because the XPC-backed callback path is more reliable

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -150,7 +150,14 @@ final class MediaPlaybackController: MediaPlaybackManaging {
             case let .paused(token):
                 guard token == generation else { return }
                 pauseState = .idle
-                ensure(.play, token: token)
+                // Retire the pause verification before starting the resume.
+                // Sharing a token would leave the pause verifier authorised to
+                // keep retrying its toggle while the resume runs; if its retry
+                // lands last, media ends up stopped after dictation, or the two
+                // oscillate. `owesResume` still carries the obligation, so
+                // cancelling the pause here cannot strand playback.
+                generation += 1
+                ensure(.play, token: generation)
             case .idle:
                 resumeIfOwed()
             }
@@ -345,11 +352,16 @@ final class SystemMediaPlaybackClient: MediaPlaybackClient {
     private let jxa = MediaRemoteJXAClient()
     private let nowPlaying = NowPlayingMediaRemoteClient()
 
+    /// Verification polls this repeatedly, so the success path is deliberately
+    /// silent — only the fallback, which indicates the preferred backend is
+    /// unavailable, is worth a line. The controller logs the decisions.
+    ///
+    /// The now-playing application is not recorded: it reveals what the user is
+    /// listening to, and the controller does not need it to make a decision.
     func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void) {
         jxa.playbackState { [weak self] result in
             switch result {
-            case let .available(state, appName):
-                MediaPlaybackLogging.log("query backend=jxa state=\(state) app=\(appName ?? "unknown")")
+            case let .available(state):
                 completion(state)
             case let .unavailable(reason):
                 self?.nowPlaying.playbackState { state in
@@ -397,7 +409,7 @@ private enum MediaPlaybackLogging {
 }
 
 private enum MediaRemoteJXAPlaybackStateResult {
-    case available(MediaPlaybackState, appName: String?)
+    case available(MediaPlaybackState)
     case unavailable(String)
 }
 
@@ -409,7 +421,6 @@ private final class MediaRemoteJXAClient {
     private struct PlaybackPayload: Decodable {
         let available: Bool
         let state: String?
-        let appName: String?
         let reason: String?
     }
 
@@ -446,7 +457,7 @@ private final class MediaRemoteJXAClient {
                     default:
                         state = .unknown
                     }
-                    completion(.available(state, appName: payload.appName))
+                    completion(.available(state))
                 } catch {
                     completion(.unavailable("invalid_output=\(error.localizedDescription)"))
                 }
@@ -520,23 +531,18 @@ private final class MediaRemoteJXAClient {
 
       const playerPath = request.localNowPlayingPlayerPath;
       const item = request.localNowPlayingItem;
-      if (!playerPath || !item) return JSON.stringify({available: true, state: 'unknown', appName: null});
+      if (!playerPath || !item) return JSON.stringify({available: true, state: 'unknown'});
 
       const info = item.nowPlayingInfo;
       const rateObject = info && info.objectForKey
         ? info.objectForKey('kMRMediaRemoteNowPlayingInfoPlaybackRate')
         : null;
       const rate = rateObject ? rateObject.js : null;
-      let appName = null;
-      try {
-        const client = playerPath.client;
-        if (client && client.displayName) appName = client.displayName.js;
-      } catch (_) {}
 
       const state = typeof rate === 'number'
         ? (rate > 0 ? 'playing' : 'not-playing')
         : 'unknown';
-      return JSON.stringify({available: true, state: state, appName: appName});
+      return JSON.stringify({available: true, state: state});
     }
     """
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -97,6 +97,9 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     /// We paused media and have not yet confirmed it resumed. Survives session
     /// boundaries so a cancelled resume is retried rather than dropped.
     private var owesResume = false
+    /// Token of the resume currently being verified, if any. Keeps duplicate
+    /// restores from starting a second verifier that would race the first.
+    private var activeResumeToken: Int?
 
     init(
         client: MediaPlaybackClient = SystemMediaPlaybackClient(),
@@ -175,6 +178,13 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     /// restore finishes the job.
     private func resumeIfOwed() {
         guard owesResume else { return }
+        // Several terminal paths restore — stop, cancel, external-session end,
+        // failure — and more than one can fire for the same dictation. A second
+        // verifier started here would share the current generation, so both
+        // would stay live, both could read paused media, and the later toggle
+        // would stop playback again. The resume already running will finish the
+        // job, and if it is cancelled the obligation outlives it.
+        guard activeResumeToken == nil else { return }
         MediaPlaybackLogging.log("restore honouring outstanding resume obligation")
         ensure(.play, token: generation)
     }
@@ -209,15 +219,26 @@ final class MediaPlaybackController: MediaPlaybackManaging {
 
     /// Drives playback to `command.targetState`, verifying and retrying.
     private func ensure(_ command: MediaPlaybackCommand, token: Int) {
+        if command == .play {
+            activeResumeToken = token
+        }
         beginOperation()
         attempt(command, token: token, attemptsRemaining: policy.maxToggleAttempts) { [weak self] settled in
             guard let self else { return }
             MediaPlaybackLogging.log("\(command) settled=\(settled)")
-            if command == .play, settled {
-                // Discharged only on confirmation. A resume that was abandoned
-                // or whose toggle was lost keeps the obligation, so the next
-                // restore retries it rather than stranding media paused.
-                self.owesResume = false
+            if command == .play {
+                // Compared by token so a superseded resume finishing late
+                // cannot clear the marker belonging to the one that replaced it.
+                if self.activeResumeToken == token {
+                    self.activeResumeToken = nil
+                }
+                if settled {
+                    // Discharged only on confirmation. A resume that was
+                    // abandoned or whose toggle was lost keeps the obligation,
+                    // so the next restore retries it rather than stranding
+                    // media paused.
+                    self.owesResume = false
+                }
             }
             self.endOperation()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -108,7 +108,12 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind) {
         queue.async { [self] in
             guard enabled else { return }
-            guard routeKind == .speakerLike else { return }
+            // Deliberately not gated on the output route. Ducking is route
+            // dependent because it exists to stop speaker bleed into the
+            // microphone, and there is no bleed on headphones. Pausing is not:
+            // a user who asks for media to pause while they dictate is talking
+            // over that media on headphones just the same.
+            _ = routeKind
 
             switch pauseState {
             case .checkingBegin:

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -180,11 +180,15 @@ final class MediaPlaybackController: MediaPlaybackManaging {
         guard owesResume else { return }
         // Several terminal paths restore — stop, cancel, external-session end,
         // failure — and more than one can fire for the same dictation. A second
-        // verifier started here would share the current generation, so both
-        // would stay live, both could read paused media, and the later toggle
-        // would stop playback again. The resume already running will finish the
-        // job, and if it is cancelled the obligation outlives it.
-        guard activeResumeToken == nil else { return }
+        // verifier for the *current* generation would race the first: both stay
+        // live, both read paused media, and the later toggle stops playback
+        // again. So defer to a resume that is still live.
+        //
+        // Only a live one, though. A resume from a superseded generation has
+        // already been abandoned and will never make progress, so blocking on
+        // it would strand the obligation: its callback clears the token without
+        // resuming, and nothing left would retry.
+        guard activeResumeToken != generation else { return }
         MediaPlaybackLogging.log("restore honouring outstanding resume obligation")
         ensure(.play, token: generation)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -94,6 +94,9 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     private var pauseState: PauseState = .idle
     private var generation = 0
     private var inFlight = 0
+    /// We paused media and have not yet confirmed it resumed. Survives session
+    /// boundaries so a cancelled resume is retried rather than dropped.
+    private var owesResume = false
 
     init(
         client: MediaPlaybackClient = SystemMediaPlaybackClient(),
@@ -143,14 +146,30 @@ final class MediaPlaybackController: MediaPlaybackManaging {
                 MediaPlaybackLogging.log("restore cancelled pending pause")
                 pauseState = .idle
                 generation += 1
+                resumeIfOwed()
             case let .paused(token):
                 guard token == generation else { return }
                 pauseState = .idle
                 ensure(.play, token: token)
             case .idle:
-                return
+                resumeIfOwed()
             }
         }
+    }
+
+    /// Resumes media this controller paused but has not yet confirmed resumed.
+    ///
+    /// A dictation that starts while a resume is still in flight bumps
+    /// `generation` and cancels that resume — possibly before its toggle was
+    /// ever sent, since the resume begins with a state query. Discarding the
+    /// obligation there would leave media paused indefinitely: the next
+    /// session's begin reads `notPlaying` and correctly declines to pause, so
+    /// nothing afterwards owns the resume. Carrying it forward means the next
+    /// restore finishes the job.
+    private func resumeIfOwed() {
+        guard owesResume else { return }
+        MediaPlaybackLogging.log("restore honouring outstanding resume obligation")
+        ensure(.play, token: generation)
     }
 
     private func startBeginPlaybackCheck() {
@@ -177,6 +196,7 @@ final class MediaPlaybackController: MediaPlaybackManaging {
             return
         }
         pauseState = .paused(token)
+        owesResume = true
         ensure(.pause, token: token)
     }
 
@@ -186,6 +206,12 @@ final class MediaPlaybackController: MediaPlaybackManaging {
         attempt(command, token: token, attemptsRemaining: policy.maxToggleAttempts) { [weak self] settled in
             guard let self else { return }
             MediaPlaybackLogging.log("\(command) settled=\(settled)")
+            if command == .play, settled {
+                // Discharged only on confirmation. A resume that was abandoned
+                // or whose toggle was lost keeps the obligation, so the next
+                // restore retries it rather than stranding media paused.
+                self.owesResume = false
+            }
             self.endOperation()
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -229,8 +229,8 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
-    @Test("media resume waits until ducking restore completes")
-    func mediaResumeWaitsUntilDuckingRestoreCompletes() {
+    @Test("media resume starts before ducking restore completes")
+    func mediaResumeStartsBeforeDuckingRestoreCompletes() {
         let harness = Harness(routeKind: .speakerLike)
         harness.ducking.completeRestoreImmediately = false
 
@@ -240,7 +240,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.ducking.restoreCalls == 1)
-        #expect(harness.media.restoreCalls == 0)
+        #expect(harness.media.restoreCalls == 1)
         #expect(harness.route.restoreCalls == 1)
         #expect(!harness.events.contains { event in
             if case .audioRestored = event {
@@ -610,6 +610,20 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.media.restoreCalls == 1)
+    }
+
+    @Test("media restore does not wait for ducking restore")
+    func mediaRestoreDoesNotWaitForDuckingRestore() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.ducking.completeRestoreImmediately = false
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false, mediaPauseEnabled: true)
+        harness.wait()
+        harness.manager.stop()
+        harness.wait()
+
+        #expect(harness.media.restoreCalls == 1)
+        #expect(harness.ducking.restoreCalls == 1)
     }
 
     @Test("cancel tears down warm recorder graph")

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -192,6 +192,37 @@ struct MediaPlaybackControllerTests {
         #expect(client.playbackState == .playing)
     }
 
+    @Test("a duplicate restore does not race the first resume")
+    func duplicateRestoreDoesNotRaceFirstResume() {
+        // stop, cancel, external-session end and the failure path all restore,
+        // and more than one can fire for the same dictation. A second verifier
+        // would share the generation, so both stay live, both read paused
+        // media, and the later toggle stops playback again.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.playbackState == .notPlaying)
+
+        // Stall the first resume so it is still in flight.
+        client.completesImmediately = false
+        controller.restoreDictationMediaPause()
+        #expect(waitUntil { client.pendingQueryCount == 1 })
+
+        // A second terminal path restores the same dictation.
+        controller.restoreDictationMediaPause()
+
+        client.completesImmediately = true
+        while client.pendingQueryCount > 0 {
+            client.completeNext(with: .notPlaying)
+        }
+        controller.waitForIdle()
+
+        #expect(client.toggles == [.pause, .play])
+        #expect(client.playbackState == .playing)
+    }
+
     @Test("release retires the pause verification instead of racing it")
     func releaseRetiresPauseVerification() {
         // If the release arrives while the pause is still being verified, the

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -13,15 +13,15 @@ struct MediaPlaybackControllerTests {
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 0)
+        #expect(client.toggles.isEmpty)
     }
 
     @Test("already-paused media is left alone throughout")
     func alreadyPausedMediaIsLeftAlone() {
-        // Paused video reports "not playing" via now-playing state, even though
-        // IsRunningOutput would (incorrectly) read active. The press must be a
-        // no-op so the blind play/pause key does not start the paused media,
-        // and the release must not toggle either.
+        // Regression guard for issue #225. A paused video still reports its
+        // audio pipeline as active, so the decision must come from now-playing
+        // state. Neither the press nor the release may toggle, or the paused
+        // media starts playing.
         let client = FakeMediaPlaybackClient(playbackState: .notPlaying)
         let controller = makeController(client: client)
 
@@ -30,13 +30,14 @@ struct MediaPlaybackControllerTests {
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 0)
+        #expect(client.toggles.isEmpty)
+        #expect(client.playbackState == .notPlaying)
     }
 
-    @Test("unknown playback state is a no-op on press")
-    func unknownPlaybackStateIsNoOpOnPress() {
-        // If we cannot positively confirm audio is playing, do not risk
-        // un-pausing already-paused media.
+    @Test("unknown playback state never toggles")
+    func unknownPlaybackStateNeverToggles() {
+        // A toggle is as likely to start silent media as to stop playing media,
+        // so an unreadable state must not be guessed at.
         let client = FakeMediaPlaybackClient(playbackState: .unknown)
         let controller = makeController(client: client)
 
@@ -45,150 +46,163 @@ struct MediaPlaybackControllerTests {
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 0)
+        #expect(client.toggles.isEmpty)
     }
 
-    @Test("headphone output is skipped")
-    func headphoneOutputIsSkipped() {
-        let client = FakeMediaPlaybackClient(playbackState: .playing)
-        let controller = makeController(client: client)
-
-        controller.beginDictationMediaPause(enabled: true, routeKind: .headphoneLike)
-        controller.waitForIdle()
-
-        #expect(client.toggleCalls == 0)
-    }
-
-    @Test("playing media pauses and restores")
-    func playingMediaPausesAndRestores() {
+    @Test("playing media pauses and resumes")
+    func playingMediaPausesAndResumes() {
         let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
         controller.waitForIdle()
-        #expect(client.toggleCalls == 1)
+        #expect(client.toggles == [.pause])
+        #expect(client.playbackState == .notPlaying)
 
-        // After pausing, now-playing reports not playing; the resume toggle fires.
-        client.playbackState = .notPlaying
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 2)
+        #expect(client.toggles == [.pause, .play])
+        #expect(client.playbackState == .playing)
+    }
+
+    @Test("a dropped toggle is retried until the state confirms")
+    func droppedToggleIsRetried() {
+        // The HID play/pause key is fire-and-forget: there is no delivery
+        // acknowledgement, and a lost event is otherwise invisible.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        client.togglesToDrop = 1
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+
+        #expect(client.toggles == [.pause, .pause])
+        #expect(client.playbackState == .notPlaying)
+    }
+
+    @Test("a toggle dropped on resume is retried")
+    func droppedResumeToggleIsRetried() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.playbackState == .notPlaying)
+
+        client.togglesToDrop = 1
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggles == [.pause, .play, .play])
+        #expect(client.playbackState == .playing)
+    }
+
+    @Test("resume is not sent when the user already resumed playback")
+    func resumeIsSkippedWhenUserAlreadyResumed() {
+        // Verify-before-toggle means a manual resume during dictation does not
+        // get toggled back off on release.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.toggles == [.pause])
+
+        client.playbackState = .playing
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggles == [.pause])
+        #expect(client.playbackState == .playing)
+    }
+
+    @Test("repeated pause and resume cycles remain reusable")
+    func repeatedCyclesRemainReusable() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        for _ in 0 ..< 4 {
+            controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+            controller.waitForIdle()
+            #expect(client.playbackState == .notPlaying)
+
+            controller.restoreDictationMediaPause()
+            controller.waitForIdle()
+            #expect(client.playbackState == .playing)
+        }
+
+        #expect(client.toggles == [.pause, .play, .pause, .play, .pause, .play, .pause, .play])
+    }
+
+    @Test("a missed restore self-heals on the next dictation")
+    func missedRestoreSelfHeals() {
+        // If a dictation ends without a restore — cancelled, errored, or a
+        // release we never saw — the controller must not stay latched in its
+        // paused state and silently stop pausing forever after.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.toggles == [.pause])
+
+        // No restore. The user resumes playback by hand.
+        client.playbackState = .playing
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+
+        #expect(client.toggles == [.pause, .pause])
+        #expect(client.playbackState == .notPlaying)
     }
 
     @Test("begin does not block while playback state is pending")
-    func beginDoesNotBlockWhilePlaybackStateIsPending() {
+    func beginDoesNotBlockWhilePlaybackStatePending() {
         let client = FakeMediaPlaybackClient(playbackState: .playing, completesImmediately: false)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
-        controller.waitForIdle()
 
-        #expect(client.pendingQueryCount == 1)
-        #expect(client.toggleCalls == 0)
+        // The call returns without waiting on the query, so the query is still
+        // outstanding and nothing has been toggled.
+        #expect(waitUntil { client.pendingQueryCount == 1 })
+        #expect(client.toggles.isEmpty)
 
+        // Let the verification pass resolve normally once the query answers.
+        client.completesImmediately = true
         client.completeNext(with: .playing)
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 1)
+        #expect(client.toggles == [.pause])
     }
 
-    @Test("restore does not block while playback state is pending")
-    func restoreDoesNotBlockWhilePlaybackStateIsPending() {
-        let client = FakeMediaPlaybackClient(playbackState: .playing)
-        let controller = makeController(client: client)
-
-        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
-        controller.waitForIdle()
-        #expect(client.toggleCalls == 1)
-
-        client.completesImmediately = false
-        controller.restoreDictationMediaPause()
-        controller.waitForIdle()
-
-        #expect(client.pendingQueryCount == 1)
-        #expect(client.toggleCalls == 1)
-
-        client.completeNext(with: .notPlaying)
-        controller.waitForIdle()
-
-        #expect(client.toggleCalls == 2)
-    }
-
-    @Test("restore does not toggle if user already resumed playback")
-    func restoreDoesNotToggleResumedPlayback() {
-        let client = FakeMediaPlaybackClient(playbackState: .playing)
-        let controller = makeController(client: client)
-
-        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
-        controller.waitForIdle()
-        // The user resumed/started playback during the session; resuming again
-        // would instead pause it, so the restore must be skipped.
-        controller.restoreDictationMediaPause()
-        controller.waitForIdle()
-
-        #expect(client.toggleCalls == 1)
-    }
-
-    @Test("restore resumes when playback state is unknown")
-    func restoreResumesWhenPlaybackStateIsUnknown() {
-        let client = FakeMediaPlaybackClient(playbackState: .playing)
-        let controller = makeController(client: client)
-
-        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
-        controller.waitForIdle()
-        client.playbackState = .unknown
-        controller.restoreDictationMediaPause()
-        controller.waitForIdle()
-
-        #expect(client.toggleCalls == 2)
-    }
-
-    @Test("release before playback query completes does not toggle")
-    func releaseBeforePlaybackQueryCompletesDoesNotToggle() {
+    @Test("release before the playback query completes sends no toggle")
+    func releaseBeforeQueryCompletesSendsNoToggle() {
         let client = FakeMediaPlaybackClient(playbackState: .playing, completesImmediately: false)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        #expect(waitUntil { client.pendingQueryCount == 1 })
         controller.restoreDictationMediaPause()
-        controller.waitForIdle()
 
         client.completeNext(with: .playing)
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 0)
+        #expect(client.toggles.isEmpty)
+        #expect(client.playbackState == .playing)
     }
 
-    @Test("new begin during restore keeps media paused for next session")
-    func newBeginDuringRestoreKeepsMediaPausedForNextSession() {
-        let client = FakeMediaPlaybackClient(playbackState: .playing)
-        let controller = makeController(client: client)
-
-        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
-        controller.waitForIdle()
-        #expect(client.toggleCalls == 1)
-
-        client.completesImmediately = false
-        controller.restoreDictationMediaPause()
-        controller.waitForIdle()
-        #expect(client.pendingQueryCount == 1)
-
-        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
-        controller.waitForIdle()
-
-        client.completeNext(with: .notPlaying)
-        controller.waitForIdle()
-
-        #expect(client.toggleCalls == 1)
-
-        controller.restoreDictationMediaPause()
-        controller.waitForIdle()
-        #expect(client.pendingQueryCount == 1)
-
-        client.completeNext(with: .notPlaying)
-        controller.waitForIdle()
-
-        #expect(client.toggleCalls == 2)
+    /// Polls `condition` until it holds or the timeout elapses. Used where the
+    /// assertion is about work still being outstanding, which `waitForIdle`
+    /// cannot express.
+    private func waitUntil(timeout: TimeInterval = 5, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            usleep(1_000)
+        }
+        return condition()
     }
 
     @Test("duplicate begin only pauses once")
@@ -200,46 +214,105 @@ struct MediaPlaybackControllerTests {
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
         controller.waitForIdle()
 
-        #expect(client.toggleCalls == 1)
+        #expect(client.toggles == [.pause])
+    }
+
+    @Test("headphone output is skipped")
+    func headphoneOutputIsSkipped() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .headphoneLike)
+        controller.waitForIdle()
+
+        #expect(client.toggles.isEmpty)
     }
 
     private func makeController(client: FakeMediaPlaybackClient) -> MediaPlaybackController {
         MediaPlaybackController(
             client: client,
-            queue: DispatchQueue(label: "test.media-playback")
+            queue: DispatchQueue(label: "test.media-playback"),
+            policy: MediaPlaybackController.VerificationPolicy(
+                maxToggleAttempts: 2,
+                pollsPerAttempt: 3,
+                pollInterval: .milliseconds(0)
+            )
         )
     }
 }
 
-private final class FakeMediaPlaybackClient: MediaPlaybackClient {
-    var playbackState: MediaPlaybackState
-    var completesImmediately: Bool
-    var toggleCalls = 0
+/// Models a real player: a toggle flips playback state, unless the event is
+/// dropped in flight.
+private final class FakeMediaPlaybackClient: MediaPlaybackClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedState: MediaPlaybackState
+    private var storedToggles: [MediaPlaybackCommand] = []
+    private var storedDrops = 0
+    private var storedCompletesImmediately: Bool
     private var pendingCompletions: [(MediaPlaybackState) -> Void] = []
 
     init(playbackState: MediaPlaybackState, completesImmediately: Bool = true) {
-        self.playbackState = playbackState
-        self.completesImmediately = completesImmediately
+        self.storedState = playbackState
+        self.storedCompletesImmediately = completesImmediately
+    }
+
+    var playbackState: MediaPlaybackState {
+        get { lock.withLock { storedState } }
+        set { lock.withLock { storedState = newValue } }
+    }
+
+    var toggles: [MediaPlaybackCommand] {
+        lock.withLock { storedToggles }
+    }
+
+    /// Number of subsequent toggles that will be recorded but not take effect.
+    var togglesToDrop: Int {
+        get { lock.withLock { storedDrops } }
+        set { lock.withLock { storedDrops = newValue } }
+    }
+
+    var completesImmediately: Bool {
+        get { lock.withLock { storedCompletesImmediately } }
+        set { lock.withLock { storedCompletesImmediately = newValue } }
     }
 
     var pendingQueryCount: Int {
-        pendingCompletions.count
+        lock.withLock { pendingCompletions.count }
     }
 
     func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void) {
-        guard completesImmediately else {
+        lock.lock()
+        guard storedCompletesImmediately else {
             pendingCompletions.append(completion)
+            lock.unlock()
             return
         }
-        completion(playbackState)
+        let state = storedState
+        lock.unlock()
+        // Called outside the lock: the controller reenters the client from its
+        // completion handler.
+        completion(state)
     }
 
-    func sendMediaPlayPauseToggle() {
-        toggleCalls += 1
+    func sendPlayPauseToggle(intent: MediaPlaybackCommand) {
+        lock.withLock {
+            storedToggles.append(intent)
+            guard storedDrops == 0 else {
+                storedDrops -= 1
+                return
+            }
+            switch storedState {
+            case .playing: storedState = .notPlaying
+            case .notPlaying: storedState = .playing
+            case .unknown: break
+            }
+        }
     }
 
     func completeNext(with playbackState: MediaPlaybackState) {
+        lock.lock()
         let completion = pendingCompletions.removeFirst()
+        lock.unlock()
         completion(playbackState)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -217,15 +217,21 @@ struct MediaPlaybackControllerTests {
         #expect(client.toggles == [.pause])
     }
 
-    @Test("headphone output is skipped")
-    func headphoneOutputIsSkipped() {
+    @Test("headphone output still pauses")
+    func headphoneOutputStillPauses() {
+        // Ducking is route dependent because it exists to stop speaker bleed
+        // into the microphone. Pausing is not: a user dictating over their own
+        // music wants it paused on headphones too.
         let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .headphoneLike)
         controller.waitForIdle()
+        #expect(client.toggles == [.pause])
 
-        #expect(client.toggles.isEmpty)
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+        #expect(client.toggles == [.pause, .play])
     }
 
     private func makeController(client: FakeMediaPlaybackClient) -> MediaPlaybackController {

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -192,6 +192,41 @@ struct MediaPlaybackControllerTests {
         #expect(client.playbackState == .playing)
     }
 
+    @Test("a superseded resume does not block the next restore")
+    func supersededResumeDoesNotBlockNextRestore() {
+        // A new dictation retires the in-flight resume, but its callback has
+        // not run yet, so the token still points at the abandoned generation.
+        // Blocking on that would strand the obligation: the stale callback
+        // clears the token without resuming, and nothing left would retry.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.playbackState == .notPlaying)
+
+        client.completesImmediately = false
+        controller.restoreDictationMediaPause()
+        #expect(waitUntil { client.pendingQueryCount == 1 })
+
+        // A new dictation supersedes that resume. Resolve only its own query,
+        // leaving the retired resume's callback still outstanding.
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        #expect(waitUntil { client.pendingQueryCount == 2 })
+        client.completeLast(with: .notPlaying)
+
+        // It ends before the stale callback has run.
+        controller.restoreDictationMediaPause()
+
+        client.completesImmediately = true
+        while client.pendingQueryCount > 0 {
+            client.completeNext(with: .notPlaying)
+        }
+        controller.waitForIdle()
+
+        #expect(client.playbackState == .playing)
+    }
+
     @Test("a duplicate restore does not race the first resume")
     func duplicateRestoreDoesNotRaceFirstResume() {
         // stop, cancel, external-session end and the failure path all restore,
@@ -422,6 +457,15 @@ private final class FakeMediaPlaybackClient: MediaPlaybackClient, @unchecked Sen
     func completeNext(with playbackState: MediaPlaybackState) {
         lock.lock()
         let completion = pendingCompletions.removeFirst()
+        lock.unlock()
+        completion(playbackState)
+    }
+
+    /// Completes the most recently queued query, leaving earlier ones pending.
+    /// Lets a test resolve a newer session while an older one is still stalled.
+    func completeLast(with playbackState: MediaPlaybackState) {
+        lock.lock()
+        let completion = pendingCompletions.removeLast()
         lock.unlock()
         completion(playbackState)
     }

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -157,6 +157,41 @@ struct MediaPlaybackControllerTests {
         #expect(client.playbackState == .notPlaying)
     }
 
+    @Test("a dictation starting during an in-flight resume does not strand media paused")
+    func dictationDuringInFlightResumeDoesNotStrandMedia() {
+        // The resume begins with a state query, so a dictation starting inside
+        // that window cancels it before any toggle is sent. The next begin then
+        // reads not-playing and correctly declines to pause — leaving nobody
+        // owning the resume unless the obligation is carried forward.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.playbackState == .notPlaying)
+
+        // Hold the resume's query open so its toggle is never sent.
+        client.completesImmediately = false
+        controller.restoreDictationMediaPause()
+        #expect(waitUntil { client.pendingQueryCount == 1 })
+
+        // A new dictation starts inside that window.
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        client.completesImmediately = true
+        while client.pendingQueryCount > 0 {
+            client.completeNext(with: .notPlaying)
+        }
+        controller.waitForIdle()
+
+        // Correctly declines to pause media that is already paused.
+        #expect(client.playbackState == .notPlaying)
+
+        // The outstanding resume must still be honoured on release.
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+        #expect(client.playbackState == .playing)
+    }
+
     @Test("begin does not block while playback state is pending")
     func beginDoesNotBlockWhilePlaybackStatePending() {
         let client = FakeMediaPlaybackClient(playbackState: .playing, completesImmediately: false)

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -192,6 +192,44 @@ struct MediaPlaybackControllerTests {
         #expect(client.playbackState == .playing)
     }
 
+    @Test("release retires the pause verification instead of racing it")
+    func releaseRetiresPauseVerification() {
+        // If the release arrives while the pause is still being verified, the
+        // pause verifier must not stay authorised to retry: its toggle would
+        // land after the resume and leave media stopped, or the two would
+        // oscillate.
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        client.togglesToDrop = 1
+        let controller = makeController(client: client)
+
+        client.completesImmediately = false
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        #expect(waitUntil { client.pendingQueryCount == 1 })
+
+        // Begin decides to pause, then `ensure` re-reads state before toggling.
+        client.completeNext(with: .playing)
+        #expect(waitUntil { client.pendingQueryCount == 1 })
+        client.completeNext(with: .playing)
+
+        // That toggle is lost, so the verifier wants to retry. Its polling
+        // queries stay stalled.
+        #expect(waitUntil { client.toggles == [.pause] })
+
+        // Release lands mid-verification.
+        controller.restoreDictationMediaPause()
+
+        client.completesImmediately = true
+        while client.pendingQueryCount > 0 {
+            client.completeNext(with: .playing)
+        }
+        controller.waitForIdle()
+
+        // The retired pause verifier must not have sent a retry, and media —
+        // never actually paused, since the toggle was lost — is left playing.
+        #expect(client.toggles == [.pause])
+        #expect(client.playbackState == .playing)
+    }
+
     @Test("begin does not block while playback state is pending")
     func beginDoesNotBlockWhilePlaybackStatePending() {
         let client = FakeMediaPlaybackClient(playbackState: .playing, completesImmediately: false)


### PR DESCRIPTION
## The bug

With `pause_media_during_dictation` enabled, media pauses when dictation starts and then never resumes. Once that has happened the feature degrades further: the user resumes playback by hand and subsequent dictations behave inconsistently, and in some cases stop pausing altogether until the app is restarted.

Reproduced on macOS 26.5.2 with Plexamp. The cause is not player-specific.

## Root cause: MediaRemote reports success for commands it does not apply

`SystemMediaPlaybackClient.sendMediaCommand` dispatched explicit `pause` / `play` commands through `MRNowPlayingController.localRouteController` and treated the call returning without error as proof the command took effect.

Measured directly against a genuinely playing Plexamp session on macOS 26.5.2, sending each command and then re-reading the now-playing playback rate:

| Command | Reported | Observed effect |
|---|---|---|
| `sendCommand(1)` — pause | success | paused |
| `sendCommand(0)` — play | success | none |
| `sendCommand(2)` — togglePlayPause | success | none |

So the pause path happened to work and the resume path silently did nothing. Because the JXA route reported success, the media-key fallback underneath it was never reached.

I also probed `MRMediaRemoteSendCommand` directly from a locally-signed helper binary in the same session: it returned `true` for `pause`, `play` and `togglePlayPause`, and none of the three changed playback state, while the `localRouteController` `pause` above worked in the same session. That is one player on one macOS version, so I would not state it more strongly than that — but it does mean a `true` return from either API is not evidence a command landed.

There is a second, independent reason explicit commands cannot be relied on here: Electron players — Plexamp among them — bind media keys through `globalShortcut` and register no MediaRemote command handlers at all, so no MediaRemote command reaches them regardless of how it is dispatched.

## The fix

Use the `NX_KEYTYPE_PLAY` HID event — the one the physical F8 key produces — as the sole command transport. Native and Electron players both honour it.

That event is a toggle with no acknowledgement, so it cannot be sent blindly; sending one at the wrong moment is exactly what #225 was about. Every transition is therefore verified:

1. Query the now-playing state.
2. If it already matches the goal, send nothing.
3. Otherwise send one toggle.
4. Poll until the system confirms the new state.
5. If it never confirms, the event was lost — send one more, then give up.

State is never guessed at. An `unknown` reading is treated as "do not touch", so an unreadable state signal can never start silent media.

Reading now-playing state through MediaRemote does still work, which is why the query is shelled out through `osascript`; the existing in-process `MRMediaRemoteGetNowPlayingApplicationIsPlaying` is retained as a fallback that returns `unknown` rather than a wrong answer.

## Also fixed: a latched pause that disabled the feature permanently

`beginDictationMediaPause` returned early whenever the controller was already in its `paused` state. If a dictation ever ended without a restore — cancelled, errored, or a hotkey release that never arrived — the controller stayed latched in `paused` and silently stopped pausing for every subsequent dictation until the app restarted.

Begin now treats a pre-existing `paused` state as stale, re-arms, and re-checks live playback state. This is what lets the feature recover on its own.

## Other changes

- Media restore no longer waits behind ducking restore. It was nested inside the ducking completion handler, which delayed resume even when ducking was disabled for the session and had nothing to undo.
- Restore no longer sends a command when the user resumed playback by hand during dictation — verify-before-toggle skips it rather than toggling playback back off.

## Second commit, separable

`Pause media during dictation on headphone routes too` is a behaviour change rather than part of the resume fix, so it is a separate commit and can be dropped without affecting the rest. `beginDictationMediaPause` returned early on any non-speaker route, so dictating on headphones produced no pause at all. That route check belongs to ducking, which exists to stop speaker bleed reaching the microphone; pausing serves a different purpose. Happy to drop it if you would rather keep the route gate.

## Resume obligations survive session boundaries

A resume starts with a state query, so a dictation beginning inside that window — about one query, ~70ms measured — cancels it before any toggle is sent. The next begin then reads `notPlaying`, correctly declines to pause, and nothing afterwards owns the resume, leaving media paused indefinitely. Same outcome if the resume toggle is sent but lost and the retry is then cancelled.

`owesResume` is therefore tracked separately from session state: set when we pause, cleared only when a play transition is *confirmed*. A restore honours an outstanding obligation even when the current session never paused anything.

Covered by `dictationDuringInFlightResumeDoesNotStrandMedia`, which holds the resume query open, starts a second session inside the window, and asserts media ends up playing. Verified to fail without the fix.

Credit to CodeRabbit for catching this on review; I had wrongly assumed the cancelled case still left media playing.

## Known limitation: media-key routing

macOS routes the play/pause key to one app, and that target is not always the app MediaRemote reports as now-playing. Measured here: with Plexamp running but its queue empty, Plexamp still held the key target and swallowed the event, so a toggle aimed at audio playing in Chrome did nothing — MediaRemote reported `Google Chrome` as now-playing throughout. Quitting Plexamp made the same toggle work immediately.

The controller degrades correctly rather than misbehaving: the toggle is retried, the state never confirms, `settled=false` is logged, and no spurious resume is issued afterwards because the restore path re-reads state and finds it already playing. Media simply keeps playing through the dictation.

Separately, QuickTime Player registers as now-playing but honours neither the HID key nor any MediaRemote command, so it cannot be paused by any remote mechanism. Also handled by the same degradation path.

Both are macOS/player behaviours rather than anything this code can route around, but they are worth knowing when reading `settled=false` in the logs.

## Testing

`MediaPlaybackControllerTests` rewritten against a fake client that models a real player: a toggle flips playback state, and toggles can be dropped to simulate lost HID events. 14 tests covering the retry path, the in-flight-resume path, the self-heal path, the already-paused no-op (#225 regression guard), the unknown-state no-op, and repeated pause/resume cycles.

- Full suite: 1484 tests across 145 suites pass.
- Verified in-app on macOS 26.5.2 across two players: five consecutive real dictation cycles against Plexamp (Electron), and five more against a Chrome media session (Blink), each confirming `pause settled=true` then `play settled=true` with playback sampled mid-hold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback restoration during dictation, allowing playback to resume without waiting for audio ducking restoration.
  * Prevented unnecessary play/pause commands when playback is already in the intended state.
  * Added verification and retry handling for missed playback commands.
  * Improved recovery from unavailable or delayed playback-state information.
* **Tests**
  * Expanded coverage for playback restoration timing, repeated dictation cycles, delayed responses, dropped commands, and headphone playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->