### PR TITLE
Fix #457: use a Computer Use planner model the backend accepts

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
@@ -25,8 +25,10 @@ enum ComputerUsePlannerError: LocalizedError, Equatable {
 
 enum ComputerUsePlannerClient {
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
-    // The WHAM endpoint rejects gpt-5.6-sol, gpt-5.4 and gpt-5.2 for ChatGPT
-    // accounts, which is the only auth this planner supports. See #457.
+    // The current WHAM endpoint rejects gpt-5.6-sol, gpt-5.4 and gpt-5.2 for
+    // ChatGPT accounts, which is the only auth this planner supports. WHAM is a
+    // ChatGPT endpoint; this is expected to change when the planner migrates to
+    // the Codex endpoint. See #457.
     static let defaultModel = "gpt-5.6-terra"
 
     static var instructions: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
@@ -25,7 +25,9 @@ enum ComputerUsePlannerError: LocalizedError, Equatable {
 
 enum ComputerUsePlannerClient {
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
-    static let defaultModel = "gpt-5.6-sol"
+    // The WHAM endpoint rejects gpt-5.6-sol, gpt-5.4 and gpt-5.2 for ChatGPT
+    // accounts, which is the only auth this planner supports. See #457.
+    static let defaultModel = "gpt-5.6-terra"
 
     static var instructions: String {
         """

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -586,13 +586,13 @@ struct SummaryModelPreset {
         "gpt-5.4-nano",
     ]
 
+    /// Only models the WHAM endpoint accepts for ChatGPT accounts. gpt-5.6-sol,
+    /// gpt-5.4 and gpt-5.2 are rejected with a 400 and are deliberately absent —
+    /// offering them in the picker only produces failed runs. See #457.
     static let computerUsePlannerModels: [SummaryModelPreset] = [
-        SummaryModelPreset(id: "gpt-5.6-sol", label: "GPT-5.6 Sol (default)"),
-        SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra"),
+        SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra (default)"),
         SummaryModelPreset(id: "gpt-5.6-luna", label: "GPT-5.6 Luna"),
-        SummaryModelPreset(id: "gpt-5.4", label: "GPT-5.4"),
         SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini"),
-        SummaryModelPreset(id: "gpt-5.2", label: "GPT-5.2"),
     ]
 
     static let openRouterModels: [SummaryModelPreset] = [
@@ -621,6 +621,24 @@ struct SummaryModelPreset {
         default:
             return nil
         }
+    }
+
+    /// Models the WHAM endpoint rejects for ChatGPT accounts. Only applies to the
+    /// Computer Use planner; the summary backends use a different endpoint that
+    /// accepts these. See #457.
+    static let rejectedComputerUsePlannerModels: Set<String> = [
+        "gpt-5.5", "gpt-5.6-sol", "gpt-5.4", "gpt-5.2",
+    ]
+
+    /// Moves a stored planner model off anything the backend refuses. Without
+    /// this, users who selected gpt-5.5 before #348 and users migrated onto
+    /// gpt-5.6-sol by it are both left unable to run Computer Use.
+    static func migratedComputerUsePlannerModel(_ model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return model }
+        return rejectedComputerUsePlannerModels.contains(trimmed)
+            ? "gpt-5.6-terra"
+            : trimmed
     }
 
     static func migratedFromGPT55(_ model: String) -> String {
@@ -1524,7 +1542,7 @@ struct AppConfig: Codable {
         meetingRecordingHotkey = (try? c.decode(HotkeyConfig.self, forKey: .meetingRecordingHotkey)) ?? defaults.meetingRecordingHotkey
         enableMeetingRecordingHotkey = (try? c.decode(Bool.self, forKey: .enableMeetingRecordingHotkey)) ?? defaults.enableMeetingRecordingHotkey
         enableComputerUsePlanner = (try? c.decode(Bool.self, forKey: .enableComputerUsePlanner)) ?? defaults.enableComputerUsePlanner
-        computerUsePlannerModel = SummaryModelPreset.migratedFromGPT55(
+        computerUsePlannerModel = SummaryModelPreset.migratedComputerUsePlannerModel(
             (try? c.decode(String.self, forKey: .computerUsePlannerModel)) ?? defaults.computerUsePlannerModel
         )
         computerUseTimeoutSeconds = (try? c.decode(Int.self, forKey: .computerUseTimeoutSeconds)) ?? defaults.computerUseTimeoutSeconds

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -586,9 +586,10 @@ struct SummaryModelPreset {
         "gpt-5.4-nano",
     ]
 
-    /// Only models the WHAM endpoint accepts for ChatGPT accounts. gpt-5.6-sol,
-    /// gpt-5.4 and gpt-5.2 are rejected with a 400 and are deliberately absent —
-    /// offering them in the picker only produces failed runs. See #457.
+    /// Only models the current WHAM endpoint accepts for ChatGPT accounts.
+    /// gpt-5.6-sol, gpt-5.4 and gpt-5.2 are rejected with a 400 and are absent
+    /// because offering them can only produce failed runs. Expected to come back
+    /// when the planner moves to the Codex endpoint. See #457.
     static let computerUsePlannerModels: [SummaryModelPreset] = [
         SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra (default)"),
         SummaryModelPreset(id: "gpt-5.6-luna", label: "GPT-5.6 Luna"),
@@ -623,20 +624,26 @@ struct SummaryModelPreset {
         }
     }
 
-    /// Models the WHAM endpoint rejects for ChatGPT accounts. Only applies to the
-    /// Computer Use planner; the summary backends use a different endpoint that
-    /// accepts these. See #457.
-    static let rejectedComputerUsePlannerModels: Set<String> = [
+    /// Models the current WHAM endpoint rejects for ChatGPT accounts.
+    ///
+    /// This is a property of the endpoint, not of the models: WHAM is a ChatGPT
+    /// endpoint, and once the planner migrates to the Codex endpoint all of these
+    /// are expected to work. Revisit this set — and the presets below — as part of
+    /// that migration rather than treating the restriction as permanent. See #457.
+    ///
+    /// Only affects the Computer Use planner; the summary backends call a
+    /// different endpoint that accepts these today.
+    static let whamRejectedPlannerModels: Set<String> = [
         "gpt-5.5", "gpt-5.6-sol", "gpt-5.4", "gpt-5.2",
     ]
 
-    /// Moves a stored planner model off anything the backend refuses. Without
-    /// this, users who selected gpt-5.5 before #348 and users migrated onto
-    /// gpt-5.6-sol by it are both left unable to run Computer Use.
+    /// Moves a stored planner model off anything the current endpoint refuses.
+    /// Without this, users who selected gpt-5.5 before #348 and users migrated
+    /// onto gpt-5.6-sol by it are both left unable to run Computer Use.
     static func migratedComputerUsePlannerModel(_ model: String) -> String {
         let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return model }
-        return rejectedComputerUsePlannerModels.contains(trimmed)
+        return whamRejectedPlannerModels.contains(trimmed)
             ? "gpt-5.6-terra"
             : trimmed
     }

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
@@ -411,14 +411,14 @@ struct ComputerUsePlannerModelTests {
 
     @Test("The default planner model is one the backend accepts")
     func defaultModelIsAccepted() {
-        #expect(!SummaryModelPreset.rejectedComputerUsePlannerModels
+        #expect(!SummaryModelPreset.whamRejectedPlannerModels
             .contains(ComputerUsePlannerClient.defaultModel))
     }
 
     @Test("No model offered in the picker is one the backend rejects")
     func noPresetIsRejected() {
         let offered = Set(SummaryModelPreset.computerUsePlannerModels.map(\.id))
-        let bad = offered.intersection(SummaryModelPreset.rejectedComputerUsePlannerModels)
+        let bad = offered.intersection(SummaryModelPreset.whamRejectedPlannerModels)
         #expect(bad.isEmpty, "picker offers models the backend refuses: \(bad.sorted())")
     }
 
@@ -433,7 +433,7 @@ struct ComputerUsePlannerModelTests {
     func migratesRejectedModels(stored: String) {
         let migrated = SummaryModelPreset.migratedComputerUsePlannerModel(stored)
         #expect(migrated == "gpt-5.6-terra")
-        #expect(!SummaryModelPreset.rejectedComputerUsePlannerModels.contains(migrated))
+        #expect(!SummaryModelPreset.whamRejectedPlannerModels.contains(migrated))
     }
 
     @Test("An accepted model is left alone",

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
@@ -385,11 +385,11 @@ struct ComputerUsePlannerModelTests {
         config.chatGPTModel = "gpt-5.4-mini"
 
         #expect(ComputerUsePlannerClient.plannerModel(for: config) == ComputerUsePlannerClient.defaultModel)
-        #expect(ComputerUsePlannerClient.defaultModel == "gpt-5.6-sol")
+        #expect(ComputerUsePlannerClient.defaultModel == "gpt-5.6-terra")
 
-        config.computerUsePlannerModel = "gpt-5.4"
+        config.computerUsePlannerModel = "gpt-5.4-mini"
 
-        #expect(ComputerUsePlannerClient.plannerModel(for: config) == "gpt-5.4")
+        #expect(ComputerUsePlannerClient.plannerModel(for: config) == "gpt-5.4-mini")
     }
 
     @Test("uses fixed High reasoning for every GPT-5.6 planner tier")
@@ -405,6 +405,60 @@ struct ComputerUsePlannerModelTests {
 
             #expect(reasoning?["effort"] == "high")
         }
+    }
+
+    // MARK: - #457: the shipped planner model was rejected by the backend
+
+    @Test("The default planner model is one the backend accepts")
+    func defaultModelIsAccepted() {
+        #expect(!SummaryModelPreset.rejectedComputerUsePlannerModels
+            .contains(ComputerUsePlannerClient.defaultModel))
+    }
+
+    @Test("No model offered in the picker is one the backend rejects")
+    func noPresetIsRejected() {
+        let offered = Set(SummaryModelPreset.computerUsePlannerModels.map(\.id))
+        let bad = offered.intersection(SummaryModelPreset.rejectedComputerUsePlannerModels)
+        #expect(bad.isEmpty, "picker offers models the backend refuses: \(bad.sorted())")
+    }
+
+    @Test("The default is among the offered presets")
+    func defaultIsOffered() {
+        #expect(SummaryModelPreset.computerUsePlannerModels
+            .map(\.id).contains(ComputerUsePlannerClient.defaultModel))
+    }
+
+    @Test("Users stored on a rejected model are migrated off it",
+          arguments: ["gpt-5.5", "gpt-5.6-sol", "gpt-5.4", "gpt-5.2"])
+    func migratesRejectedModels(stored: String) {
+        let migrated = SummaryModelPreset.migratedComputerUsePlannerModel(stored)
+        #expect(migrated == "gpt-5.6-terra")
+        #expect(!SummaryModelPreset.rejectedComputerUsePlannerModels.contains(migrated))
+    }
+
+    @Test("An accepted model is left alone",
+          arguments: ["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4-mini"])
+    func leavesAcceptedModels(stored: String) {
+        #expect(SummaryModelPreset.migratedComputerUsePlannerModel(stored) == stored)
+    }
+
+    @Test("An empty stored value falls through to the default rather than being rewritten")
+    func leavesEmptyAlone() {
+        #expect(SummaryModelPreset.migratedComputerUsePlannerModel("").isEmpty)
+    }
+
+    @Test("A config written before the fix decodes onto a working model")
+    func legacyConfigMigratesOnDecode() throws {
+        let legacy = Data(#"{"computer_use_planner_model":"gpt-5.6-sol"}"#.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: legacy)
+        #expect(decoded.computerUsePlannerModel == "gpt-5.6-terra")
+    }
+
+    @Test("The summary backends keep their own migration and are unaffected")
+    func summaryMigrationUnchanged() {
+        // gpt-5.6-sol works on the summary endpoint; only the CUA planner path
+        // treats it as rejected.
+        #expect(SummaryModelPreset.migratedFromGPT55("gpt-5.5") == "gpt-5.6-sol")
     }
 
     @Test("keeps GPT-5.4 Mini available without changing its reasoning behavior")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -649,13 +649,15 @@ struct SummaryModelPresetTests {
         }
     }
 
-    @Test("Computer use planner presets use GPT-5.6 Sol by default")
+    @Test("Computer use planner presets use GPT-5.6 Terra by default")
     func computerUsePlannerModels() {
-        #expect(SummaryModelPreset.computerUsePlannerModels.first?.id == "gpt-5.6-sol")
-        #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.6-terra" })
+        // Only models the WHAM endpoint accepts for ChatGPT accounts. See #457.
+        #expect(SummaryModelPreset.computerUsePlannerModels.first?.id == "gpt-5.6-terra")
         #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.6-luna" })
         #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.4-mini" })
-        #expect(!SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.5" })
+        for rejected in SummaryModelPreset.rejectedComputerUsePlannerModels {
+            #expect(!SummaryModelPreset.computerUsePlannerModels.contains { $0.id == rejected })
+        }
         for preset in SummaryModelPreset.computerUsePlannerModels {
             #expect(!preset.id.isEmpty)
             #expect(!preset.label.isEmpty)
@@ -1033,7 +1035,7 @@ struct AppConfigTests {
         config.computerUseHotkey = HotkeyConfig(keyCode: 62, label: "Right Ctrl")
         config.enableComputerUseHotkey = false
         config.enableComputerUsePlanner = false
-        config.computerUsePlannerModel = "gpt-5.4"
+        config.computerUsePlannerModel = "gpt-5.4-mini"
         config.computerUseTimeoutSeconds = 180
         config.hotkeyTriggerThresholdMS = 125
         config.computerUseHotkeyTriggerThresholdMS = 350
@@ -1115,7 +1117,7 @@ struct AppConfigTests {
         #expect(decoded.computerUseHotkey == HotkeyConfig(keyCode: 62, label: "Right Ctrl"))
         #expect(decoded.enableComputerUseHotkey == false)
         #expect(decoded.enableComputerUsePlanner == false)
-        #expect(decoded.computerUsePlannerModel == "gpt-5.4")
+        #expect(decoded.computerUsePlannerModel == "gpt-5.4-mini")
         #expect(decoded.computerUseTimeoutSeconds == 180)
         #expect(decoded.hotkeyTriggerThresholdMS == 125)
         #expect(decoded.computerUseHotkeyTriggerThresholdMS == 350)
@@ -1468,7 +1470,9 @@ struct AppConfigTests {
         """
         let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
 
-        #expect(config.computerUsePlannerModel == "gpt-5.6-sol")
+        // The CUA planner migrates onto a model the backend accepts (#457); the
+        // summary backends use a different endpoint and keep gpt-5.6-sol.
+        #expect(config.computerUsePlannerModel == "gpt-5.6-terra")
         #expect(config.openAIModel == "gpt-5.6-sol")
         #expect(config.chatGPTModel == "gpt-5.6-sol")
         #expect(config.postProcessorOpenAIModel == "gpt-5.6-sol")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -655,7 +655,7 @@ struct SummaryModelPresetTests {
         #expect(SummaryModelPreset.computerUsePlannerModels.first?.id == "gpt-5.6-terra")
         #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.6-luna" })
         #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.4-mini" })
-        for rejected in SummaryModelPreset.rejectedComputerUsePlannerModels {
+        for rejected in SummaryModelPreset.whamRejectedPlannerModels {
             #expect(!SummaryModelPreset.computerUsePlannerModels.contains { $0.id == rejected })
         }
         for preset in SummaryModelPreset.computerUsePlannerModels {


### PR DESCRIPTION
Fixes #457.

Computer Use could not run at all on a default install. `ComputerUsePlannerClient.defaultModel` is `gpt-5.6-sol`, which the WHAM endpoint rejects for ChatGPT accounts — the only auth the CUA planner supports — so every command failed with a 400 before the planner took an action.

## What the endpoint actually accepts

Probed with the app's own request shape (`ComputerUsePlannerClient.requestBody`), 2026-08-22, ChatGPT Plus account:

| Model | Result |
|---|---|
| `gpt-5.6-sol` | **400 — not supported** (shipped default) |
| `gpt-5.6-terra` | 200 OK |
| `gpt-5.6-luna` | 200 OK |
| `gpt-5.4` | **400 — not supported** |
| `gpt-5.4-mini` | 200 OK |
| `gpt-5.2` | **400 — not supported** |
| `gpt-5.5` | 200 OK — the previous default |

Three of the six presets offered in the picker are rejected, including the default.

## Changes

- `defaultModel` → `gpt-5.6-terra`, the closest working member of the shipped family
- The three rejected ids are removed from `computerUsePlannerModels`; offering them could only ever produce failed runs
- A CUA-scoped migration (`migratedComputerUsePlannerModel`) moves stored selections off any rejected model, so both users who chose `gpt-5.5` before #348 and users migrated onto `gpt-5.6-sol` by it end up on something that works

The shared `migratedFromGPT55` is deliberately left alone. The summary backends use a different endpoint that accepts `gpt-5.6-sol`, so only the planner path may treat it as rejected — changing the shared helper would fix CUA by breaking the summary migration.

## Tests

Three existing tests asserted the broken behaviour and are corrected: the default preset, a round-trip sample value, and the GPT-5.5 migration target. One of them read:

```swift
#expect(ComputerUsePlannerClient.defaultModel == "gpt-5.6-sol")
```

The new cover asserts the invariant rather than the literal — the default must not be in the rejected set, and no offered preset may be — so the next model change is caught at review time instead of at runtime.

Full suite: **1809 tests in 166 suites pass.**

## Verification

Built MuesliDev from this branch and ran a Computer Use command with an **unmodified config** (no model override):

```
final_status   done
final_message  Opened a new Chrome tab and navigated it to https://www.wikipedia.org.
steps          13 trace events
```

Confirmed independently of the trace by reading Chrome's active tab URL, rather than trusting the planner's own `finish` claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790045069&installation_model_id=422865&pr_number=458&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F458&signature=daaf0dfcfd51e33efa1b5b56087c256738a82549d173f2bf76cafc56a1be16e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the default Computer Use planner to GPT-5.6 Terra.
  - Removed unsupported planner model options from model selection.
  - Automatically migrates saved selections of retired or unsupported planner models.

- **Bug Fixes**
  - Preserved valid custom and empty model selections during configuration migration.
  - Improved compatibility with current ChatGPT planner model restrictions.

- **Tests**
  - Added coverage for model filtering, migration, configuration decoding, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->