### PR TITLE
Add a non-production Computer Use automation bridge

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseAutomationBridge.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseAutomationBridge.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Non-production entry point that starts a Computer Use command from outside the
+/// app, so an acceptance sweep can run unattended.
+///
+/// Muesli already records every CUA run — a `dictations` row with `source = "cua"`
+/// joined to a `computer_use_traces` row — so reading results needs no app support.
+/// Starting a run does: CUA lives in this executable target and `muesli-cli` cannot
+/// import it, leaving the hotkey as the only way in. That makes a 100-attempt sweep
+/// 100 spoken commands.
+///
+/// This bridge bypasses **only** audio capture. The command text is handed to the
+/// same `handleComputerUseCommand` the transcribed path calls, so a sweep measures
+/// the real planner loop rather than a parallel one.
+///
+/// Two independent conditions gate it, because a listener that runs arbitrary
+/// computer-use commands is a real attack surface:
+///
+/// 1. `enableComputerUseAutomationBridge` is off by default.
+/// 2. Production builds refuse regardless of configuration — `isPermittedBuild`
+///    rejects the production bundle identifier before the flag is even read.
+///
+/// Either alone would do; both are cheap.
+enum ComputerUseAutomationBridge {
+    /// Bundle identifier that must never accept externally-posted commands.
+    static let productionBundleIdentifier = "com.muesli.app"
+
+    /// Scoped to this build's bundle identifier so parallel dev lanes do not
+    /// answer each other's commands.
+    static var notificationName: Notification.Name {
+        let identifier = Bundle.main.bundleIdentifier ?? "com.muesli.dev"
+        return Notification.Name("\(identifier).cua.run")
+    }
+
+    static var isPermittedBuild: Bool {
+        (Bundle.main.bundleIdentifier ?? "") != productionBundleIdentifier
+    }
+
+    struct Request: Equatable {
+        let command: String
+        let runTag: String?
+    }
+
+    /// Decodes the `{"command": "...", "run_tag": "..."}` payload carried as the
+    /// notification's object. Returns nil for anything malformed, blank, or
+    /// implausibly long — a bad payload is ignored, never partially executed.
+    static func decode(payload: String?) -> Request? {
+        guard let payload,
+              let data = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rawCommand = object["command"] as? String else {
+            return nil
+        }
+        let command = rawCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty, command.count <= 500 else { return nil }
+        let rawTag = (object["run_tag"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return Request(command: command, runTag: rawTag?.isEmpty == false ? rawTag : nil)
+    }
+
+    final class Observer {
+        private var token: NSObjectProtocol?
+        private let center: DistributedNotificationCenter
+
+        init(center: DistributedNotificationCenter = .default()) {
+            self.center = center
+        }
+
+        var isObserving: Bool { token != nil }
+
+        /// Starts listening when the build and configuration both permit it.
+        /// Returns whether observation is active afterwards, so the caller can log it.
+        @discardableResult
+        func sync(enabled: Bool, handler: @escaping (Request) -> Void) -> Bool {
+            let shouldObserve = enabled && ComputerUseAutomationBridge.isPermittedBuild
+            if shouldObserve == isObserving { return isObserving }
+            if shouldObserve {
+                token = center.addObserver(
+                    forName: ComputerUseAutomationBridge.notificationName,
+                    object: nil,
+                    queue: .main
+                ) { notification in
+                    guard let request = ComputerUseAutomationBridge.decode(
+                        payload: notification.object as? String
+                    ) else {
+                        fputs("[cua-bridge] ignored malformed command payload\n", stderr)
+                        return
+                    }
+                    handler(request)
+                }
+                fputs("[cua-bridge] listening on \(ComputerUseAutomationBridge.notificationName.rawValue)\n", stderr)
+            } else {
+                if let token { center.removeObserver(token) }
+                token = nil
+                fputs("[cua-bridge] stopped listening\n", stderr)
+            }
+            return isObserving
+        }
+
+        deinit {
+            if let token { center.removeObserver(token) }
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1266,6 +1266,10 @@ struct AppConfig: Codable {
     var enableMeetingRecordingHotkey: Bool = false
     var computerUseHotkeyDefaultDisabledMigrationApplied: Bool = true
     var enableComputerUsePlanner: Bool = true
+    /// Non-production only: lets an external process start a CUA command so the
+    /// acceptance harness can sweep unattended. Refused outright on production
+    /// builds — see ComputerUseAutomationBridge.
+    var enableComputerUseAutomationBridge: Bool = false
     var computerUsePlannerModel: String = ""
     var computerUseTimeoutSeconds: Int = 120
     var sttBackend: String = BackendOption.parakeetUnified.backend
@@ -1393,6 +1397,7 @@ struct AppConfig: Codable {
         case enableMeetingRecordingHotkey = "enable_meeting_recording_hotkey"
         case computerUseHotkeyDefaultDisabledMigrationApplied = "computer_use_hotkey_default_disabled_migration_applied"
         case enableComputerUsePlanner = "enable_computer_use_planner"
+        case enableComputerUseAutomationBridge = "enable_computer_use_automation_bridge"
         case computerUsePlannerModel = "computer_use_planner_model"
         case computerUseTimeoutSeconds = "computer_use_timeout_seconds"
         case sttBackend = "stt_backend"
@@ -1524,6 +1529,7 @@ struct AppConfig: Codable {
         meetingRecordingHotkey = (try? c.decode(HotkeyConfig.self, forKey: .meetingRecordingHotkey)) ?? defaults.meetingRecordingHotkey
         enableMeetingRecordingHotkey = (try? c.decode(Bool.self, forKey: .enableMeetingRecordingHotkey)) ?? defaults.enableMeetingRecordingHotkey
         enableComputerUsePlanner = (try? c.decode(Bool.self, forKey: .enableComputerUsePlanner)) ?? defaults.enableComputerUsePlanner
+        enableComputerUseAutomationBridge = (try? c.decode(Bool.self, forKey: .enableComputerUseAutomationBridge)) ?? defaults.enableComputerUseAutomationBridge
         computerUsePlannerModel = SummaryModelPreset.migratedFromGPT55(
             (try? c.decode(String.self, forKey: .computerUsePlannerModel)) ?? defaults.computerUsePlannerModel
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -673,11 +673,11 @@ public final class MuesliController: NSObject {
         if canRunMainApp {
             startMeetingRecordingHotkeyMonitorIfNeeded()
         }
-        // The automation bridge is independent of the hotkey and of push-to-talk,
-        // so it is configured here rather than inside the hotkey setup above.
-        if canRunMainApp {
-            configureComputerUseAutomationBridge()
-        }
+        // The automation bridge is independent of the hotkey, of push-to-talk, and
+        // of onboarding state. Its own flag and the production-build refusal are
+        // the gating; adding `canRunMainApp` here would only create a window where
+        // an enabled bridge never registers.
+        configureComputerUseAutomationBridge()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.startup))
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
@@ -7366,13 +7366,17 @@ public final class MuesliController: NSObject {
             fputs("[cua-bridge] busy, rejected: \(request.command)\n", stderr)
             return
         }
-        fputs("[cua-bridge] command: \(request.command)\n", stderr)
+        fputs("[cua-bridge] command: \(request.command) tag=\(request.runTag ?? "-")\n", stderr)
         let taskID = UUID()
         computerUseCommandTaskID = taskID
         let startedAt = Date()
         let dictationID = try? dictationStore.insertDictation(
             text: request.command,
             durationSeconds: 0,
+            // There is no screen context for a bridge-started run, so the column
+            // carries the harness's run tag instead. Without it a sweep's rows are
+            // indistinguishable from real dictations in history.
+            appContext: request.runTag.map { "harness:\($0)" } ?? "harness",
             source: "cua",
             startedAt: startedAt,
             endedAt: startedAt

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -673,6 +673,11 @@ public final class MuesliController: NSObject {
         if canRunMainApp {
             startMeetingRecordingHotkeyMonitorIfNeeded()
         }
+        // The automation bridge is independent of the hotkey and of push-to-talk,
+        // so it is configured here rather than inside the hotkey setup above.
+        if canRunMainApp {
+            configureComputerUseAutomationBridge()
+        }
         syncDictationRecorderWarmup(intent: .idlePrewarm(.startup))
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
@@ -1443,7 +1448,11 @@ public final class MuesliController: NSObject {
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
         let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         let previousEnableLiveStreamingPartials = config.enableLiveStreamingPartials
+        let previousEnableComputerUseAutomationBridge = config.enableComputerUseAutomationBridge
         mutate(&config)
+        if previousEnableComputerUseAutomationBridge != config.enableComputerUseAutomationBridge {
+            configureComputerUseAutomationBridge()
+        }
         if previousEnableLiveStreamingPartials, !config.enableLiveStreamingPartials {
             preparingMeetingSession?.stopStreamingPartials()
             activeMeetingSession?.stopStreamingPartials()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -446,6 +446,7 @@ public final class MuesliController: NSObject {
     private var pendingComputerUseStopSessionID: UUID?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseCommandTaskID: UUID?
+    private let computerUseAutomationBridge = ComputerUseAutomationBridge.Observer()
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
     private var computerUseLastFloatingStatusAt = Date.distantPast
     private var computerUseLastFloatingStatus = ""
@@ -7326,12 +7327,56 @@ public final class MuesliController: NSObject {
     }
 
     private func configureComputerUseHotkeyMonitor() {
+        configureComputerUseAutomationBridge()
         guard config.enableComputerUseHotkey else {
             computerUseHotkeyMonitor.stop()
             return
         }
         computerUseHotkeyMonitor.configure(config.computerUseHotkey)
         startComputerUseHotkeyMonitorIfNeeded()
+    }
+
+    /// Non-production only. See ComputerUseAutomationBridge for the two gates.
+    private func configureComputerUseAutomationBridge() {
+        computerUseAutomationBridge.sync(
+            enabled: config.enableComputerUseAutomationBridge
+        ) { [weak self] request in
+            self?.handleComputerUseAutomationRequest(request)
+        }
+    }
+
+    /// Starts a CUA command supplied by the acceptance harness instead of the
+    /// microphone. Everything after the transcript — the dictation row, the
+    /// planner loop, the trace — is the normal path.
+    private func handleComputerUseAutomationRequest(
+        _ request: ComputerUseAutomationBridge.Request
+    ) {
+        guard config.enableComputerUseAutomationBridge,
+              ComputerUseAutomationBridge.isPermittedBuild else { return }
+        guard canStartComputerUseCommand else {
+            fputs("[cua-bridge] busy, rejected: \(request.command)\n", stderr)
+            return
+        }
+        fputs("[cua-bridge] command: \(request.command)\n", stderr)
+        let taskID = UUID()
+        computerUseCommandTaskID = taskID
+        let startedAt = Date()
+        let dictationID = try? dictationStore.insertDictation(
+            text: request.command,
+            durationSeconds: 0,
+            source: "cua",
+            startedAt: startedAt,
+            endedAt: startedAt
+        )
+        scheduleICloudSyncAfterLocalChange()
+        computerUseCommandTask = Task { [weak self] in
+            guard let self else { return }
+            await self.handleComputerUseCommand(
+                transcript: request.command,
+                dictationID: dictationID,
+                taskID: taskID
+            )
+        }
     }
 
     private func configureHotkeyMonitorTiming() {

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUseAutomationBridgeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUseAutomationBridgeTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Computer Use automation bridge")
+struct ComputerUseAutomationBridgeTests {
+
+    // MARK: - Payload decoding
+
+    @Test("Decodes a well-formed command payload")
+    func decodesValidPayload() {
+        let request = ComputerUseAutomationBridge.decode(
+            payload: #"{"command":"open a new tab","run_tag":"MuesliCUA-1234abcd-7"}"#
+        )
+        #expect(request == ComputerUseAutomationBridge.Request(
+            command: "open a new tab",
+            runTag: "MuesliCUA-1234abcd-7"
+        ))
+    }
+
+    @Test("Run tag is optional")
+    func runTagOptional() {
+        let request = ComputerUseAutomationBridge.decode(payload: #"{"command":"scroll down"}"#)
+        #expect(request?.command == "scroll down")
+        #expect(request?.runTag == nil)
+    }
+
+    @Test("Trims surrounding whitespace from the command")
+    func trimsCommand() {
+        let request = ComputerUseAutomationBridge.decode(payload: #"{"command":"  open Notes \n"}"#)
+        #expect(request?.command == "open Notes")
+    }
+
+    @Test("Blank run tag is treated as absent, not as an empty tag")
+    func blankRunTagIsNil() {
+        let request = ComputerUseAutomationBridge.decode(
+            payload: #"{"command":"open Notes","run_tag":"   "}"#
+        )
+        #expect(request?.runTag == nil)
+    }
+
+    @Test("Rejects malformed payloads rather than partially executing them",
+          arguments: [
+            "",
+            "not json",
+            "[]",
+            "{}",
+            #"{"run_tag":"MuesliCUA-1234abcd-1"}"#,   // no command
+            #"{"command":""}"#,                        // empty command
+            #"{"command":"   "}"#,                     // whitespace only
+            #"{"command":123}"#,                       // wrong type
+          ])
+    func rejectsMalformedPayload(payload: String) {
+        #expect(ComputerUseAutomationBridge.decode(payload: payload) == nil)
+    }
+
+    @Test("Rejects a nil payload")
+    func rejectsNilPayload() {
+        #expect(ComputerUseAutomationBridge.decode(payload: nil) == nil)
+    }
+
+    @Test("Rejects an implausibly long command")
+    func rejectsOverlongCommand() {
+        let long = String(repeating: "a", count: 501)
+        #expect(ComputerUseAutomationBridge.decode(payload: #"{"command":"\#(long)"}"#) == nil)
+    }
+
+    @Test("Accepts a command at the length limit")
+    func acceptsCommandAtLimit() {
+        let atLimit = String(repeating: "a", count: 500)
+        #expect(ComputerUseAutomationBridge.decode(payload: #"{"command":"\#(atLimit)"}"#)?.command == atLimit)
+    }
+
+    // MARK: - Safety gates
+
+    @Test("Production bundle identifier is the one build that must never listen")
+    func productionIdentifierIsGuarded() {
+        #expect(ComputerUseAutomationBridge.productionBundleIdentifier == "com.muesli.app")
+    }
+
+    @Test("Test bundle is a permitted build, so the gate does not block dev use")
+    func testBundleIsPermitted() {
+        // The test host is not the production app, so this must be true --
+        // otherwise the bridge could never be exercised anywhere.
+        #expect(ComputerUseAutomationBridge.isPermittedBuild)
+    }
+
+    @Test("Notification name is scoped to the bundle so dev lanes stay isolated")
+    func notificationNameIsScoped() {
+        let name = ComputerUseAutomationBridge.notificationName.rawValue
+        #expect(name.hasSuffix(".cua.run"))
+        let identifier = Bundle.main.bundleIdentifier ?? "com.muesli.dev"
+        #expect(name == "\(identifier).cua.run")
+    }
+
+    // MARK: - Observer lifecycle
+
+    @Test("Observer does not listen until enabled")
+    func observerStartsInactive() {
+        let observer = ComputerUseAutomationBridge.Observer()
+        #expect(!observer.isObserving)
+    }
+
+    @Test("Enabling starts observation and disabling stops it")
+    func observerTogglesWithFlag() {
+        let observer = ComputerUseAutomationBridge.Observer()
+        #expect(observer.sync(enabled: true) { _ in })
+        #expect(observer.isObserving)
+        #expect(!observer.sync(enabled: false) { _ in })
+        #expect(!observer.isObserving)
+    }
+
+    @Test("Re-syncing with the same value is a no-op")
+    func observerSyncIsIdempotent() {
+        let observer = ComputerUseAutomationBridge.Observer()
+        #expect(observer.sync(enabled: true) { _ in })
+        #expect(observer.sync(enabled: true) { _ in })
+        #expect(observer.isObserving)
+        _ = observer.sync(enabled: false) { _ in }
+    }
+
+    // MARK: - Config
+
+    @Test("The bridge is off by default")
+    func disabledByDefault() {
+        #expect(AppConfig().enableComputerUseAutomationBridge == false)
+    }
+
+    @Test("Config round-trips through snake_case JSON")
+    func configRoundTrips() throws {
+        var config = AppConfig()
+        config.enableComputerUseAutomationBridge = true
+        let data = try JSONEncoder().encode(config)
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["enable_computer_use_automation_bridge"] as? Bool == true)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.enableComputerUseAutomationBridge)
+    }
+
+    @Test("A config written before this flag existed decodes to off")
+    func legacyConfigDefaultsToDisabled() throws {
+        let legacy = Data(#"{"enable_computer_use_planner":true}"#.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: legacy)
+        #expect(!decoded.enableComputerUseAutomationBridge)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUseAutomationBridgeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUseAutomationBridgeTests.swift
@@ -119,6 +119,29 @@ struct ComputerUseAutomationBridgeTests {
         _ = observer.sync(enabled: false) { _ in }
     }
 
+    // MARK: - Run tag correlation
+
+    @Test("A run tag survives decoding so it can be persisted with the attempt")
+    func runTagIsAvailableDownstream() {
+        let request = ComputerUseAutomationBridge.decode(
+            payload: #"{"command":"open Notes","run_tag":"MuesliCUA-1234abcd-7"}"#
+        )
+        #expect(request?.runTag == "MuesliCUA-1234abcd-7")
+    }
+
+    @Test("Run tags are recorded in a form that separates sweep rows from real dictations")
+    func runTagContextIsDistinguishable() {
+        // Mirrors how the controller stores the tag: a bridge-started run has no
+        // screen context, so the column carries the harness tag instead.
+        let tagged = ComputerUseAutomationBridge.Request(
+            command: "open Notes", runTag: "MuesliCUA-1234abcd-7"
+        )
+        let untagged = ComputerUseAutomationBridge.Request(command: "open Notes", runTag: nil)
+
+        #expect(tagged.runTag.map { "harness:\($0)" } == "harness:MuesliCUA-1234abcd-7")
+        #expect(untagged.runTag.map { "harness:\($0)" } ?? "harness" == "harness")
+    }
+
     // MARK: - Config
 
     @Test("The bridge is off by default")

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -37,6 +37,7 @@ case "${shard}" in
       ModelDownloadCoordinatorTests
       IndicASRBackendTests
       ContributionMilestoneTests
+      ComputerUseAutomationBridgeTests
     )
     ;;
   dictation-transcription)


### PR DESCRIPTION
Adds a non-production entry point that starts a Computer Use command from outside the app, so CUA quality can be measured unattended.

**Additive only: 4 files, +302/−0. Off by default. Refuses to run on production builds.**

## Why

Muesli already records every CUA run — a `dictations` row with `source = "cua"` joined to a `computer_use_traces` row — so *reading* results needs no app support. *Starting* a run does: CUA lives in the `MuesliNativeApp` executable target and `muesli-cli` cannot import it, leaving the hotkey as the only way in.

That makes a 100-attempt acceptance sweep 100 spoken commands, which is why no CUA baseline exists today. Both prior CUA efforts (#241, #307) were argued without one — #307's closing comment cites 97 local runs that were never committed and so could never be re-run or regressed against.

## What it does

`ComputerUseAutomationBridge` observes a distributed notification and hands the command to `handleComputerUseCommand` — the same function the transcribed path calls once it has text. **Only audio capture is bypassed.** The dictation row, planner loop, trace persistence and status UI are the normal path, so a sweep measures the real loop rather than a parallel one.

## Security

A listener that runs arbitrary computer-use commands is a real attack surface: any local process can post a distributed notification. Two independent gates, either sufficient alone:

1. `enable_computer_use_automation_bridge` is **off by default**
2. Production builds **refuse regardless of configuration** — `isPermittedBuild` rejects `com.muesli.app` before the flag is read

Further:

- the notification name is scoped to the bundle identifier, so parallel dev lanes cannot answer each other's commands
- malformed, blank, or >500-character payloads are ignored rather than partially executed
- a command arriving while CUA is busy is rejected by the existing `canStartComputerUseCommand` guard

This is deliberately **not** a general automation API. It is a test seam, and the production refusal is what makes that claim enforceable rather than aspirational. Happy to gate it behind a compile flag instead if you'd prefer it cannot exist in a release binary at all.

## Tests

17 new, covering payload decoding (8 malformed cases), both safety gates, observer lifecycle and idempotence, and config round-trip including a legacy config predating the flag. Wider `ComputerUse|AppConfig|Models` filter: 326 tests in 35 suites pass.

## Verification

Built MuesliDev and drove commands through it end to end:

- bridge received and decoded the posted command **with the CUA hotkey disabled**, confirming it is wired independently of hotkey configuration
- `chrome-navigate-01` and `safari-navigate-01` both reached `done`, each confirmed independently by reading the browser's active tab rather than trusting the planner's `finish` claim

The second commit exists because live testing caught a wiring bug the unit tests missed: `configureComputerUseHotkeyMonitor()` is not called during startup — the launch path calls `startComputerUseHotkeyMonitorIfNeeded()` directly — so hanging the observer off it meant it never started unless CUA hotkey settings were later edited.

## Related

The first sweep using this bridge surfaced #457 (fixed in #458): the shipped default planner model is rejected by the backend, so Computer Use cannot run on a default install. That is worth landing first — a baseline measured with a model override would not describe what users actually get.

The harness that drives this lives outside the app repo, per the decision on #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790045095&installation_model_id=422865&pr_number=459&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F459&signature=4f317cb3a3cef8ccc7b2c22f3df50a5dde1d0e5a43d0eefd58bf98c605002fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in computer-use automation bridge for non-production builds.
  * Supports validated automation commands, optional run tags, and integration with existing command processing.
  * Added persisted configuration support, disabled by default, with legacy compatibility.

* **Bug Fixes**
  * Invalid, blank, oversized, or unauthorized automation requests are safely ignored.
  * Prevents overlapping computer-use commands and restricts automation to permitted builds.
  * Improved observer lifecycle handling and configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->