### PR TITLE
Fix dead Push to Talk after meetings-only onboarding

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -191,6 +191,7 @@ final class AppState {
     var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()
     var launchAtLoginRegistrationState: LaunchAtLoginRegistrationState = .disabled
+    var interactionPermissionSnapshot: InteractionPermissionSnapshot?
 
     // Live status
     var isMeetingRecording: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -176,7 +176,8 @@ struct DictationsView: View {
             return "Try another source, app, or time range"
         }
         let useCase = appState.config.resolvedOnboardingUseCase
-        if useCase.includesDictation {
+        if appState.config.enablePushToTalk
+            && (useCase.includesDictation || !useCase.includesVoiceNotes) {
             return "Hold \(appState.config.dictationHotkey.label) to start dictating"
         }
         if useCase.includesVoiceNotes {

--- a/native/MuesliNative/Sources/MuesliNativeApp/InteractionPermissionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InteractionPermissionMonitor.swift
@@ -38,6 +38,7 @@ actor InteractionPermissionMonitor {
     private var clientIDs = Set<UUID>()
     private var clientRevision = 0
     private var lastSnapshot: InteractionPermissionSnapshot?
+    private var captureGeneration = 0
     private var pollingGeneration = UUID()
     private var pollingTask: Task<Void, Never>?
 
@@ -93,10 +94,13 @@ actor InteractionPermissionMonitor {
     }
 
     private func captureAndPublishIfChanged() async {
+        captureGeneration += 1
+        let generation = captureGeneration
         let reader = readSnapshot
         let snapshot = await Task.detached(priority: .utility) {
             reader()
         }.value
+        guard generation == captureGeneration else { return }
         guard snapshot != lastSnapshot else { return }
         lastSnapshot = snapshot
         await onChange(snapshot)

--- a/native/MuesliNative/Sources/MuesliNativeApp/InteractionPermissionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InteractionPermissionMonitor.swift
@@ -1,0 +1,104 @@
+import AppKit
+import AVFoundation
+import Foundation
+
+struct InteractionPermissionSnapshot: Equatable, Sendable {
+    let microphone: Bool
+    let accessibility: Bool
+    let inputMonitoring: Bool
+    let screenRecording: Bool
+
+    var onboardingSnapshot: OnboardingPermissionSnapshot {
+        OnboardingPermissionSnapshot(
+            microphone: microphone,
+            accessibility: accessibility,
+            inputMonitoring: inputMonitoring,
+            systemAudio: false,
+            screenRecording: screenRecording
+        )
+    }
+
+    static func captureSystemSnapshot() -> Self {
+        Self(
+            microphone: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
+            accessibility: AXIsProcessTrusted(),
+            inputMonitoring: CGPreflightListenEventAccess(),
+            screenRecording: CGPreflightScreenCaptureAccess()
+        )
+    }
+}
+
+actor InteractionPermissionMonitor {
+    typealias SnapshotReader = @Sendable () -> InteractionPermissionSnapshot
+    typealias ChangeHandler = @MainActor @Sendable (InteractionPermissionSnapshot) -> Void
+
+    private let interval: Duration
+    private let readSnapshot: SnapshotReader
+    private let onChange: ChangeHandler
+    private var clientIDs = Set<UUID>()
+    private var clientRevision = 0
+    private var lastSnapshot: InteractionPermissionSnapshot?
+    private var pollingGeneration = UUID()
+    private var pollingTask: Task<Void, Never>?
+
+    init(
+        interval: Duration = .seconds(1),
+        readSnapshot: @escaping SnapshotReader = {
+            InteractionPermissionSnapshot.captureSystemSnapshot()
+        },
+        onChange: @escaping ChangeHandler
+    ) {
+        self.interval = interval
+        self.readSnapshot = readSnapshot
+        self.onChange = onChange
+    }
+
+    func updateClients(_ updatedClientIDs: Set<UUID>, revision: Int) {
+        guard revision > clientRevision else { return }
+        clientRevision = revision
+        clientIDs = updatedClientIDs
+
+        if clientIDs.isEmpty {
+            pollingGeneration = UUID()
+            pollingTask?.cancel()
+            pollingTask = nil
+        } else if pollingTask == nil {
+            let generation = UUID()
+            pollingGeneration = generation
+            pollingTask = Task { [weak self] in
+                await self?.poll(generation: generation)
+            }
+        }
+    }
+
+    func refresh() async {
+        await captureAndPublishIfChanged()
+    }
+
+    private func poll(generation: UUID) async {
+        while !Task.isCancelled,
+              generation == pollingGeneration,
+              !clientIDs.isEmpty {
+            await captureAndPublishIfChanged()
+            do {
+                try await Task.sleep(for: interval)
+            } catch {
+                break
+            }
+        }
+
+        if generation == pollingGeneration {
+            pollingTask = nil
+        }
+    }
+
+    private func captureAndPublishIfChanged() async {
+        let reader = readSnapshot
+        let snapshot = await Task.detached(priority: .utility) {
+            reader()
+        }.value
+        guard snapshot != lastSnapshot else { return }
+        lastSnapshot = snapshot
+        await onChange(snapshot)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1168,6 +1168,11 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
         self == .dictation
     }
 
+    /// Meetings-only installs can later opt into dictation without dropping meetings.
+    var enablingPushToTalk: OnboardingUseCase {
+        self == .meetings ? .dictationAndMeetings : self
+    }
+
     static func resolved(_ rawValue: String?) -> OnboardingUseCase {
         guard let rawValue, let useCase = OnboardingUseCase(rawValue: rawValue) else {
             return .dictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1489,6 +1489,12 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
         return .everything
     }
 
+    /// Meetings-only installs can later opt into dictation without dropping meetings.
+    var enablingPushToTalk: OnboardingUseCase {
+        guard !includesPushToTalk else { return self }
+        return Self.from(capabilities: capabilities.union([.dictation]))
+    }
+
     static func resolved(_ rawValue: String?) -> OnboardingUseCase {
         guard let rawValue, let useCase = OnboardingUseCase(rawValue: rawValue) else {
             return .dictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1489,12 +1489,6 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
         return .everything
     }
 
-    /// Meetings-only installs can later opt into dictation without dropping meetings.
-    var enablingPushToTalk: OnboardingUseCase {
-        guard !includesPushToTalk else { return self }
-        return Self.from(capabilities: capabilities.union([.dictation]))
-    }
-
     static func resolved(_ rawValue: String?) -> OnboardingUseCase {
         guard let rawValue, let useCase = OnboardingUseCase(rawValue: rawValue) else {
             return .dictation
@@ -1505,6 +1499,7 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
 
 struct AppConfig: Codable {
     var dictationHotkey: HotkeyConfig = .default
+    var enablePushToTalk: Bool = true
     var quilHotkey: HotkeyConfig = .quilDefault
     var enableQuilMode: Bool = false
     var computerUseHotkey: HotkeyConfig = .computerUseDefault
@@ -1643,6 +1638,7 @@ struct AppConfig: Codable {
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
+        case enablePushToTalk = "enable_push_to_talk"
         case quilHotkey = "quil_hotkey"
         case enableQuilMode = "enable_quil_mode"
         case computerUseHotkey = "computer_use_hotkey"
@@ -1781,6 +1777,7 @@ struct AppConfig: Codable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         let defaults = AppConfig()
         dictationHotkey = (try? c.decode(HotkeyConfig.self, forKey: .dictationHotkey)) ?? defaults.dictationHotkey
+        let decodedEnablePushToTalk = try? c.decode(Bool.self, forKey: .enablePushToTalk)
         quilHotkey = (try? c.decode(HotkeyConfig.self, forKey: .quilHotkey)) ?? defaults.quilHotkey
         enableQuilMode = (try? c.decode(Bool.self, forKey: .enableQuilMode)) ?? defaults.enableQuilMode
         computerUseHotkey = (try? c.decode(HotkeyConfig.self, forKey: .computerUseHotkey))
@@ -1912,6 +1909,10 @@ struct AppConfig: Codable {
         } else {
             onboardingUseCase = defaults.onboardingUseCase
         }
+        // Existing installs used the onboarding selection as runtime state. Preserve that
+        // behavior once, then persist future Push to Talk changes independently.
+        enablePushToTalk = decodedEnablePushToTalk
+            ?? OnboardingUseCase.resolved(onboardingUseCase).includesPushToTalk
         userName = (try? c.decode(String.self, forKey: .userName)) ?? defaults.userName
         customMeetingTemplates = (try? c.decode([CustomMeetingTemplate].self, forKey: .customMeetingTemplates)) ?? defaults.customMeetingTemplates
         customWords = (try? c.decode([CustomWord].self, forKey: .customWords)) ?? defaults.customWords

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -390,6 +390,7 @@ public final class MuesliController: NSObject {
     private var autoRecordedCalendarEventIDs = Set<String>()
     private var meetingFeatureMonitorsAllowed = false
     private var meetingDetectionMonitorStarted = false
+    private var pendingPushToTalkEnable = false
 
     private var searchTask: Task<Void, Never>?
     private var onboardingModelPreparationTask: Task<Void, Never>?
@@ -655,10 +656,12 @@ public final class MuesliController: NSObject {
         meetingFeatureMonitorsAllowed = canRunMainApp
 
         // Defer permission-triggering monitors until after onboarding
-        if canRunMainApp && config.resolvedOnboardingUseCase.includesPushToTalk {
-            hotkeyMonitor.configure(config.dictationHotkey)
-            hotkeyMonitor.start()
-            startComputerUseHotkeyMonitorIfNeeded()
+        if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            hasRequiredStartupPermissions: hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase),
+            useCase: config.resolvedOnboardingUseCase
+        ) {
+            startDictationHotkeyMonitorIfNeeded()
         }
         if canRunMainApp {
             startMeetingRecordingHotkeyMonitorIfNeeded()
@@ -3596,6 +3599,7 @@ public final class MuesliController: NSObject {
         updateConfig { $0.dictationHotkey = hotkey }
         hotkeyMonitor.configure(hotkey)
         configureComputerUseHotkeyMonitor()
+        enablePushToTalkIfNeeded(requestPermissions: true)
         return result
     }
 
@@ -4008,9 +4012,12 @@ public final class MuesliController: NSObject {
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {
             meetingFeatureMonitorsAllowed = true
-            if onboardingUseCase.includesPushToTalk {
-                hotkeyMonitor.start()
-                startComputerUseHotkeyMonitorIfNeeded()
+            if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+                hasCompletedOnboarding: true,
+                hasRequiredStartupPermissions: true,
+                useCase: onboardingUseCase
+            ) {
+                startDictationHotkeyMonitorIfNeeded()
             }
             syncCalendarMonitor()
             // Start monitors that were deferred during onboarding
@@ -4060,13 +4067,7 @@ public final class MuesliController: NSObject {
 
     private func hasRequiredStartupPermissions(for useCase: OnboardingUseCase) -> Bool {
         OnboardingPermissionGate.hasRequiredPermissions(
-            OnboardingPermissionSnapshot(
-                microphone: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
-                accessibility: AXIsProcessTrusted(),
-                inputMonitoring: CGPreflightListenEventAccess(),
-                systemAudio: false,
-                screenRecording: false
-            ),
+            currentOnboardingPermissionSnapshot(),
             for: useCase
         )
     }
@@ -4088,14 +4089,83 @@ public final class MuesliController: NSObject {
         ) else { return }
 
         updateConfig { $0.onboardingUseCase = OnboardingUseCase.dictation.rawValue }
-        hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
-        hotkeyMonitor.start()
-        startComputerUseHotkeyMonitorIfNeeded()
+        startDictationHotkeyMonitorIfNeeded()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
         TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
             "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
             "to_use_case": OnboardingUseCase.dictation.rawValue,
             "reason": "dictation_permissions_granted",
+        ])
+    }
+
+    enum PushToTalkEnableResult: Equatable {
+        case alreadyEnabled
+        case enabled
+        case needsPermissions
+    }
+
+    @discardableResult
+    func enablePushToTalkIfNeeded(requestPermissions: Bool = false) -> PushToTalkEnableResult {
+        let snapshot = currentOnboardingPermissionSnapshot()
+        let hasDictationPermissions = OnboardingPermissionGate.hasRequiredDictationPermissions(snapshot)
+        switch PushToTalkEnablementPolicy.outcome(
+            currentUseCase: config.resolvedOnboardingUseCase,
+            hasDictationPermissions: hasDictationPermissions
+        ) {
+        case .alreadyEnabled:
+            pendingPushToTalkEnable = false
+            startDictationHotkeyMonitorIfNeeded()
+            return .alreadyEnabled
+        case .promote(let useCase):
+            applyPushToTalkEnablement(useCase: useCase)
+            return .enabled
+        case .waitForPermissions:
+            pendingPushToTalkEnable = true
+            if requestPermissions {
+                requestMissingDictationPermissions(snapshot)
+            }
+            return .needsPermissions
+        }
+    }
+
+    func completePendingPushToTalkEnableIfReady() {
+        guard pendingPushToTalkEnable else { return }
+        enablePushToTalkIfNeeded(requestPermissions: false)
+    }
+
+    private func currentOnboardingPermissionSnapshot() -> OnboardingPermissionSnapshot {
+        OnboardingPermissionSnapshot(
+            microphone: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
+            accessibility: AXIsProcessTrusted(),
+            inputMonitoring: CGPreflightListenEventAccess(),
+            systemAudio: false,
+            screenRecording: false
+        )
+    }
+
+    private func requestMissingDictationPermissions(_ snapshot: OnboardingPermissionSnapshot) {
+        if !snapshot.microphone {
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        }
+        if !snapshot.accessibility {
+            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+            AXIsProcessTrustedWithOptions(options)
+        }
+        if !snapshot.inputMonitoring {
+            _ = CGRequestListenEventAccess()
+        }
+    }
+
+    private func applyPushToTalkEnablement(useCase: OnboardingUseCase) {
+        let fromUseCase = config.resolvedOnboardingUseCase
+        pendingPushToTalkEnable = false
+        updateConfig { $0.onboardingUseCase = useCase.rawValue }
+        startDictationHotkeyMonitorIfNeeded()
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
+        TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
+            "from_use_case": fromUseCase.rawValue,
+            "to_use_case": useCase.rawValue,
+            "reason": "push_to_talk_enabled",
         ])
     }
 
@@ -7315,6 +7385,13 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.configureTriggerThreshold(milliseconds: config.hotkeyTriggerThresholdMS)
         computerUseHotkeyMonitor.configureTriggerThreshold(milliseconds: config.computerUseHotkeyTriggerThresholdMS)
         meetingRecordingHotkeyMonitor.configureTriggerThreshold(milliseconds: config.meetingRecordingHotkeyTriggerThresholdMS)
+    }
+
+    private func startDictationHotkeyMonitorIfNeeded() {
+        guard config.resolvedOnboardingUseCase.includesPushToTalk else { return }
+        hotkeyMonitor.configure(config.dictationHotkey)
+        hotkeyMonitor.start()
+        startComputerUseHotkeyMonitorIfNeeded()
     }
 
     private func startComputerUseHotkeyMonitorIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -752,9 +752,12 @@ public final class MuesliController: NSObject {
         meetingFeatureMonitorsAllowed = canRunMainApp
 
         // Defer permission-triggering monitors until after onboarding
+        let pushToTalkPermissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+            for: config.resolvedOnboardingUseCase
+        )
         if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: config.hasCompletedOnboarding,
-            hasDictationPermissions: OnboardingPermissionGate.hasRequiredDictationPermissions(
+            hasRequiredPermissions: pushToTalkPermissionProfile.hasRequiredPermissions(
                 currentOnboardingPermissionSnapshot()
             ),
             isEnabled: config.enablePushToTalk
@@ -762,6 +765,7 @@ public final class MuesliController: NSObject {
             startDictationHotkeyMonitorIfNeeded()
         }
         if canRunMainApp {
+            startIndependentDictationFeatureHotkeyMonitorsIfNeeded()
             startMeetingRecordingHotkeyMonitorIfNeeded()
         }
         syncDictationRecorderWarmup(intent: .idlePrewarm(.startup))
@@ -4859,15 +4863,19 @@ public final class MuesliController: NSObject {
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {
             meetingFeatureMonitorsAllowed = true
+            let pushToTalkPermissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+                for: onboardingUseCase
+            )
             if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
                 hasCompletedOnboarding: true,
-                hasDictationPermissions: OnboardingPermissionGate.hasRequiredDictationPermissions(
+                hasRequiredPermissions: pushToTalkPermissionProfile.hasRequiredPermissions(
                     currentOnboardingPermissionSnapshot()
                 ),
                 isEnabled: config.enablePushToTalk
             ) {
                 startDictationHotkeyMonitorIfNeeded()
             }
+            startIndependentDictationFeatureHotkeyMonitorsIfNeeded()
             syncCalendarMonitor()
             // Start monitors that were deferred during onboarding
             if shouldRunMeetingFeatureMonitors {
@@ -4976,14 +4984,18 @@ public final class MuesliController: NSObject {
     ) -> PushToTalkEnableResult {
         let wasEnabled = config.enablePushToTalk
         let snapshot = currentOnboardingPermissionSnapshot()
-        let hasDictationPermissions = OnboardingPermissionGate.hasRequiredDictationPermissions(snapshot)
+        let permissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+            for: config.resolvedOnboardingUseCase
+        )
+        let hasRequiredPermissions = permissionProfile.hasRequiredPermissions(snapshot)
         guard enabled else {
             pushToTalkEnablementIntentStore.clear()
             if wasEnabled {
                 updateConfig { $0.enablePushToTalk = false }
                 signalPushToTalkEnablementChanged(
                     enabled: false,
-                    hasDictationPermissions: hasDictationPermissions
+                    permissionProfile: permissionProfile,
+                    hasRequiredPermissions: hasRequiredPermissions
                 )
             }
             hotkeyMonitor.stop()
@@ -4997,7 +5009,7 @@ public final class MuesliController: NSObject {
 
         switch PushToTalkEnablementPolicy.outcome(
             isEnabled: config.enablePushToTalk,
-            hasDictationPermissions: hasDictationPermissions
+            hasRequiredPermissions: hasRequiredPermissions
         ) {
         case .disabled:
             return .disabled
@@ -5006,17 +5018,25 @@ public final class MuesliController: NSObject {
             startDictationHotkeyMonitorIfNeeded()
             syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
             if !wasEnabled {
-                signalPushToTalkEnablementChanged(enabled: true, hasDictationPermissions: true)
+                signalPushToTalkEnablementChanged(
+                    enabled: true,
+                    permissionProfile: permissionProfile,
+                    hasRequiredPermissions: true
+                )
                 return .enabled
             }
             return .alreadyEnabled
         case .waitForPermissions:
             pushToTalkEnablementIntentStore.markPending()
             if requestPermissions {
-                requestMissingDictationPermissions(snapshot)
+                requestMissingPushToTalkPermissions(snapshot, profile: permissionProfile)
             }
             if !wasEnabled {
-                signalPushToTalkEnablementChanged(enabled: true, hasDictationPermissions: false)
+                signalPushToTalkEnablementChanged(
+                    enabled: true,
+                    permissionProfile: permissionProfile,
+                    hasRequiredPermissions: false
+                )
             }
             return .needsPermissions
         }
@@ -5041,11 +5061,14 @@ public final class MuesliController: NSObject {
         )
     }
 
-    private func requestMissingDictationPermissions(_ snapshot: OnboardingPermissionSnapshot) {
+    private func requestMissingPushToTalkPermissions(
+        _ snapshot: OnboardingPermissionSnapshot,
+        profile: PushToTalkEnablementPolicy.PermissionProfile
+    ) {
         if !snapshot.microphone {
             AVCaptureDevice.requestAccess(for: .audio) { _ in }
         }
-        if !snapshot.accessibility {
+        if profile.requiresAccessibility, !snapshot.accessibility {
             let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
             AXIsProcessTrustedWithOptions(options)
         }
@@ -5056,12 +5079,14 @@ public final class MuesliController: NSObject {
 
     private func signalPushToTalkEnablementChanged(
         enabled: Bool,
-        hasDictationPermissions: Bool
+        permissionProfile: PushToTalkEnablementPolicy.PermissionProfile,
+        hasRequiredPermissions: Bool
     ) {
         TelemetryDeck.signal("push_to_talk.enablement_changed", parameters: [
             "enabled": enabled ? "true" : "false",
             "onboarding_use_case": config.resolvedOnboardingUseCase.rawValue,
-            "dictation_permissions_granted": hasDictationPermissions ? "true" : "false",
+            "permission_profile": permissionProfile.rawValue,
+            "required_permissions_granted": hasRequiredPermissions ? "true" : "false",
         ])
     }
 
@@ -8313,6 +8338,9 @@ public final class MuesliController: NSObject {
         }
         hotkeyMonitor.configure(config.dictationHotkey)
         hotkeyMonitor.start()
+    }
+
+    private func startIndependentDictationFeatureHotkeyMonitorsIfNeeded() {
         startComputerUseHotkeyMonitorIfNeeded()
         startQuilHotkeyMonitorIfNeeded()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4983,6 +4983,7 @@ public final class MuesliController: NSObject {
         requestPermissions: Bool = false
     ) -> PushToTalkEnableResult {
         let wasEnabled = config.enablePushToTalk
+        let wasPending = pushToTalkEnablementIntentStore.isPending
         let snapshot = currentOnboardingPermissionSnapshot()
         let permissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
             for: config.resolvedOnboardingUseCase
@@ -5017,7 +5018,7 @@ public final class MuesliController: NSObject {
             pushToTalkEnablementIntentStore.clear()
             startDictationHotkeyMonitorIfNeeded()
             syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
-            if !wasEnabled {
+            if !wasEnabled || wasPending {
                 signalPushToTalkEnablementChanged(
                     enabled: true,
                     permissionProfile: permissionProfile,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -416,7 +416,7 @@ public final class MuesliController: NSObject {
     private var autoRecordedCalendarEventIDs = Set<String>()
     private var meetingFeatureMonitorsAllowed = false
     private var meetingDetectionMonitorStarted = false
-    private var pendingPushToTalkEnable = false
+    private let pushToTalkEnablementIntentStore = PushToTalkEnablementIntentStore()
 
     private var searchTask: Task<Void, Never>?
     private var onboardingModelPreparationTask: Task<Void, Never>?
@@ -744,6 +744,8 @@ public final class MuesliController: NSObject {
         meetingRecordingHotkeyMonitor.onCancel = { [weak self] in
             DispatchQueue.main.async { self?.stopMeetingRecording() }
         }
+
+        reconcilePendingPushToTalkEnableIfReady()
 
         let canRunMainApp = config.hasCompletedOnboarding
             && hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase)
@@ -2167,6 +2169,7 @@ public final class MuesliController: NSObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                self?.reconcilePendingPushToTalkEnableIfReady()
                 self?.scheduleICloudSync(
                     intent: .incoming,
                     delay: 0.5,
@@ -4965,14 +4968,14 @@ public final class MuesliController: NSObject {
             hasDictationPermissions: hasDictationPermissions
         ) {
         case .alreadyEnabled:
-            pendingPushToTalkEnable = false
+            pushToTalkEnablementIntentStore.clear()
             startDictationHotkeyMonitorIfNeeded()
             return .alreadyEnabled
         case .promote(let useCase):
             applyPushToTalkEnablement(useCase: useCase)
             return .enabled
         case .waitForPermissions:
-            pendingPushToTalkEnable = true
+            pushToTalkEnablementIntentStore.markPending()
             if requestPermissions {
                 requestMissingDictationPermissions(snapshot)
             }
@@ -4980,8 +4983,9 @@ public final class MuesliController: NSObject {
         }
     }
 
-    func completePendingPushToTalkEnableIfReady() {
-        guard pendingPushToTalkEnable else { return }
+    func reconcilePendingPushToTalkEnableIfReady() {
+        guard config.hasCompletedOnboarding,
+              pushToTalkEnablementIntentStore.isPending else { return }
         enablePushToTalkIfNeeded(requestPermissions: false)
     }
 
@@ -5010,7 +5014,7 @@ public final class MuesliController: NSObject {
 
     private func applyPushToTalkEnablement(useCase: OnboardingUseCase) {
         let fromUseCase = config.resolvedOnboardingUseCase
-        pendingPushToTalkEnable = false
+        pushToTalkEnablementIntentStore.clear()
         updateConfig { $0.onboardingUseCase = useCase.rawValue }
         startDictationHotkeyMonitorIfNeeded()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -764,8 +764,11 @@ public final class MuesliController: NSObject {
         ) {
             startDictationHotkeyMonitorIfNeeded()
         }
+        // Quill and Computer Use own their runtime permission checks. Their
+        // availability must not inherit the startup requirements of whichever
+        // use case happened to be selected during onboarding.
+        startIndependentDictationFeatureHotkeyMonitorsIfNeeded()
         if canRunMainApp {
-            startIndependentDictationFeatureHotkeyMonitorsIfNeeded()
             startMeetingRecordingHotkeyMonitorIfNeeded()
         }
         syncDictationRecorderWarmup(intent: .idlePrewarm(.startup))
@@ -2176,6 +2179,7 @@ public final class MuesliController: NSObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.reconcilePendingPushToTalkEnableIfReady()
+                self?.reconcileIndependentShortcutFeatureEnablement()
                 self?.scheduleICloudSync(
                     intent: .incoming,
                     delay: 0.5,
@@ -4384,6 +4388,7 @@ public final class MuesliController: NSObject {
 
     @discardableResult
     func updateComputerUseHotkeyEnabled(_ enabled: Bool) -> ShortcutHotkeyUpdateResult {
+        let wasEnabled = config.enableComputerUseHotkey
         if enabled {
             if config.enableQuilMode,
                ShortcutHotkeyPolicy.hotkeysConflict(config.computerUseHotkey, config.quilHotkey) {
@@ -4405,10 +4410,33 @@ public final class MuesliController: NSObject {
                 config.enableComputerUseHotkey = true
             }
             configureComputerUseHotkeyMonitor()
-            return resolution.result
+            let permissions = currentOnboardingPermissionSnapshot()
+            let hasRequiredPermissions = ShortcutFeatureEnablementPolicy.hasRequiredPermissions(permissions)
+            if !hasRequiredPermissions {
+                requestMissingShortcutPermissions(permissions, requiresAccessibility: true)
+            }
+            if !wasEnabled {
+                signalIndependentShortcutEnablementChanged(
+                    feature: "computer_use",
+                    enabled: true,
+                    hasRequiredPermissions: hasRequiredPermissions
+                )
+            }
+            return hasRequiredPermissions
+                ? resolution.result
+                : .updated(notice: ShortcutFeatureEnablementPolicy.missingPermissionsMessage)
         }
-        updateConfig { $0.enableComputerUseHotkey = enabled }
+        updateConfig { $0.enableComputerUseHotkey = false }
         configureComputerUseHotkeyMonitor()
+        if wasEnabled {
+            signalIndependentShortcutEnablementChanged(
+                feature: "computer_use",
+                enabled: false,
+                hasRequiredPermissions: ShortcutFeatureEnablementPolicy.hasRequiredPermissions(
+                    currentOnboardingPermissionSnapshot()
+                )
+            )
+        }
         return .updated
     }
 
@@ -4474,6 +4502,8 @@ public final class MuesliController: NSObject {
 
     @discardableResult
     func updateQuilModeEnabled(_ enabled: Bool) -> ShortcutHotkeyUpdateResult {
+        let wasEnabled = config.enableQuilMode
+        var validationResult: ShortcutHotkeyUpdateResult = .updated
         if enabled {
             let result = ShortcutHotkeyPolicy.validateQuilHotkey(
                 config.quilHotkey,
@@ -4484,10 +4514,25 @@ public final class MuesliController: NSObject {
                 isMeetingRecordingEnabled: config.enableMeetingRecordingHotkey
             )
             guard result.didUpdate else { return result }
+            validationResult = result
         }
         updateConfig { $0.enableQuilMode = enabled }
         configureQuilHotkeyMonitor()
-        return .updated
+        let permissions = currentOnboardingPermissionSnapshot()
+        let hasRequiredPermissions = ShortcutFeatureEnablementPolicy.hasRequiredPermissions(permissions)
+        if enabled, !hasRequiredPermissions {
+            requestMissingShortcutPermissions(permissions, requiresAccessibility: true)
+        }
+        if wasEnabled != enabled {
+            signalIndependentShortcutEnablementChanged(
+                feature: "quill",
+                enabled: enabled,
+                hasRequiredPermissions: hasRequiredPermissions
+            )
+        }
+        return enabled && !hasRequiredPermissions
+            ? .updated(notice: ShortcutFeatureEnablementPolicy.missingPermissionsMessage)
+            : validationResult
     }
 
     func resetShortcutDefaults() {
@@ -5066,16 +5111,52 @@ public final class MuesliController: NSObject {
         _ snapshot: OnboardingPermissionSnapshot,
         profile: PushToTalkEnablementPolicy.PermissionProfile
     ) {
+        requestMissingShortcutPermissions(
+            snapshot,
+            requiresAccessibility: profile.requiresAccessibility
+        )
+    }
+
+    private func requestMissingShortcutPermissions(
+        _ snapshot: OnboardingPermissionSnapshot,
+        requiresAccessibility: Bool
+    ) {
         if !snapshot.microphone {
             AVCaptureDevice.requestAccess(for: .audio) { _ in }
         }
-        if profile.requiresAccessibility, !snapshot.accessibility {
+        if requiresAccessibility, !snapshot.accessibility {
             let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
             AXIsProcessTrustedWithOptions(options)
         }
         if !snapshot.inputMonitoring {
             _ = CGRequestListenEventAccess()
         }
+    }
+
+    func independentShortcutPermissionMessageIfNeeded(isEnabled: Bool) -> String? {
+        guard isEnabled,
+              !ShortcutFeatureEnablementPolicy.hasRequiredPermissions(
+                  currentOnboardingPermissionSnapshot()
+              ) else { return nil }
+        return ShortcutFeatureEnablementPolicy.missingPermissionsMessage
+    }
+
+    private func reconcileIndependentShortcutFeatureEnablement() {
+        configureComputerUseHotkeyMonitor()
+        configureQuilHotkeyMonitor()
+    }
+
+    private func signalIndependentShortcutEnablementChanged(
+        feature: String,
+        enabled: Bool,
+        hasRequiredPermissions: Bool
+    ) {
+        TelemetryDeck.signal("shortcut_feature.enablement_changed", parameters: [
+            "feature": feature,
+            "enabled": enabled ? "true" : "false",
+            "onboarding_use_case": config.resolvedOnboardingUseCase.rawValue,
+            "required_permissions_granted": hasRequiredPermissions ? "true" : "false",
+        ])
     }
 
     private func signalPushToTalkEnablementChanged(
@@ -8351,7 +8432,11 @@ public final class MuesliController: NSObject {
             computerUseHotkeyMonitor.stop()
             return
         }
-        guard config.resolvedOnboardingUseCase.includesDictation else {
+        guard ShortcutFeatureEnablementPolicy.outcome(
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            isEnabled: config.enableComputerUseHotkey,
+            permissions: currentOnboardingPermissionSnapshot()
+        ) == .ready else {
             computerUseHotkeyMonitor.stop()
             return
         }
@@ -8372,8 +8457,11 @@ public final class MuesliController: NSObject {
     }
 
     private func startQuilHotkeyMonitorIfNeeded() {
-        guard config.enableQuilMode,
-              config.resolvedOnboardingUseCase.includesDictation else {
+        guard ShortcutFeatureEnablementPolicy.outcome(
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            isEnabled: config.enableQuilMode,
+            permissions: currentOnboardingPermissionSnapshot()
+        ) == .ready else {
             quilHotkeyMonitor.stop()
             return
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4918,7 +4918,7 @@ public final class MuesliController: NSObject {
     }
 
     private func hasRequiredStartupPermissions(for useCase: OnboardingUseCase) -> Bool {
-        OnboardingPermissionGate.hasRequiredPermissions(
+        OnboardingPermissionGate.hasRequiredStartupPermissions(
             currentOnboardingPermissionSnapshot(),
             for: useCase
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -754,8 +754,10 @@ public final class MuesliController: NSObject {
         // Defer permission-triggering monitors until after onboarding
         if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: config.hasCompletedOnboarding,
-            hasRequiredStartupPermissions: hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase),
-            useCase: config.resolvedOnboardingUseCase
+            hasDictationPermissions: OnboardingPermissionGate.hasRequiredDictationPermissions(
+                currentOnboardingPermissionSnapshot()
+            ),
+            isEnabled: config.enablePushToTalk
         ) {
             startDictationHotkeyMonitorIfNeeded()
         }
@@ -4352,7 +4354,6 @@ public final class MuesliController: NSObject {
         updateConfig { $0.dictationHotkey = hotkey }
         hotkeyMonitor.configure(hotkey)
         configureComputerUseHotkeyMonitor()
-        enablePushToTalkIfNeeded(requestPermissions: true)
         return result
     }
 
@@ -4833,6 +4834,7 @@ public final class MuesliController: NSObject {
             config.enableComputerUseHotkey = false
             config.enableComputerUsePlanner = true
             config.onboardingUseCase = onboardingUseCase.rawValue
+            config.enablePushToTalk = onboardingUseCase.includesPushToTalk
             if let summaryBackend {
                 config.meetingSummaryBackend = summaryBackend.backend
             }
@@ -4859,8 +4861,10 @@ public final class MuesliController: NSObject {
             meetingFeatureMonitorsAllowed = true
             if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
                 hasCompletedOnboarding: true,
-                hasRequiredStartupPermissions: true,
-                useCase: onboardingUseCase
+                hasDictationPermissions: OnboardingPermissionGate.hasRequiredDictationPermissions(
+                    currentOnboardingPermissionSnapshot()
+                ),
+                isEnabled: config.enablePushToTalk
             ) {
                 startDictationHotkeyMonitorIfNeeded()
             }
@@ -4956,37 +4960,75 @@ public final class MuesliController: NSObject {
     enum PushToTalkEnableResult: Equatable {
         case alreadyEnabled
         case enabled
+        case disabled
         case needsPermissions
     }
 
     @discardableResult
     func enablePushToTalkIfNeeded(requestPermissions: Bool = false) -> PushToTalkEnableResult {
+        updatePushToTalkEnabled(true, requestPermissions: requestPermissions)
+    }
+
+    @discardableResult
+    func updatePushToTalkEnabled(
+        _ enabled: Bool,
+        requestPermissions: Bool = false
+    ) -> PushToTalkEnableResult {
+        let wasEnabled = config.enablePushToTalk
         let snapshot = currentOnboardingPermissionSnapshot()
         let hasDictationPermissions = OnboardingPermissionGate.hasRequiredDictationPermissions(snapshot)
+        guard enabled else {
+            pushToTalkEnablementIntentStore.clear()
+            if wasEnabled {
+                updateConfig { $0.enablePushToTalk = false }
+                signalPushToTalkEnablementChanged(
+                    enabled: false,
+                    hasDictationPermissions: hasDictationPermissions
+                )
+            }
+            hotkeyMonitor.stop()
+            syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
+            return .disabled
+        }
+
+        if !wasEnabled {
+            updateConfig { $0.enablePushToTalk = true }
+        }
+
         switch PushToTalkEnablementPolicy.outcome(
-            currentUseCase: config.resolvedOnboardingUseCase,
+            isEnabled: config.enablePushToTalk,
             hasDictationPermissions: hasDictationPermissions
         ) {
-        case .alreadyEnabled:
+        case .disabled:
+            return .disabled
+        case .ready:
             pushToTalkEnablementIntentStore.clear()
             startDictationHotkeyMonitorIfNeeded()
+            syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
+            if !wasEnabled {
+                signalPushToTalkEnablementChanged(enabled: true, hasDictationPermissions: true)
+                return .enabled
+            }
             return .alreadyEnabled
-        case .promote(let useCase):
-            applyPushToTalkEnablement(useCase: useCase)
-            return .enabled
         case .waitForPermissions:
             pushToTalkEnablementIntentStore.markPending()
             if requestPermissions {
                 requestMissingDictationPermissions(snapshot)
             }
+            if !wasEnabled {
+                signalPushToTalkEnablementChanged(enabled: true, hasDictationPermissions: false)
+            }
             return .needsPermissions
         }
     }
 
-    func reconcilePendingPushToTalkEnableIfReady() {
-        guard config.hasCompletedOnboarding,
-              pushToTalkEnablementIntentStore.isPending else { return }
-        enablePushToTalkIfNeeded(requestPermissions: false)
+    @discardableResult
+    func reconcilePendingPushToTalkEnableIfReady() -> PushToTalkEnableResult? {
+        guard PushToTalkEnablementPolicy.shouldReconcilePendingEnable(
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            isPending: pushToTalkEnablementIntentStore.isPending
+        ) else { return nil }
+        return enablePushToTalkIfNeeded(requestPermissions: false)
     }
 
     private func currentOnboardingPermissionSnapshot() -> OnboardingPermissionSnapshot {
@@ -5012,16 +5054,14 @@ public final class MuesliController: NSObject {
         }
     }
 
-    private func applyPushToTalkEnablement(useCase: OnboardingUseCase) {
-        let fromUseCase = config.resolvedOnboardingUseCase
-        pushToTalkEnablementIntentStore.clear()
-        updateConfig { $0.onboardingUseCase = useCase.rawValue }
-        startDictationHotkeyMonitorIfNeeded()
-        syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
-        TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
-            "from_use_case": fromUseCase.rawValue,
-            "to_use_case": useCase.rawValue,
-            "reason": "push_to_talk_enabled",
+    private func signalPushToTalkEnablementChanged(
+        enabled: Bool,
+        hasDictationPermissions: Bool
+    ) {
+        TelemetryDeck.signal("push_to_talk.enablement_changed", parameters: [
+            "enabled": enabled ? "true" : "false",
+            "onboarding_use_case": config.resolvedOnboardingUseCase.rawValue,
+            "dictation_permissions_granted": hasDictationPermissions ? "true" : "false",
         ])
     }
 
@@ -8267,7 +8307,10 @@ public final class MuesliController: NSObject {
     }
 
     private func startDictationHotkeyMonitorIfNeeded() {
-        guard config.resolvedOnboardingUseCase.includesPushToTalk else { return }
+        guard config.enablePushToTalk else {
+            hotkeyMonitor.stop()
+            return
+        }
         hotkeyMonitor.configure(config.dictationHotkey)
         hotkeyMonitor.start()
         startComputerUseHotkeyMonitorIfNeeded()
@@ -9712,7 +9755,10 @@ public final class MuesliController: NSObject {
     }
 
     private var defaultDictationOutputMode: DictationOutputMode {
-        config.resolvedOnboardingUseCase.includesDictation ? .paste : .voiceNote
+        let onboardingUseCase = config.resolvedOnboardingUseCase
+        return onboardingUseCase.includesVoiceNotes && !onboardingUseCase.includesDictation
+            ? .voiceNote
+            : .paste
     }
 
     private func beginDictationOutput(mode: DictationOutputMode? = nil) {
@@ -9728,7 +9774,7 @@ public final class MuesliController: NSObject {
     private var canPrimeDictationRecorder: Bool {
         config.hasCompletedOnboarding
             && hasStarted
-            && config.resolvedOnboardingUseCase.includesPushToTalk
+            && config.enablePushToTalk
             && AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
             && dictationState == .idle
             && !isMeetingAudioProcessing

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -416,6 +416,7 @@ public final class MuesliController: NSObject {
     private var autoRecordedCalendarEventIDs = Set<String>()
     private var meetingFeatureMonitorsAllowed = false
     private var meetingDetectionMonitorStarted = false
+    private var pendingPushToTalkEnable = false
 
     private var searchTask: Task<Void, Never>?
     private var onboardingModelPreparationTask: Task<Void, Never>?
@@ -749,11 +750,12 @@ public final class MuesliController: NSObject {
         meetingFeatureMonitorsAllowed = canRunMainApp
 
         // Defer permission-triggering monitors until after onboarding
-        if canRunMainApp && config.resolvedOnboardingUseCase.includesPushToTalk {
-            hotkeyMonitor.configure(config.dictationHotkey)
-            hotkeyMonitor.start()
-            startComputerUseHotkeyMonitorIfNeeded()
-            startQuilHotkeyMonitorIfNeeded()
+        if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            hasRequiredStartupPermissions: hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase),
+            useCase: config.resolvedOnboardingUseCase
+        ) {
+            startDictationHotkeyMonitorIfNeeded()
         }
         if canRunMainApp {
             startMeetingRecordingHotkeyMonitorIfNeeded()
@@ -4347,6 +4349,7 @@ public final class MuesliController: NSObject {
         updateConfig { $0.dictationHotkey = hotkey }
         hotkeyMonitor.configure(hotkey)
         configureComputerUseHotkeyMonitor()
+        enablePushToTalkIfNeeded(requestPermissions: true)
         return result
     }
 
@@ -4851,9 +4854,12 @@ public final class MuesliController: NSObject {
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {
             meetingFeatureMonitorsAllowed = true
-            if onboardingUseCase.includesPushToTalk {
-                hotkeyMonitor.start()
-                startComputerUseHotkeyMonitorIfNeeded()
+            if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+                hasCompletedOnboarding: true,
+                hasRequiredStartupPermissions: true,
+                useCase: onboardingUseCase
+            ) {
+                startDictationHotkeyMonitorIfNeeded()
             }
             syncCalendarMonitor()
             // Start monitors that were deferred during onboarding
@@ -4906,13 +4912,7 @@ public final class MuesliController: NSObject {
 
     private func hasRequiredStartupPermissions(for useCase: OnboardingUseCase) -> Bool {
         OnboardingPermissionGate.hasRequiredPermissions(
-            OnboardingPermissionSnapshot(
-                microphone: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
-                accessibility: AXIsProcessTrusted(),
-                inputMonitoring: CGPreflightListenEventAccess(),
-                systemAudio: false,
-                screenRecording: false
-            ),
+            currentOnboardingPermissionSnapshot(),
             for: useCase
         )
     }
@@ -4941,14 +4941,83 @@ public final class MuesliController: NSObject {
                 .union([.dictation])
         )
         updateConfig { $0.onboardingUseCase = updatedUseCase.rawValue }
-        hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
-        hotkeyMonitor.start()
-        startComputerUseHotkeyMonitorIfNeeded()
+        startDictationHotkeyMonitorIfNeeded()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
         TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
             "from_use_case": previousUseCase.rawValue,
             "to_use_case": updatedUseCase.rawValue,
             "reason": "dictation_permissions_granted",
+        ])
+    }
+
+    enum PushToTalkEnableResult: Equatable {
+        case alreadyEnabled
+        case enabled
+        case needsPermissions
+    }
+
+    @discardableResult
+    func enablePushToTalkIfNeeded(requestPermissions: Bool = false) -> PushToTalkEnableResult {
+        let snapshot = currentOnboardingPermissionSnapshot()
+        let hasDictationPermissions = OnboardingPermissionGate.hasRequiredDictationPermissions(snapshot)
+        switch PushToTalkEnablementPolicy.outcome(
+            currentUseCase: config.resolvedOnboardingUseCase,
+            hasDictationPermissions: hasDictationPermissions
+        ) {
+        case .alreadyEnabled:
+            pendingPushToTalkEnable = false
+            startDictationHotkeyMonitorIfNeeded()
+            return .alreadyEnabled
+        case .promote(let useCase):
+            applyPushToTalkEnablement(useCase: useCase)
+            return .enabled
+        case .waitForPermissions:
+            pendingPushToTalkEnable = true
+            if requestPermissions {
+                requestMissingDictationPermissions(snapshot)
+            }
+            return .needsPermissions
+        }
+    }
+
+    func completePendingPushToTalkEnableIfReady() {
+        guard pendingPushToTalkEnable else { return }
+        enablePushToTalkIfNeeded(requestPermissions: false)
+    }
+
+    private func currentOnboardingPermissionSnapshot() -> OnboardingPermissionSnapshot {
+        OnboardingPermissionSnapshot(
+            microphone: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
+            accessibility: AXIsProcessTrusted(),
+            inputMonitoring: CGPreflightListenEventAccess(),
+            systemAudio: false,
+            screenRecording: false
+        )
+    }
+
+    private func requestMissingDictationPermissions(_ snapshot: OnboardingPermissionSnapshot) {
+        if !snapshot.microphone {
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        }
+        if !snapshot.accessibility {
+            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+            AXIsProcessTrustedWithOptions(options)
+        }
+        if !snapshot.inputMonitoring {
+            _ = CGRequestListenEventAccess()
+        }
+    }
+
+    private func applyPushToTalkEnablement(useCase: OnboardingUseCase) {
+        let fromUseCase = config.resolvedOnboardingUseCase
+        pendingPushToTalkEnable = false
+        updateConfig { $0.onboardingUseCase = useCase.rawValue }
+        startDictationHotkeyMonitorIfNeeded()
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
+        TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
+            "from_use_case": fromUseCase.rawValue,
+            "to_use_case": useCase.rawValue,
+            "reason": "push_to_talk_enabled",
         ])
     }
 
@@ -8191,6 +8260,14 @@ public final class MuesliController: NSObject {
         computerUseHotkeyMonitor.configureTriggerThreshold(milliseconds: config.computerUseHotkeyTriggerThresholdMS)
         quilHotkeyMonitor.configureTriggerThreshold(milliseconds: config.quilHotkeyTriggerThresholdMS)
         meetingRecordingHotkeyMonitor.configureTriggerThreshold(milliseconds: config.meetingRecordingHotkeyTriggerThresholdMS)
+    }
+
+    private func startDictationHotkeyMonitorIfNeeded() {
+        guard config.resolvedOnboardingUseCase.includesPushToTalk else { return }
+        hotkeyMonitor.configure(config.dictationHotkey)
+        hotkeyMonitor.start()
+        startComputerUseHotkeyMonitorIfNeeded()
+        startQuilHotkeyMonitorIfNeeded()
     }
 
     private func startComputerUseHotkeyMonitorIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -349,6 +349,9 @@ public final class MuesliController: NSObject {
     private static let pendingDictionaryCorrectionAccessibilityRequestedAtKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestedAt"
     private static let pendingDictionaryCorrectionAccessibilityRequestProcessIDKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestProcessID"
     private static let dictionaryCorrectionAccessibilityIntentTimeout: TimeInterval = 24 * 60 * 60
+    private static let pendingScreenContextEnableKey = "settings.pendingScreenContextEnable"
+    private static let pendingScreenContextRequestedAtKey = "settings.pendingScreenContextRequestedAt"
+    private static let screenContextGrantIntentTimeout: TimeInterval = 15 * 60
     private let runtime: RuntimePaths
     private let configStore: ConfigStore
     private let dictationStore: DictationStore
@@ -417,6 +420,11 @@ public final class MuesliController: NSObject {
     private var meetingFeatureMonitorsAllowed = false
     private var meetingDetectionMonitorStarted = false
     private let pushToTalkEnablementIntentStore = PushToTalkEnablementIntentStore()
+    private var interactionPermissionMonitoringClientIDs = Set<UUID>()
+    private var interactionPermissionMonitoringRevision = 0
+    private lazy var interactionPermissionMonitor = InteractionPermissionMonitor { [weak self] snapshot in
+        self?.applyInteractionPermissionSnapshot(snapshot)
+    }
 
     private var searchTask: Task<Void, Never>?
     private var onboardingModelPreparationTask: Task<Void, Never>?
@@ -2178,8 +2186,7 @@ public final class MuesliController: NSObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.reconcilePendingPushToTalkEnableIfReady()
-                self?.reconcileIndependentShortcutFeatureEnablement()
+                self?.refreshInteractionPermissionSnapshot()
                 self?.scheduleICloudSync(
                     intent: .incoming,
                     delay: 0.5,
@@ -5025,11 +5032,12 @@ public final class MuesliController: NSObject {
     @discardableResult
     func updatePushToTalkEnabled(
         _ enabled: Bool,
-        requestPermissions: Bool = false
+        requestPermissions: Bool = false,
+        permissionSnapshot: OnboardingPermissionSnapshot? = nil
     ) -> PushToTalkEnableResult {
         let wasEnabled = config.enablePushToTalk
         let wasPending = pushToTalkEnablementIntentStore.isPending
-        let snapshot = currentOnboardingPermissionSnapshot()
+        let snapshot = permissionSnapshot ?? currentOnboardingPermissionSnapshot()
         let permissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
             for: config.resolvedOnboardingUseCase
         )
@@ -5089,12 +5097,18 @@ public final class MuesliController: NSObject {
     }
 
     @discardableResult
-    func reconcilePendingPushToTalkEnableIfReady() -> PushToTalkEnableResult? {
+    func reconcilePendingPushToTalkEnableIfReady(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) -> PushToTalkEnableResult? {
         guard PushToTalkEnablementPolicy.shouldReconcilePendingEnable(
             hasCompletedOnboarding: config.hasCompletedOnboarding,
             isPending: pushToTalkEnablementIntentStore.isPending
         ) else { return nil }
-        return enablePushToTalkIfNeeded(requestPermissions: false)
+        return updatePushToTalkEnabled(
+            true,
+            requestPermissions: false,
+            permissionSnapshot: permissions
+        )
     }
 
     private func currentOnboardingPermissionSnapshot() -> OnboardingPermissionSnapshot {
@@ -5135,15 +5149,96 @@ public final class MuesliController: NSObject {
 
     func independentShortcutPermissionMessageIfNeeded(isEnabled: Bool) -> String? {
         guard isEnabled,
+              let permissions = appState.interactionPermissionSnapshot?.onboardingSnapshot,
               !ShortcutFeatureEnablementPolicy.hasRequiredPermissions(
-                  currentOnboardingPermissionSnapshot()
+                  permissions
               ) else { return nil }
         return ShortcutFeatureEnablementPolicy.missingPermissionsMessage
     }
 
-    private func reconcileIndependentShortcutFeatureEnablement() {
-        configureComputerUseHotkeyMonitor()
-        configureQuilHotkeyMonitor()
+    func beginInteractionPermissionMonitoring(clientID: UUID) {
+        guard interactionPermissionMonitoringClientIDs.insert(clientID).inserted else { return }
+        synchronizeInteractionPermissionMonitoringClients()
+    }
+
+    func endInteractionPermissionMonitoring(clientID: UUID) {
+        guard interactionPermissionMonitoringClientIDs.remove(clientID) != nil else { return }
+        synchronizeInteractionPermissionMonitoringClients()
+    }
+
+    private func synchronizeInteractionPermissionMonitoringClients() {
+        interactionPermissionMonitoringRevision += 1
+        let clientIDs = interactionPermissionMonitoringClientIDs
+        let revision = interactionPermissionMonitoringRevision
+        let monitor = interactionPermissionMonitor
+        Task {
+            await monitor.updateClients(clientIDs, revision: revision)
+        }
+    }
+
+    func refreshInteractionPermissionSnapshot() {
+        let monitor = interactionPermissionMonitor
+        Task {
+            await monitor.refresh()
+        }
+    }
+
+    private func applyInteractionPermissionSnapshot(_ snapshot: InteractionPermissionSnapshot) {
+        guard appState.interactionPermissionSnapshot != snapshot else { return }
+        appState.interactionPermissionSnapshot = snapshot
+
+        let permissions = snapshot.onboardingSnapshot
+        reconcilePendingDictionaryCorrectionAccessibilityEnable()
+        reclassifyVoiceNotesAsDictationIfReady(
+            microphoneGranted: snapshot.microphone,
+            accessibilityGranted: snapshot.accessibility,
+            inputMonitoringGranted: snapshot.inputMonitoring
+        )
+        reconcilePendingScreenContextPermission(snapshot)
+        reconcilePendingPushToTalkEnableIfReady(permissions: permissions)
+        reconcileIndependentShortcutFeatureEnablement(permissions: permissions)
+    }
+
+    private func reconcilePendingScreenContextPermission(_ snapshot: InteractionPermissionSnapshot) {
+        let defaults = UserDefaults.standard
+        let isPending = defaults.bool(forKey: Self.pendingScreenContextEnableKey)
+        let requestedAt = defaults.double(forKey: Self.pendingScreenContextRequestedAtKey)
+
+        if snapshot.accessibility, isPending, requestScreenContextEnable() {
+            clearPendingScreenContextPermission(defaults: defaults)
+        }
+
+        let pendingRequestExpired = isPending
+            && (requestedAt <= 0
+                || Date().timeIntervalSince1970 - requestedAt > Self.screenContextGrantIntentTimeout)
+        if !snapshot.accessibility, pendingRequestExpired {
+            clearPendingScreenContextPermission(defaults: defaults)
+        }
+
+        if !snapshot.accessibility, config.enableScreenContext {
+            clearPendingScreenContextPermission(defaults: defaults)
+            updateConfig {
+                $0.enableScreenContext = false
+                $0.enableDictationOCRContext = false
+            }
+        }
+
+        if (!config.enableScreenContext || !snapshot.screenRecording),
+           config.enableDictationOCRContext {
+            updateConfig { $0.enableDictationOCRContext = false }
+        }
+    }
+
+    private func clearPendingScreenContextPermission(defaults: UserDefaults) {
+        defaults.set(false, forKey: Self.pendingScreenContextEnableKey)
+        defaults.set(0, forKey: Self.pendingScreenContextRequestedAtKey)
+    }
+
+    private func reconcileIndependentShortcutFeatureEnablement(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
+        configureComputerUseHotkeyMonitor(permissions: permissions)
+        configureQuilHotkeyMonitor(permissions: permissions)
     }
 
     private func signalIndependentShortcutEnablementChanged(
@@ -8388,22 +8483,26 @@ public final class MuesliController: NSObject {
         )
     }
 
-    private func configureComputerUseHotkeyMonitor() {
+    private func configureComputerUseHotkeyMonitor(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
         guard config.enableComputerUseHotkey else {
             computerUseHotkeyMonitor.stop()
             return
         }
         computerUseHotkeyMonitor.configure(config.computerUseHotkey)
-        startComputerUseHotkeyMonitorIfNeeded()
+        startComputerUseHotkeyMonitorIfNeeded(permissions: permissions)
     }
 
-    private func configureQuilHotkeyMonitor() {
+    private func configureQuilHotkeyMonitor(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
         guard config.enableQuilMode else {
             quilHotkeyMonitor.stop()
             return
         }
         quilHotkeyMonitor.configure(config.quilHotkey)
-        startQuilHotkeyMonitorIfNeeded()
+        startQuilHotkeyMonitorIfNeeded(permissions: permissions)
     }
 
     private func configureHotkeyMonitorTiming() {
@@ -8427,7 +8526,9 @@ public final class MuesliController: NSObject {
         startQuilHotkeyMonitorIfNeeded()
     }
 
-    private func startComputerUseHotkeyMonitorIfNeeded() {
+    private func startComputerUseHotkeyMonitorIfNeeded(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
         guard config.enableComputerUseHotkey else {
             computerUseHotkeyMonitor.stop()
             return
@@ -8435,7 +8536,7 @@ public final class MuesliController: NSObject {
         guard ShortcutFeatureEnablementPolicy.outcome(
             hasCompletedOnboarding: config.hasCompletedOnboarding,
             isEnabled: config.enableComputerUseHotkey,
-            permissions: currentOnboardingPermissionSnapshot()
+            permissions: permissions ?? currentOnboardingPermissionSnapshot()
         ) == .ready else {
             computerUseHotkeyMonitor.stop()
             return
@@ -8456,11 +8557,13 @@ public final class MuesliController: NSObject {
         computerUseHotkeyMonitor.start()
     }
 
-    private func startQuilHotkeyMonitorIfNeeded() {
+    private func startQuilHotkeyMonitorIfNeeded(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
         guard ShortcutFeatureEnablementPolicy.outcome(
             hasCompletedOnboarding: config.hasCompletedOnboarding,
             isEnabled: config.enableQuilMode,
-            permissions: currentOnboardingPermissionSnapshot()
+            permissions: permissions ?? currentOnboardingPermissionSnapshot()
         ) == .ready else {
             quilHotkeyMonitor.stop()
             return

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -763,14 +763,15 @@ public final class MuesliController: NSObject {
         let pushToTalkPermissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
             for: config.resolvedOnboardingUseCase
         )
+        let pushToTalkPermissionSnapshot = currentOnboardingPermissionSnapshot()
         if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: config.hasCompletedOnboarding,
             hasRequiredPermissions: pushToTalkPermissionProfile.hasRequiredPermissions(
-                currentOnboardingPermissionSnapshot()
+                pushToTalkPermissionSnapshot
             ),
             isEnabled: config.enablePushToTalk
         ) {
-            startDictationHotkeyMonitorIfNeeded()
+            startDictationHotkeyMonitorIfNeeded(permissions: pushToTalkPermissionSnapshot)
         }
         // Quill and Computer Use own their runtime permission checks. Their
         // availability must not inherit the startup requirements of whichever
@@ -4918,14 +4919,15 @@ public final class MuesliController: NSObject {
             let pushToTalkPermissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
                 for: onboardingUseCase
             )
+            let pushToTalkPermissionSnapshot = currentOnboardingPermissionSnapshot()
             if PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
                 hasCompletedOnboarding: true,
                 hasRequiredPermissions: pushToTalkPermissionProfile.hasRequiredPermissions(
-                    currentOnboardingPermissionSnapshot()
+                    pushToTalkPermissionSnapshot
                 ),
                 isEnabled: config.enablePushToTalk
             ) {
-                startDictationHotkeyMonitorIfNeeded()
+                startDictationHotkeyMonitorIfNeeded(permissions: pushToTalkPermissionSnapshot)
             }
             startIndependentDictationFeatureHotkeyMonitorsIfNeeded()
             syncCalendarMonitor()
@@ -5008,7 +5010,7 @@ public final class MuesliController: NSObject {
                 .union([.dictation])
         )
         updateConfig { $0.onboardingUseCase = updatedUseCase.rawValue }
-        startDictationHotkeyMonitorIfNeeded()
+        startDictationHotkeyMonitorIfNeeded(permissions: permissions)
         syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
         TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
             "from_use_case": previousUseCase.rawValue,
@@ -5069,7 +5071,7 @@ public final class MuesliController: NSObject {
             return .disabled
         case .ready:
             pushToTalkEnablementIntentStore.clear()
-            startDictationHotkeyMonitorIfNeeded()
+            startDictationHotkeyMonitorIfNeeded(permissions: snapshot)
             syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
             if !wasEnabled || wasPending {
                 signalPushToTalkEnablementChanged(
@@ -5082,6 +5084,7 @@ public final class MuesliController: NSObject {
             return .alreadyEnabled
         case .waitForPermissions:
             pushToTalkEnablementIntentStore.markPending()
+            hotkeyMonitor.stop()
             if requestPermissions {
                 requestMissingPushToTalkPermissions(snapshot, profile: permissionProfile)
             }
@@ -5195,8 +5198,18 @@ public final class MuesliController: NSObject {
             inputMonitoringGranted: snapshot.inputMonitoring
         )
         reconcilePendingScreenContextPermission(snapshot)
-        reconcilePendingPushToTalkEnableIfReady(permissions: permissions)
+        reconcilePushToTalkMonitorAvailability(permissions: permissions)
         reconcileIndependentShortcutFeatureEnablement(permissions: permissions)
+    }
+
+    private func reconcilePushToTalkMonitorAvailability(
+        permissions: OnboardingPermissionSnapshot
+    ) {
+        guard config.hasCompletedOnboarding, !isDictationTestMode else { return }
+        if reconcilePendingPushToTalkEnableIfReady(permissions: permissions) != nil {
+            return
+        }
+        startDictationHotkeyMonitorIfNeeded(permissions: permissions)
     }
 
     private func reconcilePendingScreenContextPermission(_ snapshot: InteractionPermissionSnapshot) {
@@ -8512,11 +8525,23 @@ public final class MuesliController: NSObject {
         meetingRecordingHotkeyMonitor.configureTriggerThreshold(milliseconds: config.meetingRecordingHotkeyTriggerThresholdMS)
     }
 
-    private func startDictationHotkeyMonitorIfNeeded() {
-        guard config.enablePushToTalk else {
+    private func startDictationHotkeyMonitorIfNeeded(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
+        let permissionProfile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+            for: config.resolvedOnboardingUseCase
+        )
+        guard PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            hasRequiredPermissions: permissionProfile.hasRequiredPermissions(
+                permissions ?? currentOnboardingPermissionSnapshot()
+            ),
+            isEnabled: config.enablePushToTalk
+        ) else {
             hotkeyMonitor.stop()
             return
         }
+        guard !hotkeyMonitor.isRunning else { return }
         hotkeyMonitor.configure(config.dictationHotkey)
         hotkeyMonitor.start()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
@@ -17,7 +17,19 @@ enum OnboardingPermissionGate {
         permissions.microphone && permissions.inputMonitoring
     }
 
-    static func hasRequiredPermissions(
+    static func hasRequiredMeetingPermissions(
+        _ permissions: OnboardingPermissionSnapshot,
+        useCoreAudioTap: Bool = true
+    ) -> Bool {
+        permissions.microphone
+            && (useCoreAudioTap ? permissions.systemAudio : permissions.screenRecording)
+    }
+
+    /// Runtime startup remains gated only by permissions needed for the app's
+    /// always-on interaction surfaces. Meeting system audio is requested during
+    /// onboarding, but a later revocation is repaired when meeting capture starts
+    /// instead of trapping an existing user back in onboarding.
+    static func hasRequiredStartupPermissions(
         _ permissions: OnboardingPermissionSnapshot,
         for useCase: OnboardingUseCase
     ) -> Bool {
@@ -30,15 +42,37 @@ enum OnboardingPermissionGate {
         return permissions.microphone
     }
 
+    static func hasRequiredPermissions(
+        _ permissions: OnboardingPermissionSnapshot,
+        for useCase: OnboardingUseCase,
+        useCoreAudioTap: Bool = true
+    ) -> Bool {
+        guard permissions.microphone else { return false }
+        if useCase.includesDictation,
+           (!permissions.accessibility || !permissions.inputMonitoring) {
+            return false
+        }
+        if useCase.includesVoiceNotes, !permissions.inputMonitoring {
+            return false
+        }
+        if useCase.includesMeetings,
+           !hasRequiredMeetingPermissions(permissions, useCoreAudioTap: useCoreAudioTap) {
+            return false
+        }
+        return true
+    }
+
     static func resumeStep(
         requestedStep: Int,
         permissions: OnboardingPermissionSnapshot,
         useCase: OnboardingUseCase,
         permissionsStep: Int,
-        dictationTestStep: Int
+        dictationTestStep: Int,
+        useCoreAudioTap: Bool = true
     ) -> Int {
         let gatedStep = useCase.includesPushToTalk ? dictationTestStep : permissionsStep + 1
-        if requestedStep >= gatedStep && !hasRequiredPermissions(permissions, for: useCase) {
+        if requestedStep >= gatedStep
+            && !hasRequiredPermissions(permissions, for: useCase, useCoreAudioTap: useCoreAudioTap) {
             return permissionsStep
         }
         return requestedStep

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct OnboardingPermissionSnapshot: Equatable {
+struct OnboardingPermissionSnapshot: Equatable, Sendable {
     var microphone: Bool
     var accessibility: Bool
     var inputMonitoring: Bool

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -140,7 +140,8 @@ struct OnboardingView: View {
             permissions: initialPermissions,
             useCase: initialUseCase,
             permissionsStep: Self.permissionsStep,
-            dictationTestStep: Self.dictationTestStep
+            dictationTestStep: Self.dictationTestStep,
+            useCoreAudioTap: appState.config.useCoreAudioTap
         )
         let effectiveInitialStep = OnboardingFlow.normalizedStep(permissionGatedInitialStep, for: initialUseCase)
 
@@ -839,8 +840,9 @@ struct OnboardingView: View {
     // MARK: - Step 3: Permissions (sequential, one at a time)
 
     /// The ordered list of permissions to grant during onboarding.
-    /// Keep this to the core dictation path so first-run setup gets to a
-    /// successful transcription before meeting-specific permissions appear.
+    /// Request the permission union for the capabilities selected during setup.
+    /// Screen Recording remains optional because it enriches meeting context but
+    /// is not required to capture the meeting's audio.
     private var permissionSteps: [(icon: String, name: String, description: String, granted: Bool, action: () -> Void)] {
         var steps: [(String, String, String, Bool, () -> Void)] = [
             ("mic.fill", "Microphone", "Record audio for voice notes, dictation, and meetings", micGranted, {
@@ -864,6 +866,37 @@ struct OnboardingView: View {
                 }
             }),
             ]
+        }
+        if selectedUseCase.includesMeetings {
+            if appState.config.useCoreAudioTap {
+                steps.append((
+                    "speaker.wave.2.fill",
+                    "System Audio",
+                    "Capture meeting audio from other participants",
+                    systemAudioGranted,
+                    {
+                        Task {
+                            let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
+                            await MainActor.run {
+                                self.systemAudioGranted = granted
+                                if granted {
+                                    self.notePermissionGranted("System Audio")
+                                } else {
+                                    self.saveProgress(atStep: self.currentStep)
+                                }
+                            }
+                        }
+                    }
+                ))
+            } else {
+                steps.append((
+                    "rectangle.dashed.badge.record",
+                    "Screen & System Audio",
+                    "Capture meeting audio from other participants",
+                    screenRecordingGranted,
+                    { CGRequestScreenCaptureAccess() }
+                ))
+            }
         }
         return steps
     }
@@ -1077,6 +1110,7 @@ struct OnboardingView: View {
         case "Microphone": return "Privacy_Microphone"
         case "Accessibility": return "Privacy_Accessibility"
         case "Input Monitoring": return "Privacy_ListenEvent"
+        case "System Audio", "Screen & System Audio": return "Privacy_ScreenCapture"
         default: return "Privacy_Microphone"
         }
     }
@@ -1141,7 +1175,8 @@ struct OnboardingView: View {
                 systemAudio: systemAudioGranted,
                 screenRecording: screenRecordingGranted
             ),
-            for: selectedUseCase
+            for: selectedUseCase,
+            useCoreAudioTap: appState.config.useCoreAudioTap
         )
     }
 
@@ -1254,6 +1289,10 @@ struct OnboardingView: View {
             return accessibilityGranted
         case "Input Monitoring":
             return inputMonitoringGranted
+        case "System Audio":
+            return systemAudioGranted
+        case "Screen & System Audio":
+            return screenRecordingGranted
         default:
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum PushToTalkEnablementPolicy {
+    enum Outcome: Equatable {
+        case alreadyEnabled
+        case promote(OnboardingUseCase)
+        case waitForPermissions(OnboardingUseCase)
+    }
+
+    static func shouldStartDictationHotkeyMonitor(
+        hasCompletedOnboarding: Bool,
+        hasRequiredStartupPermissions: Bool,
+        useCase: OnboardingUseCase
+    ) -> Bool {
+        hasCompletedOnboarding && hasRequiredStartupPermissions && useCase.includesPushToTalk
+    }
+
+    static func outcome(
+        currentUseCase: OnboardingUseCase,
+        hasDictationPermissions: Bool
+    ) -> Outcome {
+        if currentUseCase.includesPushToTalk {
+            return .alreadyEnabled
+        }
+        let promoted = currentUseCase.enablingPushToTalk
+        if hasDictationPermissions {
+            return .promote(promoted)
+        }
+        return .waitForPermissions(promoted)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
@@ -1,5 +1,30 @@
 import Foundation
 
+struct PushToTalkEnablementIntentStore {
+    private let defaults: UserDefaults
+    private let key: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        key: String = "pushToTalk.pendingEnable"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    var isPending: Bool {
+        defaults.bool(forKey: key)
+    }
+
+    func markPending() {
+        defaults.set(true, forKey: key)
+    }
+
+    func clear() {
+        defaults.removeObject(forKey: key)
+    }
+}
+
 enum PushToTalkEnablementPolicy {
     enum Outcome: Equatable {
         case alreadyEnabled

--- a/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
@@ -27,30 +27,31 @@ struct PushToTalkEnablementIntentStore {
 
 enum PushToTalkEnablementPolicy {
     enum Outcome: Equatable {
-        case alreadyEnabled
-        case promote(OnboardingUseCase)
-        case waitForPermissions(OnboardingUseCase)
+        case disabled
+        case ready
+        case waitForPermissions
     }
 
     static func shouldStartDictationHotkeyMonitor(
         hasCompletedOnboarding: Bool,
-        hasRequiredStartupPermissions: Bool,
-        useCase: OnboardingUseCase
+        hasDictationPermissions: Bool,
+        isEnabled: Bool
     ) -> Bool {
-        hasCompletedOnboarding && hasRequiredStartupPermissions && useCase.includesPushToTalk
+        hasCompletedOnboarding && hasDictationPermissions && isEnabled
+    }
+
+    static func shouldReconcilePendingEnable(
+        hasCompletedOnboarding: Bool,
+        isPending: Bool
+    ) -> Bool {
+        hasCompletedOnboarding && isPending
     }
 
     static func outcome(
-        currentUseCase: OnboardingUseCase,
+        isEnabled: Bool,
         hasDictationPermissions: Bool
     ) -> Outcome {
-        if currentUseCase.includesPushToTalk {
-            return .alreadyEnabled
-        }
-        let promoted = currentUseCase.enablingPushToTalk
-        if hasDictationPermissions {
-            return .promote(promoted)
-        }
-        return .waitForPermissions(promoted)
+        guard isEnabled else { return .disabled }
+        return hasDictationPermissions ? .ready : .waitForPermissions
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
@@ -26,6 +26,30 @@ struct PushToTalkEnablementIntentStore {
 }
 
 enum PushToTalkEnablementPolicy {
+    enum PermissionProfile: String, Equatable {
+        case voiceNote = "voice_note"
+        case paste = "paste"
+
+        static func resolved(for useCase: OnboardingUseCase) -> Self {
+            useCase.includesVoiceNotes && !useCase.includesDictation
+                ? .voiceNote
+                : .paste
+        }
+
+        func hasRequiredPermissions(_ permissions: OnboardingPermissionSnapshot) -> Bool {
+            switch self {
+            case .voiceNote:
+                OnboardingPermissionGate.hasRequiredVoiceNotesPermissions(permissions)
+            case .paste:
+                OnboardingPermissionGate.hasRequiredDictationPermissions(permissions)
+            }
+        }
+
+        var requiresAccessibility: Bool {
+            self == .paste
+        }
+    }
+
     enum Outcome: Equatable {
         case disabled
         case ready
@@ -34,10 +58,10 @@ enum PushToTalkEnablementPolicy {
 
     static func shouldStartDictationHotkeyMonitor(
         hasCompletedOnboarding: Bool,
-        hasDictationPermissions: Bool,
+        hasRequiredPermissions: Bool,
         isEnabled: Bool
     ) -> Bool {
-        hasCompletedOnboarding && hasDictationPermissions && isEnabled
+        hasCompletedOnboarding && hasRequiredPermissions && isEnabled
     }
 
     static func shouldReconcilePendingEnable(
@@ -49,9 +73,9 @@ enum PushToTalkEnablementPolicy {
 
     static func outcome(
         isEnabled: Bool,
-        hasDictationPermissions: Bool
+        hasRequiredPermissions: Bool
     ) -> Outcome {
         guard isEnabled else { return .disabled }
-        return hasDictationPermissions ? .ready : .waitForPermissions
+        return hasRequiredPermissions ? .ready : .waitForPermissions
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PushToTalkEnablementPolicy.swift
@@ -48,6 +48,12 @@ enum PushToTalkEnablementPolicy {
         var requiresAccessibility: Bool {
             self == .paste
         }
+
+        var missingPermissionsMessage: String {
+            requiresAccessibility
+                ? "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
+                : "Grant Microphone and Input Monitoring to use Push to Talk."
+        }
     }
 
     enum Outcome: Equatable {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -2207,6 +2207,7 @@ struct SettingsView: View {
             accessibilityGranted: accessibilityGranted,
             inputMonitoringGranted: inputMonitoringGranted
         )
+        controller.completePendingPushToTalkEnableIfReady()
         refreshSystemAudioPermissionIfNeeded()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -3009,6 +3009,7 @@ struct SettingsView: View {
             accessibilityGranted: accessibilityGranted,
             inputMonitoringGranted: inputMonitoringGranted
         )
+        controller.completePendingPushToTalkEnableIfReady()
         if reason.refreshesSystemAudio {
             refreshSystemAudioPermissionIfNeeded()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -3009,7 +3009,7 @@ struct SettingsView: View {
             accessibilityGranted: accessibilityGranted,
             inputMonitoringGranted: inputMonitoringGranted
         )
-        controller.completePendingPushToTalkEnableIfReady()
+        controller.reconcilePendingPushToTalkEnableIfReady()
         if reason.refreshesSystemAudio {
             refreshSystemAudioPermissionIfNeeded()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1379,6 +1379,13 @@ struct SettingsView: View {
                     _ = controller.updateQuilModeEnabled(newValue)
                 }
             }
+            if appState.config.enableQuilMode,
+               (!micGranted || !accessibilityGranted || !inputMonitoringGranted) {
+                Text(ShortcutFeatureEnablementPolicy.missingPermissionsMessage)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.transcribing)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
             if appState.config.enableQuilMode {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -21,7 +21,6 @@ private struct MicrophoneOption: Identifiable {
 
 enum SettingsPermissionRefreshReason {
     case initialDisplay
-    case periodicPoll
     case permissionRequested
     case settingsSelected
     case appActivated
@@ -34,7 +33,7 @@ enum SettingsPermissionRefreshReason {
         switch self {
         case .initialDisplay, .settingsSelected, .appActivated:
             true
-        case .periodicPoll, .permissionRequested:
+        case .permissionRequested:
             false
         }
     }
@@ -201,12 +200,8 @@ struct SettingsView: View {
     @State private var downloadedMeetingLiveCaptionBackends: [MeetingLiveCaptionBackend] = []
     @State private var audioInputDevices: [AudioInputDeviceInfo] = []
     @State private var audioInputDeviceRefreshTask: Task<Void, Never>?
-    @State private var permissionPollTimer: Timer?
+    @State private var permissionMonitoringClientID = UUID()
     @State private var isCleanupPromptManagerPresented = false
-    @State private var micGranted = false
-    @State private var accessibilityGranted = false
-    @State private var inputMonitoringGranted = false
-    @State private var screenRecordingGranted = false
     @AppStorage("settings.pendingScreenContextEnable") private var pendingScreenContextEnable = false
     @AppStorage("settings.pendingScreenContextRequestedAt") private var pendingScreenContextRequestedAt = 0.0
     @State private var systemAudioGranted = false
@@ -226,11 +221,26 @@ struct SettingsView: View {
         _selectedPane = State(initialValue: appState.selectedSettingsPane)
     }
 
+    private var micGranted: Bool {
+        appState.interactionPermissionSnapshot?.microphone ?? false
+    }
+
+    private var accessibilityGranted: Bool {
+        appState.interactionPermissionSnapshot?.accessibility ?? false
+    }
+
+    private var inputMonitoringGranted: Bool {
+        appState.interactionPermissionSnapshot?.inputMonitoring ?? false
+    }
+
+    private var screenRecordingGranted: Bool {
+        appState.interactionPermissionSnapshot?.screenRecording ?? false
+    }
+
     // Uniform width for standard right-side controls.
     private let controlWidth: CGFloat = 220
     // Wider controls keep model/provider selections visually consistent in Settings.
     private let meetingControlWidth: CGFloat = 275
-    private let screenContextGrantIntentTimeout: TimeInterval = 15 * 60
     private let meetingDetectionAppOptions: [MeetingDetectionAppOption] = [
         MeetingDetectionAppOption(bundleID: "com.google.Chrome", name: "Chrome", icon: "globe"),
         MeetingDetectionAppOption(bundleID: "company.thebrowser.Browser", name: "Arc", icon: "globe"),
@@ -459,7 +469,7 @@ struct SettingsView: View {
             .onAppear {
                 refreshDownloadedModelOptions()
                 refreshAudioInputDevices()
-                startPermissionPolling()
+                startPermissionMonitoring()
                 if appState.selectedMeetingSummaryBackend == .openRouter {
                     loadOpenRouterFreeModelsIfNeeded()
                 }
@@ -474,7 +484,7 @@ struct SettingsView: View {
                 isPreviewingClip = false
                 audioInputDeviceRefreshTask?.cancel()
                 audioInputDeviceRefreshTask = nil
-                stopPermissionPolling()
+                stopPermissionMonitoring()
             }
             .onChange(of: appState.selectedTab) { _, tab in
                 if tab == .settings {
@@ -1379,9 +1389,10 @@ struct SettingsView: View {
                     _ = controller.updateQuilModeEnabled(newValue)
                 }
             }
-            if appState.config.enableQuilMode,
-               (!micGranted || !accessibilityGranted || !inputMonitoringGranted) {
-                Text(ShortcutFeatureEnablementPolicy.missingPermissionsMessage)
+            if let quilPermissionMessage = controller.independentShortcutPermissionMessageIfNeeded(
+                isEnabled: appState.config.enableQuilMode
+            ) {
+                Text(quilPermissionMessage)
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.transcribing)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -2949,11 +2960,11 @@ struct SettingsView: View {
             pendingScreenContextEnable = true
             pendingScreenContextRequestedAt = Date().timeIntervalSince1970
             let granted = controller.requestScreenContextEnable()
-            accessibilityGranted = AXIsProcessTrusted()
-            if granted || accessibilityGranted {
+            controller.refreshInteractionPermissionSnapshot()
+            if granted {
                 clearPendingScreenContextEnable()
             }
-            return granted || accessibilityGranted
+            return granted
         }
 
         clearPendingScreenContextEnable()
@@ -2966,66 +2977,23 @@ struct SettingsView: View {
         }
     }
 
-    private func startPermissionPolling() {
-        // Keep the 1 Hz poll limited to cheap TCC snapshots. SMAppService can block
-        // the main thread, while probing system audio creates a CoreAudio process
-        // tap and can perturb the HAL. Refresh those only at lifecycle boundaries.
+    private func startPermissionMonitoring() {
+        controller.beginInteractionPermissionMonitoring(clientID: permissionMonitoringClientID)
         refreshPermissionStatuses(for: .initialDisplay)
-        permissionPollTimer?.invalidate()
-        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            refreshPermissionStatuses(for: .periodicPoll)
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        permissionPollTimer = timer
     }
 
-    private func stopPermissionPolling() {
-        permissionPollTimer?.invalidate()
-        permissionPollTimer = nil
+    private func stopPermissionMonitoring() {
+        controller.endInteractionPermissionMonitoring(clientID: permissionMonitoringClientID)
     }
 
     private func refreshPermissionStatuses(for reason: SettingsPermissionRefreshReason) {
-        micGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
-        accessibilityGranted = AXIsProcessTrusted()
-        controller.reconcilePendingDictionaryCorrectionAccessibilityEnable()
-        inputMonitoringGranted = CGPreflightListenEventAccess()
-        screenRecordingGranted = CGPreflightScreenCaptureAccess()
         if reason.refreshesLaunchAtLogin {
             controller.refreshLaunchAtLoginState()
         }
-        if accessibilityGranted && pendingScreenContextEnable {
-            if controller.requestScreenContextEnable() {
-                clearPendingScreenContextEnable()
-            }
-        }
-        if !accessibilityGranted && isPendingScreenContextGrantExpired {
-            clearPendingScreenContextEnable()
-        }
-        if !accessibilityGranted && appState.config.enableScreenContext {
-            clearPendingScreenContextEnable()
-            controller.updateConfig {
-                $0.enableScreenContext = false
-                $0.enableDictationOCRContext = false
-            }
-        }
-        if (!appState.config.enableScreenContext || !screenRecordingGranted) && appState.config.enableDictationOCRContext {
-            controller.updateConfig { $0.enableDictationOCRContext = false }
-        }
-        controller.reclassifyVoiceNotesAsDictationIfReady(
-            microphoneGranted: micGranted,
-            accessibilityGranted: accessibilityGranted,
-            inputMonitoringGranted: inputMonitoringGranted
-        )
-        controller.reconcilePendingPushToTalkEnableIfReady()
+        controller.refreshInteractionPermissionSnapshot()
         if reason.refreshesSystemAudio {
             refreshSystemAudioPermissionIfNeeded()
         }
-    }
-
-    private var isPendingScreenContextGrantExpired: Bool {
-        guard pendingScreenContextEnable else { return false }
-        guard pendingScreenContextRequestedAt > 0 else { return true }
-        return Date().timeIntervalSince1970 - pendingScreenContextRequestedAt > screenContextGrantIntentTimeout
     }
 
     private func clearPendingScreenContextEnable() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutFeatureEnablementPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutFeatureEnablementPolicy.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Runtime availability for shortcuts that record speech and then act on text in
+/// another app. Onboarding intent chooses initial defaults, but must not remain a
+/// permanent eligibility gate after setup.
+enum ShortcutFeatureEnablementPolicy {
+    enum Outcome: Equatable {
+        case disabled
+        case waitForPermissions
+        case ready
+    }
+
+    static let missingPermissionsMessage =
+        "Grant Microphone, Accessibility, and Input Monitoring to use this shortcut."
+
+    static func hasRequiredPermissions(_ permissions: OnboardingPermissionSnapshot) -> Bool {
+        OnboardingPermissionGate.hasRequiredDictationPermissions(permissions)
+    }
+
+    static func outcome(
+        hasCompletedOnboarding: Bool,
+        isEnabled: Bool,
+        permissions: OnboardingPermissionSnapshot
+    ) -> Outcome {
+        guard hasCompletedOnboarding, isEnabled else { return .disabled }
+        return hasRequiredPermissions(permissions) ? .ready : .waitForPermissions
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -38,9 +38,23 @@ struct ShortcutsView: View {
             .padding(.bottom, MuesliTheme.spacing32)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .onAppear {
+            controller.completePendingPushToTalkEnableIfReady()
+        }
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
+            guard !isPushToTalkEnabled else { return }
+            controller.completePendingPushToTalkEnableIfReady()
+            if isPushToTalkEnabled {
+                dictationShortcutMessage = nil
+            }
+        }
         .onDisappear {
             stopRecording()
         }
+    }
+
+    private var isPushToTalkEnabled: Bool {
+        appState.config.resolvedOnboardingUseCase.includesPushToTalk
     }
 
     private enum ShortcutTarget {
@@ -72,6 +86,10 @@ struct ShortcutsView: View {
                 threshold: appState.config.hotkeyTriggerThresholdMS
             ) { value in
                 controller.updateConfig { $0.hotkeyTriggerThresholdMS = value }
+            }
+
+            if !isPushToTalkEnabled {
+                pushToTalkDisabledNotice
             }
 
             if let dictationShortcutMessage {
@@ -274,6 +292,36 @@ struct ShortcutsView: View {
         .help("Hold threshold: \(HotkeyTriggerTiming.minThresholdMilliseconds)-\(HotkeyTriggerTiming.maxThresholdMilliseconds) ms")
     }
 
+    private var pushToTalkDisabledNotice: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Text("Push to Talk is off because setup chose meetings only. Enable dictation to start the hotkey monitor.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            Button {
+                let result = controller.enablePushToTalkIfNeeded(requestPermissions: true)
+                switch result {
+                case .alreadyEnabled, .enabled:
+                    dictationShortcutMessage = nil
+                case .needsPermissions:
+                    dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring, then Push to Talk will turn on."
+                }
+            } label: {
+                Text("Enable Dictation")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, MuesliTheme.spacing8)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+    }
+
     private func shortcutMessage(_ message: String) -> some View {
         Text(message)
             .font(MuesliTheme.caption())
@@ -420,6 +468,11 @@ struct ShortcutsView: View {
         switch target {
         case .dictation:
             result = controller.updateDictationHotkey(config)
+            if result.didUpdate && !isPushToTalkEnabled {
+                dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring, then Push to Talk will turn on."
+                stopRecording()
+                return
+            }
         case .computerUse:
             result = controller.updateComputerUseHotkey(config)
         case .meetingRecording:

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -42,11 +42,11 @@ struct ShortcutsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onAppear {
-            controller.completePendingPushToTalkEnableIfReady()
+            controller.reconcilePendingPushToTalkEnableIfReady()
         }
         .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
             guard !isPushToTalkEnabled else { return }
-            controller.completePendingPushToTalkEnableIfReady()
+            controller.reconcilePendingPushToTalkEnableIfReady()
             if isPushToTalkEnabled {
                 dictationShortcutMessage = nil
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -41,9 +41,23 @@ struct ShortcutsView: View {
             .padding(.bottom, MuesliTheme.spacing32)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .onAppear {
+            controller.completePendingPushToTalkEnableIfReady()
+        }
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
+            guard !isPushToTalkEnabled else { return }
+            controller.completePendingPushToTalkEnableIfReady()
+            if isPushToTalkEnabled {
+                dictationShortcutMessage = nil
+            }
+        }
         .onDisappear {
             stopRecording()
         }
+    }
+
+    private var isPushToTalkEnabled: Bool {
+        appState.config.resolvedOnboardingUseCase.includesPushToTalk
     }
 
     private enum ShortcutTarget {
@@ -76,6 +90,10 @@ struct ShortcutsView: View {
                 threshold: appState.config.hotkeyTriggerThresholdMS
             ) { value in
                 controller.updateConfig { $0.hotkeyTriggerThresholdMS = value }
+            }
+
+            if !isPushToTalkEnabled {
+                pushToTalkDisabledNotice
             }
 
             if let dictationShortcutMessage {
@@ -333,6 +351,36 @@ struct ShortcutsView: View {
         .help("Hold threshold: \(HotkeyTriggerTiming.minThresholdMilliseconds)-\(HotkeyTriggerTiming.maxThresholdMilliseconds) ms")
     }
 
+    private var pushToTalkDisabledNotice: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Text("Push to Talk is off because setup chose meetings only. Enable dictation to start the hotkey monitor.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            Button {
+                let result = controller.enablePushToTalkIfNeeded(requestPermissions: true)
+                switch result {
+                case .alreadyEnabled, .enabled:
+                    dictationShortcutMessage = nil
+                case .needsPermissions:
+                    dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring, then Push to Talk will turn on."
+                }
+            } label: {
+                Text("Enable Dictation")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, MuesliTheme.spacing8)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+    }
+
     private func shortcutMessage(_ message: String) -> some View {
         Text(message)
             .font(MuesliTheme.caption())
@@ -488,6 +536,11 @@ struct ShortcutsView: View {
         switch target {
         case .dictation:
             result = controller.updateDictationHotkey(config)
+            if result.didUpdate && !isPushToTalkEnabled {
+                dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring, then Push to Talk will turn on."
+                stopRecording()
+                return
+            }
         case .computerUse:
             result = controller.updateComputerUseHotkey(config)
         case .quil:

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -57,6 +57,15 @@ struct ShortcutsView: View {
         appState.config.enablePushToTalk
     }
 
+    private var pushToTalkPermissionMessage: String {
+        let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+            for: appState.config.resolvedOnboardingUseCase
+        )
+        return profile.requiresAccessibility
+            ? "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
+            : "Grant Microphone and Input Monitoring to use Push to Talk."
+    }
+
     private enum ShortcutTarget {
         case dictation
         case computerUse
@@ -446,7 +455,7 @@ struct ShortcutsView: View {
         case .alreadyEnabled, .enabled, .disabled:
             dictationShortcutMessage = nil
         case .needsPermissions:
-            dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
+            dictationShortcutMessage = pushToTalkPermissionMessage
         }
     }
 
@@ -456,7 +465,7 @@ struct ShortcutsView: View {
         case .alreadyEnabled, .enabled, .disabled:
             dictationShortcutMessage = nil
         case .needsPermissions:
-            dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
+            dictationShortcutMessage = pushToTalkPermissionMessage
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -42,14 +42,11 @@ struct ShortcutsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onAppear {
-            controller.reconcilePendingPushToTalkEnableIfReady()
+            reconcilePushToTalkState()
         }
         .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
-            guard !isPushToTalkEnabled else { return }
-            controller.reconcilePendingPushToTalkEnableIfReady()
-            if isPushToTalkEnabled {
-                dictationShortcutMessage = nil
-            }
+            guard isPushToTalkEnabled else { return }
+            reconcilePushToTalkState()
         }
         .onDisappear {
             stopRecording()
@@ -57,7 +54,7 @@ struct ShortcutsView: View {
     }
 
     private var isPushToTalkEnabled: Bool {
-        appState.config.resolvedOnboardingUseCase.includesPushToTalk
+        appState.config.enablePushToTalk
     }
 
     private enum ShortcutTarget {
@@ -79,21 +76,27 @@ struct ShortcutsView: View {
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }
                 Spacer()
-                hotkeyBadge(appState.config.dictationHotkey)
+                HStack(spacing: MuesliTheme.spacing8) {
+                    Text(isPushToTalkEnabled ? "On" : "Off")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                    Toggle("Push to Talk", isOn: Binding(
+                        get: { isPushToTalkEnabled },
+                        set: updatePushToTalkEnabled
+                    ))
+                    .toggleStyle(.switch)
+                    .tint(MuesliTheme.accent)
+                    .labelsHidden()
+                }
             }
 
             Divider()
                 .background(MuesliTheme.surfaceBorder)
 
-            shortcutControls(
-                target: .dictation,
-                threshold: appState.config.hotkeyTriggerThresholdMS
-            ) { value in
-                controller.updateConfig { $0.hotkeyTriggerThresholdMS = value }
-            }
+            pushToTalkControls
 
             if !isPushToTalkEnabled {
-                pushToTalkDisabledNotice
+                pushToTalkDisabledMessage
             }
 
             if let dictationShortcutMessage {
@@ -303,6 +306,25 @@ struct ShortcutsView: View {
         }
     }
 
+    private var pushToTalkControls: some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            Text("Shortcut")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            hotkeyBadge(appState.config.dictationHotkey)
+            compactChangeButton(for: .dictation)
+            Spacer(minLength: MuesliTheme.spacing16)
+            thresholdInput(
+                value: appState.config.hotkeyTriggerThresholdMS,
+                label: "Hold duration"
+            ) { value in
+                controller.updateConfig { $0.hotkeyTriggerThresholdMS = value }
+            }
+        }
+        .disabled(!isPushToTalkEnabled)
+        .opacity(isPushToTalkEnabled ? 1 : 0.55)
+    }
+
     private func hotkey(for target: ShortcutTarget) -> HotkeyConfig {
         switch target {
         case .dictation:
@@ -316,9 +338,13 @@ struct ShortcutsView: View {
         }
     }
 
-    private func thresholdInput(value: Int, onChange: @escaping (Int) -> Void) -> some View {
+    private func thresholdInput(
+        value: Int,
+        label: String = "Hold",
+        onChange: @escaping (Int) -> Void
+    ) -> some View {
         HStack(spacing: MuesliTheme.spacing8) {
-            Text("Hold")
+            Text(label)
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textSecondary)
 
@@ -351,34 +377,20 @@ struct ShortcutsView: View {
         .help("Hold threshold: \(HotkeyTriggerTiming.minThresholdMilliseconds)-\(HotkeyTriggerTiming.maxThresholdMilliseconds) ms")
     }
 
-    private var pushToTalkDisabledNotice: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-            Text("Push to Talk is off because setup chose meetings only. Enable dictation to start the hotkey monitor.")
+    private var pushToTalkDisabledMessage: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(MuesliTheme.accent)
+            Text(pushToTalkDisabledMessageText)
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textSecondary)
-            Button {
-                let result = controller.enablePushToTalkIfNeeded(requestPermissions: true)
-                switch result {
-                case .alreadyEnabled, .enabled:
-                    dictationShortcutMessage = nil
-                case .needsPermissions:
-                    dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring, then Push to Talk will turn on."
-                }
-            } label: {
-                Text("Enable Dictation")
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-            }
-            .buttonStyle(.plain)
-            .padding(.horizontal, MuesliTheme.spacing12)
-            .padding(.vertical, MuesliTheme.spacing8)
-            .background(MuesliTheme.surfacePrimary)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-            )
         }
+    }
+
+    private var pushToTalkDisabledMessageText: String {
+        appState.config.resolvedOnboardingUseCase.includesPushToTalk
+            ? "Push to Talk is turned off."
+            : "Dictation wasn’t enabled during setup."
     }
 
     private func shortcutMessage(_ message: String) -> some View {
@@ -408,6 +420,44 @@ struct ShortcutsView: View {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                 .strokeBorder(recordingTarget == target ? MuesliTheme.accent.opacity(0.3) : MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+    }
+
+    private func compactChangeButton(for target: ShortcutTarget) -> some View {
+        Button {
+            if recordingTarget == target {
+                stopRecording()
+            } else {
+                startRecording(target)
+            }
+        } label: {
+            Text(recordingTarget == target ? recordingPrompt(for: target) : "Change…")
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.accent)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func updatePushToTalkEnabled(_ enabled: Bool) {
+        if !enabled, recordingTarget == .dictation {
+            stopRecording()
+        }
+        let result = controller.updatePushToTalkEnabled(enabled, requestPermissions: enabled)
+        switch result {
+        case .alreadyEnabled, .enabled, .disabled:
+            dictationShortcutMessage = nil
+        case .needsPermissions:
+            dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
+        }
+    }
+
+    private func reconcilePushToTalkState() {
+        guard let result = controller.reconcilePendingPushToTalkEnableIfReady() else { return }
+        switch result {
+        case .alreadyEnabled, .enabled, .disabled:
+            dictationShortcutMessage = nil
+        case .needsPermissions:
+            dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
+        }
     }
 
     private func recordingPrompt(for target: ShortcutTarget) -> String {
@@ -536,11 +586,6 @@ struct ShortcutsView: View {
         switch target {
         case .dictation:
             result = controller.updateDictationHotkey(config)
-            if result.didUpdate && !isPushToTalkEnabled {
-                dictationShortcutMessage = "Grant Microphone, Accessibility, and Input Monitoring, then Push to Talk will turn on."
-                stopRecording()
-                return
-            }
         case .computerUse:
             result = controller.updateComputerUseHotkey(config)
         case .quil:

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -43,10 +43,13 @@ struct ShortcutsView: View {
         }
         .onAppear {
             reconcilePushToTalkState()
+            reconcileIndependentShortcutState()
         }
         .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
-            guard isPushToTalkEnabled else { return }
-            reconcilePushToTalkState()
+            if isPushToTalkEnabled {
+                reconcilePushToTalkState()
+            }
+            reconcileIndependentShortcutState()
         }
         .onDisappear {
             stopRecording()
@@ -302,7 +305,7 @@ struct ShortcutsView: View {
     ) -> some View {
         HStack(spacing: MuesliTheme.spacing12) {
             hotkeyBadge(hotkey(for: target))
-            changeButton(for: target)
+            compactChangeButton(for: target)
                 .disabled(!isEnabled)
                 .opacity(isEnabled ? 1 : 0.55)
             Spacer(minLength: MuesliTheme.spacing16)
@@ -408,29 +411,6 @@ struct ShortcutsView: View {
             .foregroundStyle(MuesliTheme.transcribing)
     }
 
-    private func changeButton(for target: ShortcutTarget) -> some View {
-        Button {
-            if recordingTarget == target {
-                stopRecording()
-            } else {
-                startRecording(target)
-            }
-        } label: {
-            Text(recordingTarget == target ? recordingPrompt(for: target) : "Change Shortcut")
-                .font(MuesliTheme.body())
-                .foregroundStyle(recordingTarget == target ? MuesliTheme.accent : MuesliTheme.textPrimary)
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, MuesliTheme.spacing12)
-        .padding(.vertical, MuesliTheme.spacing8)
-        .background(recordingTarget == target ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                .strokeBorder(recordingTarget == target ? MuesliTheme.accent.opacity(0.3) : MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
-    }
-
     private func compactChangeButton(for target: ShortcutTarget) -> some View {
         Button {
             if recordingTarget == target {
@@ -466,6 +446,27 @@ struct ShortcutsView: View {
             dictationShortcutMessage = nil
         case .needsPermissions:
             dictationShortcutMessage = pushToTalkPermissionMessage
+        }
+    }
+
+    private func reconcileIndependentShortcutState() {
+        let permissionMessage = ShortcutFeatureEnablementPolicy.missingPermissionsMessage
+        let computerUsePermissionMessage = controller.independentShortcutPermissionMessageIfNeeded(
+            isEnabled: appState.config.enableComputerUseHotkey
+        )
+        if let computerUsePermissionMessage {
+            computerUseShortcutMessage = computerUsePermissionMessage
+        } else if computerUseShortcutMessage == permissionMessage {
+            computerUseShortcutMessage = nil
+        }
+
+        let quilPermissionMessage = controller.independentShortcutPermissionMessageIfNeeded(
+            isEnabled: appState.config.enableQuilMode
+        )
+        if let quilPermissionMessage {
+            quilShortcutMessage = quilPermissionMessage
+        } else if quilShortcutMessage == permissionMessage {
+            quilShortcutMessage = nil
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -5,6 +5,7 @@ import MuesliCore
 struct ShortcutsView: View {
     let appState: AppState
     let controller: MuesliController
+    @State private var permissionMonitoringClientID = UUID()
     @State private var recordingTarget: ShortcutTarget?
     @State private var eventMonitor: Any?
     @State private var pendingModifierKeyCode: UInt16?
@@ -42,16 +43,17 @@ struct ShortcutsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onAppear {
+            controller.beginInteractionPermissionMonitoring(clientID: permissionMonitoringClientID)
             reconcilePushToTalkState()
             reconcileIndependentShortcutState()
         }
-        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
-            if isPushToTalkEnabled {
-                reconcilePushToTalkState()
-            }
+        .onChange(of: appState.interactionPermissionSnapshot) { _, snapshot in
+            guard let snapshot else { return }
+            reconcilePushToTalkState(permissions: snapshot.onboardingSnapshot)
             reconcileIndependentShortcutState()
         }
         .onDisappear {
+            controller.endInteractionPermissionMonitoring(clientID: permissionMonitoringClientID)
             stopRecording()
         }
     }
@@ -61,12 +63,9 @@ struct ShortcutsView: View {
     }
 
     private var pushToTalkPermissionMessage: String {
-        let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+        PushToTalkEnablementPolicy.PermissionProfile.resolved(
             for: appState.config.resolvedOnboardingUseCase
-        )
-        return profile.requiresAccessibility
-            ? "Grant Microphone, Accessibility, and Input Monitoring to use Push to Talk."
-            : "Grant Microphone and Input Monitoring to use Push to Talk."
+        ).missingPermissionsMessage
     }
 
     private enum ShortcutTarget {
@@ -439,13 +438,30 @@ struct ShortcutsView: View {
         }
     }
 
-    private func reconcilePushToTalkState() {
-        guard let result = controller.reconcilePendingPushToTalkEnableIfReady() else { return }
-        switch result {
-        case .alreadyEnabled, .enabled, .disabled:
-            dictationShortcutMessage = nil
-        case .needsPermissions:
-            dictationShortcutMessage = pushToTalkPermissionMessage
+    private func reconcilePushToTalkState(
+        permissions: OnboardingPermissionSnapshot? = nil
+    ) {
+        if let result = controller.reconcilePendingPushToTalkEnableIfReady(permissions: permissions) {
+            switch result {
+            case .alreadyEnabled, .enabled, .disabled:
+                dictationShortcutMessage = nil
+            case .needsPermissions:
+                dictationShortcutMessage = pushToTalkPermissionMessage
+            }
+            return
+        }
+
+        guard isPushToTalkEnabled, let permissions else { return }
+        let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(
+            for: appState.config.resolvedOnboardingUseCase
+        )
+        if profile.hasRequiredPermissions(permissions) {
+            if dictationShortcutMessage == profile.missingPermissionsMessage {
+                dictationShortcutMessage = nil
+            }
+        } else if dictationShortcutMessage == nil
+                    || dictationShortcutMessage == profile.missingPermissionsMessage {
+            dictationShortcutMessage = profile.missingPermissionsMessage
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/InteractionPermissionMonitorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InteractionPermissionMonitorTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+private final class PermissionReaderThreadProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var capturedOnMainThread = false
+
+    func recordCaptureThread() {
+        lock.lock()
+        capturedOnMainThread = Thread.isMainThread
+        lock.unlock()
+    }
+
+    var wasCapturedOnMainThread: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedOnMainThread
+    }
+}
+
+@MainActor
+private final class PermissionSnapshotDeliveryRecorder {
+    var snapshots: [InteractionPermissionSnapshot] = []
+    var deliveredOnMainThread = false
+
+    func record(_ snapshot: InteractionPermissionSnapshot) {
+        snapshots.append(snapshot)
+        deliveredOnMainThread = Thread.isMainThread
+    }
+}
+
+@Suite("Interaction permission monitor")
+struct InteractionPermissionMonitorTests {
+    private let snapshot = InteractionPermissionSnapshot(
+        microphone: true,
+        accessibility: false,
+        inputMonitoring: true,
+        screenRecording: false
+    )
+
+    @Test("captures off-main and delivers changes on the main actor")
+    @MainActor
+    func capturesOffMainAndDeliversOnMainActor() async {
+        let probe = PermissionReaderThreadProbe()
+        let recorder = PermissionSnapshotDeliveryRecorder()
+        let expectedSnapshot = snapshot
+        let monitor = InteractionPermissionMonitor(
+            readSnapshot: {
+                probe.recordCaptureThread()
+                return expectedSnapshot
+            },
+            onChange: { snapshot in
+                recorder.record(snapshot)
+            }
+        )
+
+        await monitor.refresh()
+
+        #expect(probe.wasCapturedOnMainThread == false)
+        #expect(recorder.deliveredOnMainThread)
+        #expect(recorder.snapshots == [expectedSnapshot])
+    }
+
+    @Test("does not republish an unchanged snapshot")
+    @MainActor
+    func suppressesUnchangedSnapshots() async {
+        let recorder = PermissionSnapshotDeliveryRecorder()
+        let expectedSnapshot = snapshot
+        let monitor = InteractionPermissionMonitor(
+            readSnapshot: { expectedSnapshot },
+            onChange: { snapshot in
+                recorder.record(snapshot)
+            }
+        )
+
+        await monitor.refresh()
+        await monitor.refresh()
+
+        #expect(recorder.snapshots == [expectedSnapshot])
+    }
+
+    @Test("maps interaction permissions into the shared onboarding snapshot")
+    func mapsToOnboardingSnapshot() {
+        #expect(snapshot.onboardingSnapshot == OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        ))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/InteractionPermissionMonitorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InteractionPermissionMonitorTests.swift
@@ -19,6 +19,49 @@ private final class PermissionReaderThreadProbe: @unchecked Sendable {
     }
 }
 
+private final class OutOfOrderPermissionReader: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseFirstRead = DispatchSemaphore(value: 0)
+    private let olderSnapshot: InteractionPermissionSnapshot
+    private let newerSnapshot: InteractionPermissionSnapshot
+    private var readCount = 0
+    private var firstReadStarted = false
+
+    init(
+        olderSnapshot: InteractionPermissionSnapshot,
+        newerSnapshot: InteractionPermissionSnapshot
+    ) {
+        self.olderSnapshot = olderSnapshot
+        self.newerSnapshot = newerSnapshot
+    }
+
+    func read() -> InteractionPermissionSnapshot {
+        lock.lock()
+        let readIndex = readCount
+        readCount += 1
+        if readIndex == 0 {
+            firstReadStarted = true
+        }
+        lock.unlock()
+
+        if readIndex == 0 {
+            releaseFirstRead.wait()
+            return olderSnapshot
+        }
+        return newerSnapshot
+    }
+
+    var hasStartedFirstRead: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return firstReadStarted
+    }
+
+    func releaseFirst() {
+        releaseFirstRead.signal()
+    }
+}
+
 @MainActor
 private final class PermissionSnapshotDeliveryRecorder {
     var snapshots: [InteractionPermissionSnapshot] = []
@@ -80,6 +123,45 @@ struct InteractionPermissionMonitorTests {
         #expect(recorder.snapshots == [expectedSnapshot])
     }
 
+    @Test("discards an older capture that completes after a newer capture")
+    @MainActor
+    func discardsOutOfOrderCapture() async {
+        let olderSnapshot = InteractionPermissionSnapshot(
+            microphone: false,
+            accessibility: false,
+            inputMonitoring: false,
+            screenRecording: false
+        )
+        let newerSnapshot = snapshot
+        let reader = OutOfOrderPermissionReader(
+            olderSnapshot: olderSnapshot,
+            newerSnapshot: newerSnapshot
+        )
+        let recorder = PermissionSnapshotDeliveryRecorder()
+        let monitor = InteractionPermissionMonitor(
+            readSnapshot: { reader.read() },
+            onChange: { snapshot in
+                recorder.record(snapshot)
+            }
+        )
+
+        let firstRefresh = Task { await monitor.refresh() }
+        let firstReadStarted = await waitUntil { reader.hasStartedFirstRead }
+        #expect(firstReadStarted)
+        guard firstReadStarted else {
+            reader.releaseFirst()
+            await firstRefresh.value
+            return
+        }
+
+        let secondRefresh = Task { await monitor.refresh() }
+        await secondRefresh.value
+        reader.releaseFirst()
+        await firstRefresh.value
+
+        #expect(recorder.snapshots == [newerSnapshot])
+    }
+
     @Test("maps interaction permissions into the shared onboarding snapshot")
     func mapsToOnboardingSnapshot() {
         #expect(snapshot.onboardingSnapshot == OnboardingPermissionSnapshot(
@@ -89,5 +171,17 @@ struct InteractionPermissionMonitorTests {
             systemAudio: false,
             screenRecording: false
         ))
+    }
+
+    @MainActor
+    private func waitUntil(_ condition: () -> Bool) async -> Bool {
+        for _ in 0..<100 {
+            if condition() {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1623,6 +1623,17 @@ struct AppConfigTests {
         #expect(!OnboardingUseCase.voiceNotes.canSwitchToVoiceNotesOnly)
     }
 
+    @Test("meetings-only can opt into push-to-talk without dropping meetings")
+    func meetingsOnlyCanEnablePushToTalk() {
+        #expect(!OnboardingUseCase.meetings.includesPushToTalk)
+        #expect(OnboardingUseCase.meetings.enablingPushToTalk == .dictationAndMeetings)
+        #expect(OnboardingUseCase.meetings.enablingPushToTalk.includesPushToTalk)
+        #expect(OnboardingUseCase.meetings.enablingPushToTalk.includesMeetings)
+        #expect(OnboardingUseCase.dictation.enablingPushToTalk == .dictation)
+        #expect(OnboardingUseCase.voiceNotes.enablingPushToTalk == .voiceNotes)
+        #expect(OnboardingUseCase.dictationAndMeetings.enablingPushToTalk == .dictationAndMeetings)
+    }
+
     @Test("scheduled meeting notifications inherit legacy detection opt-out")
     func scheduledMeetingNotificationsInheritLegacyDetectionOptOut() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1898,6 +1898,20 @@ struct AppConfigTests {
         #expect(OnboardingUseCase.dictation.toggling(.dictation) == .dictation)
     }
 
+    @Test("meetings-only can opt into push-to-talk without dropping meetings")
+    func meetingsOnlyCanEnablePushToTalk() {
+        #expect(!OnboardingUseCase.meetings.includesPushToTalk)
+        #expect(OnboardingUseCase.meetings.enablingPushToTalk == .dictationAndMeetings)
+        #expect(OnboardingUseCase.meetings.enablingPushToTalk.includesPushToTalk)
+        #expect(OnboardingUseCase.meetings.enablingPushToTalk.includesMeetings)
+        #expect(OnboardingUseCase.dictation.enablingPushToTalk == .dictation)
+        #expect(OnboardingUseCase.voiceNotes.enablingPushToTalk == .voiceNotes)
+        #expect(OnboardingUseCase.voiceNotesAndDictation.enablingPushToTalk == .voiceNotesAndDictation)
+        #expect(OnboardingUseCase.voiceNotesAndMeetings.enablingPushToTalk == .voiceNotesAndMeetings)
+        #expect(OnboardingUseCase.dictationAndMeetings.enablingPushToTalk == .dictationAndMeetings)
+        #expect(OnboardingUseCase.everything.enablingPushToTalk == .everything)
+    }
+
     @Test("scheduled meeting notifications inherit legacy detection opt-out")
     func scheduledMeetingNotificationsInheritLegacyDetectionOptOut() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1091,6 +1091,7 @@ struct AppConfigTests {
         config.userName = "Test User"
         config.hasCompletedOnboarding = true
         config.onboardingUseCase = OnboardingUseCase.dictationAndMeetings.rawValue
+        config.enablePushToTalk = false
         config.cohereLanguage = CohereTranscribeLanguage.german.rawValue
         config.indicASRLanguage = IndicASRLanguage.tamil.rawValue
         config.appleSpeechLanguage = "en-GB"
@@ -1173,6 +1174,7 @@ struct AppConfigTests {
         #expect(decoded.userName == "Test User")
         #expect(decoded.hasCompletedOnboarding == true)
         #expect(decoded.resolvedOnboardingUseCase == .dictationAndMeetings)
+        #expect(decoded.enablePushToTalk == false)
         #expect(decoded.cohereLanguage == CohereTranscribeLanguage.german.rawValue)
         #expect(decoded.indicASRLanguage == IndicASRLanguage.tamil.rawValue)
         #expect(decoded.appleSpeechLanguage == "en-GB")
@@ -1275,6 +1277,7 @@ struct AppConfigTests {
         #expect(json["indicator_anchor"] != nil)
         #expect(json["has_completed_onboarding"] != nil)
         #expect(json["onboarding_use_case"] != nil)
+        #expect(json["enable_push_to_talk"] != nil)
         #expect(json["user_name"] != nil)
         #expect(json["default_meeting_template_id"] != nil)
         #expect(json["meeting_recording_save_policy"] != nil)
@@ -1898,18 +1901,32 @@ struct AppConfigTests {
         #expect(OnboardingUseCase.dictation.toggling(.dictation) == .dictation)
     }
 
-    @Test("meetings-only can opt into push-to-talk without dropping meetings")
-    func meetingsOnlyCanEnablePushToTalk() {
-        #expect(!OnboardingUseCase.meetings.includesPushToTalk)
-        #expect(OnboardingUseCase.meetings.enablingPushToTalk == .dictationAndMeetings)
-        #expect(OnboardingUseCase.meetings.enablingPushToTalk.includesPushToTalk)
-        #expect(OnboardingUseCase.meetings.enablingPushToTalk.includesMeetings)
-        #expect(OnboardingUseCase.dictation.enablingPushToTalk == .dictation)
-        #expect(OnboardingUseCase.voiceNotes.enablingPushToTalk == .voiceNotes)
-        #expect(OnboardingUseCase.voiceNotesAndDictation.enablingPushToTalk == .voiceNotesAndDictation)
-        #expect(OnboardingUseCase.voiceNotesAndMeetings.enablingPushToTalk == .voiceNotesAndMeetings)
-        #expect(OnboardingUseCase.dictationAndMeetings.enablingPushToTalk == .dictationAndMeetings)
-        #expect(OnboardingUseCase.everything.enablingPushToTalk == .everything)
+    @Test("legacy Push to Talk state migrates from the onboarding use case")
+    func legacyPushToTalkStateMigratesFromOnboardingUseCase() throws {
+        let meetings = try JSONDecoder().decode(
+            AppConfig.self,
+            from: Data(#"{"has_completed_onboarding":true,"onboarding_use_case":"meetings"}"#.utf8)
+        )
+        let dictation = try JSONDecoder().decode(
+            AppConfig.self,
+            from: Data(#"{"has_completed_onboarding":true,"onboarding_use_case":"dictation"}"#.utf8)
+        )
+
+        #expect(!meetings.enablePushToTalk)
+        #expect(dictation.enablePushToTalk)
+    }
+
+    @Test("explicit Push to Talk state is independent from onboarding intent")
+    func explicitPushToTalkStateIsIndependentFromOnboardingIntent() throws {
+        let config = try JSONDecoder().decode(
+            AppConfig.self,
+            from: Data(
+                #"{"has_completed_onboarding":true,"onboarding_use_case":"meetings","enable_push_to_talk":true}"#.utf8
+            )
+        )
+
+        #expect(config.resolvedOnboardingUseCase == .meetings)
+        #expect(config.enablePushToTalk)
     }
 
     @Test("scheduled meeting notifications inherit legacy detection opt-out")

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
@@ -212,8 +212,31 @@ struct OnboardingProgressTests {
         #expect(step == 3)
     }
 
-    @Test("meetings-only does not require input monitoring")
-    func meetingsOnlyDoesNotRequireInputMonitoring() {
+    @Test("meetings-only requires system audio but not input monitoring")
+    func meetingsOnlyRequiresSystemAudioButNotInputMonitoring() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: false,
+            systemAudio: true,
+            screenRecording: false
+        )
+
+        let step = OnboardingPermissionGate.resumeStep(
+            requestedStep: 5,
+            permissions: permissions,
+            useCase: .meetings,
+            permissionsStep: 3,
+            dictationTestStep: 4
+        )
+
+        #expect(OnboardingPermissionGate.hasRequiredMeetingPermissions(permissions))
+        #expect(OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .meetings))
+        #expect(step == 5)
+    }
+
+    @Test("meetings-only cannot leave permissions without system audio")
+    func meetingsOnlyMissingSystemAudioResumesAtPermissionsStep() {
         let permissions = OnboardingPermissionSnapshot(
             microphone: true,
             accessibility: false,
@@ -230,8 +253,32 @@ struct OnboardingProgressTests {
             dictationTestStep: 4
         )
 
-        #expect(OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .meetings))
-        #expect(step == 5)
+        #expect(!OnboardingPermissionGate.hasRequiredMeetingPermissions(permissions))
+        #expect(!OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .meetings))
+        #expect(OnboardingPermissionGate.hasRequiredStartupPermissions(permissions, for: .meetings))
+        #expect(step == 3)
+    }
+
+    @Test("ScreenCaptureKit meetings require Screen Recording instead of the CoreAudio permission")
+    func screenCaptureKitMeetingsRequireScreenRecording() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: false,
+            systemAudio: false,
+            screenRecording: true
+        )
+
+        #expect(OnboardingPermissionGate.hasRequiredMeetingPermissions(
+            permissions,
+            useCoreAudioTap: false
+        ))
+        #expect(OnboardingPermissionGate.hasRequiredPermissions(
+            permissions,
+            for: .meetings,
+            useCoreAudioTap: false
+        ))
+        #expect(!OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .meetings))
     }
 
     @Test("voice notes require microphone and input monitoring")
@@ -285,16 +332,23 @@ struct OnboardingProgressTests {
             microphone: true,
             accessibility: false,
             inputMonitoring: true,
-            systemAudio: false,
+            systemAudio: true,
             screenRecording: false
         )
         #expect(OnboardingPermissionGate.hasRequiredPermissions(voiceAndMeetings, for: .voiceNotesAndMeetings))
+
+        var voiceAndMeetingsWithoutSystemAudio = voiceAndMeetings
+        voiceAndMeetingsWithoutSystemAudio.systemAudio = false
+        #expect(!OnboardingPermissionGate.hasRequiredPermissions(
+            voiceAndMeetingsWithoutSystemAudio,
+            for: .voiceNotesAndMeetings
+        ))
 
         let everythingWithoutAccessibility = OnboardingPermissionSnapshot(
             microphone: true,
             accessibility: false,
             inputMonitoring: true,
-            systemAudio: false,
+            systemAudio: true,
             screenRecording: false
         )
         #expect(!OnboardingPermissionGate.hasRequiredPermissions(everythingWithoutAccessibility, for: .everything))

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -1,0 +1,72 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("PushToTalkEnablementPolicy")
+struct PushToTalkEnablementPolicyTests {
+
+    @Test("meetings-only onboarding does not start the dictation hotkey monitor")
+    func meetingsOnlyDoesNotStartDictationMonitor() {
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .meetings
+        ))
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .dictation
+        ))
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .dictationAndMeetings
+        ))
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .voiceNotes
+        ))
+    }
+
+    @Test("incomplete onboarding never starts the dictation hotkey monitor")
+    func incompleteOnboardingDoesNotStartDictationMonitor() {
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: false,
+            hasRequiredStartupPermissions: true,
+            useCase: .dictation
+        ))
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: false,
+            useCase: .dictation
+        ))
+    }
+
+    @Test("enabling push-to-talk waits for dictation permissions before promoting meetings")
+    func enableWaitsForDictationPermissions() {
+        #expect(
+            PushToTalkEnablementPolicy.outcome(
+                currentUseCase: .meetings,
+                hasDictationPermissions: false
+            ) == .waitForPermissions(.dictationAndMeetings)
+        )
+        #expect(
+            PushToTalkEnablementPolicy.outcome(
+                currentUseCase: .meetings,
+                hasDictationPermissions: true
+            ) == .promote(.dictationAndMeetings)
+        )
+    }
+
+    @Test("push-to-talk use cases are already enabled")
+    func pushToTalkUseCasesAreAlreadyEnabled() {
+        for useCase: OnboardingUseCase in [.dictation, .dictationAndMeetings, .voiceNotes] {
+            #expect(
+                PushToTalkEnablementPolicy.outcome(
+                    currentUseCase: useCase,
+                    hasDictationPermissions: false
+                ) == .alreadyEnabled
+            )
+        }
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("PushToTalkEnablementPolicy")
+struct PushToTalkEnablementPolicyTests {
+
+    @Test("meetings-only onboarding does not start the dictation hotkey monitor")
+    func meetingsOnlyDoesNotStartDictationMonitor() {
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .meetings
+        ))
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .dictation
+        ))
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .dictationAndMeetings
+        ))
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: true,
+            useCase: .voiceNotes
+        ))
+    }
+
+    @Test("incomplete onboarding never starts the dictation hotkey monitor")
+    func incompleteOnboardingDoesNotStartDictationMonitor() {
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: false,
+            hasRequiredStartupPermissions: true,
+            useCase: .dictation
+        ))
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredStartupPermissions: false,
+            useCase: .dictation
+        ))
+    }
+
+    @Test("enabling push-to-talk waits for dictation permissions before promoting meetings")
+    func enableWaitsForDictationPermissions() {
+        #expect(
+            PushToTalkEnablementPolicy.outcome(
+                currentUseCase: .meetings,
+                hasDictationPermissions: false
+            ) == .waitForPermissions(.dictationAndMeetings)
+        )
+        #expect(
+            PushToTalkEnablementPolicy.outcome(
+                currentUseCase: .meetings,
+                hasDictationPermissions: true
+            ) == .promote(.dictationAndMeetings)
+        )
+    }
+
+    @Test("push-to-talk use cases are already enabled")
+    func pushToTalkUseCasesAreAlreadyEnabled() {
+        for useCase: OnboardingUseCase in [
+            .voiceNotes,
+            .dictation,
+            .voiceNotesAndDictation,
+            .voiceNotesAndMeetings,
+            .dictationAndMeetings,
+            .everything,
+        ] {
+            #expect(
+                PushToTalkEnablementPolicy.outcome(
+                    currentUseCase: useCase,
+                    hasDictationPermissions: false
+                ) == .alreadyEnabled
+            )
+        }
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -5,27 +5,17 @@ import Testing
 @Suite("PushToTalkEnablementPolicy")
 struct PushToTalkEnablementPolicyTests {
 
-    @Test("meetings-only onboarding does not start the dictation hotkey monitor")
-    func meetingsOnlyDoesNotStartDictationMonitor() {
+    @Test("disabled Push to Talk does not start the dictation hotkey monitor")
+    func disabledPushToTalkDoesNotStartDictationMonitor() {
         #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: true,
-            hasRequiredStartupPermissions: true,
-            useCase: .meetings
+            hasDictationPermissions: true,
+            isEnabled: false
         ))
         #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: true,
-            hasRequiredStartupPermissions: true,
-            useCase: .dictation
-        ))
-        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
-            hasCompletedOnboarding: true,
-            hasRequiredStartupPermissions: true,
-            useCase: .dictationAndMeetings
-        ))
-        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
-            hasCompletedOnboarding: true,
-            hasRequiredStartupPermissions: true,
-            useCase: .voiceNotes
+            hasDictationPermissions: true,
+            isEnabled: true
         ))
     }
 
@@ -33,52 +23,59 @@ struct PushToTalkEnablementPolicyTests {
     func incompleteOnboardingDoesNotStartDictationMonitor() {
         #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: false,
-            hasRequiredStartupPermissions: true,
-            useCase: .dictation
+            hasDictationPermissions: true,
+            isEnabled: true
         ))
         #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: true,
-            hasRequiredStartupPermissions: false,
-            useCase: .dictation
+            hasDictationPermissions: false,
+            isEnabled: true
         ))
     }
 
-    @Test("enabling push-to-talk waits for dictation permissions before promoting meetings")
+    @Test("enabled Push to Talk waits for dictation permissions")
     func enableWaitsForDictationPermissions() {
         #expect(
             PushToTalkEnablementPolicy.outcome(
-                currentUseCase: .meetings,
+                isEnabled: true,
                 hasDictationPermissions: false
-            ) == .waitForPermissions(.dictationAndMeetings)
+            ) == .waitForPermissions
         )
         #expect(
             PushToTalkEnablementPolicy.outcome(
-                currentUseCase: .meetings,
+                isEnabled: true,
                 hasDictationPermissions: true
-            ) == .promote(.dictationAndMeetings)
+            ) == .ready
         )
     }
 
-    @Test("push-to-talk use cases are already enabled")
-    func pushToTalkUseCasesAreAlreadyEnabled() {
-        for useCase: OnboardingUseCase in [
-            .voiceNotes,
-            .dictation,
-            .voiceNotesAndDictation,
-            .voiceNotesAndMeetings,
-            .dictationAndMeetings,
-            .everything,
-        ] {
-            #expect(
-                PushToTalkEnablementPolicy.outcome(
-                    currentUseCase: useCase,
-                    hasDictationPermissions: false
-                ) == .alreadyEnabled
-            )
-        }
+    @Test("disabled Push to Talk remains disabled regardless of permissions")
+    func disabledPushToTalkRemainsDisabled() {
+        #expect(
+            PushToTalkEnablementPolicy.outcome(
+                isEnabled: false,
+                hasDictationPermissions: true
+            ) == .disabled
+        )
     }
 
-    @Test("pending enablement survives controller recreation and can promote meetings")
+    @Test("permission reconciliation stops after pending enablement clears")
+    func reconciliationOnlyRunsWhileEnablementIsPending() {
+        #expect(PushToTalkEnablementPolicy.shouldReconcilePendingEnable(
+            hasCompletedOnboarding: true,
+            isPending: true
+        ))
+        #expect(!PushToTalkEnablementPolicy.shouldReconcilePendingEnable(
+            hasCompletedOnboarding: true,
+            isPending: false
+        ))
+        #expect(!PushToTalkEnablementPolicy.shouldReconcilePendingEnable(
+            hasCompletedOnboarding: false,
+            isPending: true
+        ))
+    }
+
+    @Test("pending enablement survives controller recreation")
     func pendingEnablementSurvivesRestart() throws {
         let suiteName = "PushToTalkEnablementIntentStoreTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -90,9 +87,9 @@ struct PushToTalkEnablementPolicyTests {
         #expect(relaunchedStore.isPending)
         #expect(
             PushToTalkEnablementPolicy.outcome(
-                currentUseCase: .meetings,
+                isEnabled: true,
                 hasDictationPermissions: true
-            ) == .promote(.dictationAndMeetings)
+            ) == .ready
         )
 
         relaunchedStore.clear()

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -72,6 +72,7 @@ struct PushToTalkEnablementPolicyTests {
         for useCase in [OnboardingUseCase.voiceNotes, .voiceNotesAndMeetings] {
             let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(for: useCase)
             #expect(profile == .voiceNote)
+            #expect(!profile.requiresAccessibility)
             #expect(profile.hasRequiredPermissions(permissions))
         }
     }
@@ -95,6 +96,7 @@ struct PushToTalkEnablementPolicyTests {
         ] {
             let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(for: useCase)
             #expect(profile == .paste)
+            #expect(profile.requiresAccessibility)
             #expect(!profile.hasRequiredPermissions(permissions))
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -9,12 +9,12 @@ struct PushToTalkEnablementPolicyTests {
     func disabledPushToTalkDoesNotStartDictationMonitor() {
         #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: true,
-            hasDictationPermissions: true,
+            hasRequiredPermissions: true,
             isEnabled: false
         ))
         #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: true,
-            hasDictationPermissions: true,
+            hasRequiredPermissions: true,
             isEnabled: true
         ))
     }
@@ -23,12 +23,12 @@ struct PushToTalkEnablementPolicyTests {
     func incompleteOnboardingDoesNotStartDictationMonitor() {
         #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: false,
-            hasDictationPermissions: true,
+            hasRequiredPermissions: true,
             isEnabled: true
         ))
         #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
             hasCompletedOnboarding: true,
-            hasDictationPermissions: false,
+            hasRequiredPermissions: false,
             isEnabled: true
         ))
     }
@@ -38,13 +38,13 @@ struct PushToTalkEnablementPolicyTests {
         #expect(
             PushToTalkEnablementPolicy.outcome(
                 isEnabled: true,
-                hasDictationPermissions: false
+                hasRequiredPermissions: false
             ) == .waitForPermissions
         )
         #expect(
             PushToTalkEnablementPolicy.outcome(
                 isEnabled: true,
-                hasDictationPermissions: true
+                hasRequiredPermissions: true
             ) == .ready
         )
     }
@@ -54,9 +54,49 @@ struct PushToTalkEnablementPolicyTests {
         #expect(
             PushToTalkEnablementPolicy.outcome(
                 isEnabled: false,
-                hasDictationPermissions: true
+                hasRequiredPermissions: true
             ) == .disabled
         )
+    }
+
+    @Test("Voice Notes Push to Talk does not require Accessibility")
+    func voiceNotesPushToTalkDoesNotRequireAccessibility() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+
+        for useCase in [OnboardingUseCase.voiceNotes, .voiceNotesAndMeetings] {
+            let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(for: useCase)
+            #expect(profile == .voiceNote)
+            #expect(profile.hasRequiredPermissions(permissions))
+        }
+    }
+
+    @Test("paste-output Push to Talk requires Accessibility")
+    func pasteOutputPushToTalkRequiresAccessibility() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+
+        for useCase in [
+            OnboardingUseCase.dictation,
+            .meetings,
+            .voiceNotesAndDictation,
+            .dictationAndMeetings,
+            .everything,
+        ] {
+            let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(for: useCase)
+            #expect(profile == .paste)
+            #expect(!profile.hasRequiredPermissions(permissions))
+        }
     }
 
     @Test("permission reconciliation stops after pending enablement clears")
@@ -88,7 +128,7 @@ struct PushToTalkEnablementPolicyTests {
         #expect(
             PushToTalkEnablementPolicy.outcome(
                 isEnabled: true,
-                hasDictationPermissions: true
+                hasRequiredPermissions: true
             ) == .ready
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import MuesliNativeApp
 
@@ -75,5 +76,26 @@ struct PushToTalkEnablementPolicyTests {
                 ) == .alreadyEnabled
             )
         }
+    }
+
+    @Test("pending enablement survives controller recreation and can promote meetings")
+    func pendingEnablementSurvivesRestart() throws {
+        let suiteName = "PushToTalkEnablementIntentStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        PushToTalkEnablementIntentStore(defaults: defaults).markPending()
+
+        let relaunchedStore = PushToTalkEnablementIntentStore(defaults: defaults)
+        #expect(relaunchedStore.isPending)
+        #expect(
+            PushToTalkEnablementPolicy.outcome(
+                currentUseCase: .meetings,
+                hasDictationPermissions: true
+            ) == .promote(.dictationAndMeetings)
+        )
+
+        relaunchedStore.clear()
+        #expect(!PushToTalkEnablementIntentStore(defaults: defaults).isPending)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PushToTalkEnablementPolicyTests.swift
@@ -59,6 +59,40 @@ struct PushToTalkEnablementPolicyTests {
         )
     }
 
+    @Test("permission revocation makes an enabled Push to Talk monitor unavailable")
+    func permissionRevocationStopsRuntimeAvailability() {
+        let grantedPermissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: true,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+        let revokedPermissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+        let profile = PushToTalkEnablementPolicy.PermissionProfile.resolved(for: .dictation)
+
+        #expect(PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredPermissions: profile.hasRequiredPermissions(grantedPermissions),
+            isEnabled: true
+        ))
+        #expect(!PushToTalkEnablementPolicy.shouldStartDictationHotkeyMonitor(
+            hasCompletedOnboarding: true,
+            hasRequiredPermissions: profile.hasRequiredPermissions(revokedPermissions),
+            isEnabled: true
+        ))
+        #expect(PushToTalkEnablementPolicy.outcome(
+            isEnabled: true,
+            hasRequiredPermissions: profile.hasRequiredPermissions(revokedPermissions)
+        ) == .waitForPermissions)
+    }
+
     @Test("Voice Notes Push to Talk does not require Accessibility")
     func voiceNotesPushToTalkDoesNotRequireAccessibility() {
         let permissions = OnboardingPermissionSnapshot(

--- a/native/MuesliNative/Tests/MuesliTests/SettingsPermissionRefreshReasonTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SettingsPermissionRefreshReasonTests.swift
@@ -3,10 +3,8 @@ import Testing
 
 @Suite("Settings permission refresh reasons")
 struct SettingsPermissionRefreshReasonTests {
-    @Test("periodic polling reuses the cached system-audio permission")
-    func periodicPollingReusesSystemAudioCache() {
-        #expect(SettingsPermissionRefreshReason.periodicPoll.refreshesSystemAudio == false)
-        #expect(SettingsPermissionRefreshReason.periodicPoll.refreshesLaunchAtLogin == false)
+    @Test("permission requests reuse lifecycle-managed state")
+    func permissionRequestsReuseLifecycleManagedState() {
         #expect(SettingsPermissionRefreshReason.permissionRequested.refreshesSystemAudio == false)
         #expect(SettingsPermissionRefreshReason.permissionRequested.refreshesLaunchAtLogin == false)
     }

--- a/native/MuesliNative/Tests/MuesliTests/ShortcutFeatureEnablementPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ShortcutFeatureEnablementPolicyTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("ShortcutFeatureEnablementPolicy")
+struct ShortcutFeatureEnablementPolicyTests {
+    private let allShortcutPermissions = OnboardingPermissionSnapshot(
+        microphone: true,
+        accessibility: true,
+        inputMonitoring: true,
+        systemAudio: false,
+        screenRecording: false
+    )
+
+    @Test("enabled shortcut is ready regardless of original onboarding use case")
+    func enabledShortcutUsesCurrentPermissions() {
+        #expect(ShortcutFeatureEnablementPolicy.outcome(
+            hasCompletedOnboarding: true,
+            isEnabled: true,
+            permissions: allShortcutPermissions
+        ) == .ready)
+    }
+
+    @Test("permission grants do not enable a shortcut whose toggle is off")
+    func permissionsDoNotChangeFeaturePreference() {
+        #expect(ShortcutFeatureEnablementPolicy.outcome(
+            hasCompletedOnboarding: true,
+            isEnabled: false,
+            permissions: allShortcutPermissions
+        ) == .disabled)
+    }
+
+    @Test("enabled shortcut waits until all interaction permissions are granted")
+    func enabledShortcutWaitsForPermissions() {
+        let missingAccessibility = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: true,
+            screenRecording: true
+        )
+
+        #expect(ShortcutFeatureEnablementPolicy.outcome(
+            hasCompletedOnboarding: true,
+            isEnabled: true,
+            permissions: missingAccessibility
+        ) == .waitForPermissions)
+    }
+
+    @Test("shortcuts remain inactive until onboarding completes")
+    func incompleteOnboardingDoesNotStartShortcuts() {
+        #expect(ShortcutFeatureEnablementPolicy.outcome(
+            hasCompletedOnboarding: false,
+            isEnabled: true,
+            permissions: allShortcutPermissions
+        ) == .disabled)
+    }
+}

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -68,6 +68,7 @@ case "${shard}" in
       BackendOptionTests
       SummaryModelPresetTests
       HotkeyMonitorTests
+      PushToTalkEnablementPolicyTests
       InteractiveAudioSessionOwnershipTests
       DictationStateTests
       HotkeyConfigTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -78,6 +78,7 @@ case "${shard}" in
       OpenRouterTranscriptionClientTests
       SummaryModelPresetTests
       HotkeyMonitorTests
+      PushToTalkEnablementPolicyTests
       InteractiveAudioSessionOwnershipTests
       DictationStateTests
       HotkeyConfigTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -79,6 +79,7 @@ case "${shard}" in
       SummaryModelPresetTests
       HotkeyMonitorTests
       PushToTalkEnablementPolicyTests
+      ShortcutFeatureEnablementPolicyTests
       InteractiveAudioSessionOwnershipTests
       DictationStateTests
       HotkeyConfigTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -26,6 +26,7 @@ case "${shard}" in
       ChatGPTTokenStorageTests
       OpenRouterAuthTests
       SettingsPermissionRefreshReasonTests
+      InteractionPermissionMonitorTests
       AccessibilityPermissionGuideTests
       DictationTestLifecycleTests
       OnboardingFlowTests


### PR DESCRIPTION
## Summary

Fixes #452 by separating the user's original onboarding intent from the current Push-to-Talk capability state.

In v0.8.3, selecting **Meetings** during onboarding permanently gated the dictation hotkey monitor behind `onboarding_use_case`. Shortcuts still displayed an editable Push-to-Talk shortcut, but the monitor never started and there was no post-onboarding recovery path.

This change:

- adds persisted `enable_push_to_talk` state independent of `onboarding_use_case`;
- initializes and migrates that state from the existing onboarding selection so upgrades preserve current behavior;
- adds a native two-way Push-to-Talk switch in Shortcuts;
- resolves the Push-to-Talk permission profile from its actual output behavior: Voice Note output requires Microphone and Input Monitoring, while paste output additionally requires Accessibility;
- starts the Push-to-Talk hotkey monitor only when onboarding is complete, Push to Talk is enabled, and the permissions for that output profile are ready;
- requests only the missing permissions required by that output profile when the user enables Push to Talk;
- persists pending enablement across app restart and completes it when the permissions become available;
- stops only the Push-to-Talk hotkey monitor when the user turns Push to Talk off;
- starts independently enabled Quill and Computer Use monitors through their own app-launch and onboarding-completion path instead of coupling them to Push to Talk;
- keeps shortcut editing separate from feature enablement;
- preserves the original onboarding use case for history and telemetry instead of rewriting `meetings` to `dictation_and_meetings`;
- records `push_to_talk.enablement_changed` with the enabled value, original onboarding use case, resolved permission profile, and current readiness for that profile, then emits the transition again when a pending permission request becomes ready;
- limits permission reconciliation to a pending enablement request, avoiding repeated hotkey registration and recorder warm-up in steady state; and
- requests and verifies the meeting-audio permission during onboarding whenever the selected capability union includes Meetings (`System Audio` for the default CoreAudio tap, or `Screen & System Audio` for the legacy ScreenCaptureKit backend). Screen Recording for visual context remains optional.

For a meetings-only user who later enables Push to Talk, the resulting recording follows the normal paste-dictation path rather than being treated as a voice note. A Voice Notes user continues to create a Voice Note and is not forced to grant Accessibility merely to keep using Push to Talk.

This PR specifically separates **Push-to-Talk enablement** from original onboarding intent and makes Quill/Computer Use monitor startup independent from the Push-to-Talk toggle. It does not yet introduce independent current-capability state and permission reconciliation for every feature: Meetings, Voice Notes output mode, Quill, and Computer Use otherwise retain their existing settings and onboarding semantics.

## Validation

### Automated

- 48 focused `AppConfigTests` passed, including legacy migration and independent Push-to-Talk state coverage.
- 8 `PushToTalkEnablementPolicyTests` passed, covering disabled state, onboarding and permission gates, Voice Notes operation without Accessibility, paste-mode Accessibility requirements, pending reconciliation, and restart persistence.
- 4 `ShortcutFeatureEnablementPolicyTests` passed, covering explicit-toggle, onboarding-completion, current-permission, and onboarding-intent independence.
- 15 `OnboardingProgressTests` passed, including capability-union permission requirements, CoreAudio System Audio, and the ScreenCaptureKit fallback.
- 20 `OnboardingFlowTests` passed.
- `./scripts/test_classify_changed_files.sh` passed.
- `./scripts/test_ci_test_shards.sh` passed.
- `./scripts/verify_update_flow.sh --skip-dmg` passed on the previous head.
- `git diff --check` passed.

### Manual macOS verification

Built, signed, installed, and tested `/Applications/MuesliDevA.app` using a meetings-only configuration on an earlier head:

- with Push to Talk **Off**, holding Left Control did not activate dictation;
- switching Push to Talk **On** enabled and persisted the feature;
- holding Left Control then activated working dictation; and
- the original `onboarding_use_case=meetings` value remained unchanged.

A roughly 6–7 second cold microphone activation delay was observed. This PR does not change the microphone/audio startup path, so latency work is intentionally out of scope.

The latest permission-profile and independent-monitor startup fixes compile and pass focused policy tests. DevA was rebuilt from the rebased head, and Quill was physically verified in the meetings-only fixture while Push to Talk remained off. Physical verification of Voice Notes without Accessibility, Computer Use relaunch with Push to Talk off, and the newly restored meeting-audio onboarding prompt remains outstanding.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None.

### AI assistance

Cursor Grok 4.6 implemented the initial recovery path. OpenAI Codex rebased the branch and revised the implementation to use independent persisted Push-to-Talk state, a two-way native toggle, durable permission intent, output-specific permission profiles, independent Quill/Computer Use monitor startup, transition telemetry, meeting-audio onboarding, and expanded regression coverage. The Push-to-Talk behavior was reviewed and tested manually on macOS; the permission-derived Quill path was also physically verified in the meetings-only DevA fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Push-to-Talk toggle with controls for its hotkey and hold duration.
  * Push-to-Talk availability now reflects onboarding choices and required permissions.
  * Added support for meeting audio permissions based on the selected capture method.
  * Existing installations retain compatible Push-to-Talk behavior through automatic migration.

* **Bug Fixes**
  * Dictation prompts and hotkey monitoring now appear only when Push-to-Talk is enabled and available.
  * Improved permission updates and messaging across dictation, voice notes, meetings, Screen Context, and Quill mode.
  * Prevented outdated permission results from overriding newer permission states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
