### PR TITLE
feat: add tap-to-toggle dictation trigger mode

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -498,6 +498,12 @@ final class HotkeyMonitor {
             } else if wasArmed {
                 onCancel?()
             }
+        } else if toggleActive {
+            // Another modifier key while toggle is active — cancel toggle
+            fputs("[hotkey] canceled by other modifier key \(keyCode) during toggle\n", stderr)
+            toggleActive = false
+            cancelTimers()
+            onCancel?()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -34,6 +34,7 @@ final class HotkeyMonitor {
     var onToggleStop: (() -> Void)?
     var targetKeyCode: UInt16 = 55
     var doubleTapEnabled: Bool = true
+    var tapToToggleEnabled: Bool = false
 
     // Combination mode (e.g. Cmd+Shift+R)
     var combinationModifiers: NSEvent.ModifierFlags?
@@ -400,8 +401,10 @@ final class HotkeyMonitor {
                         return
                     }
 
-                    // Check for double-tap
-                    if doubleTapEnabled,
+                    // Check for double-tap (skipped in tap-to-toggle mode — a
+                    // single tap already toggles, so double-tap is redundant)
+                    if !tapToToggleEnabled,
+                       doubleTapEnabled,
                        lastTapWasShort,
                        let lastUp = lastTapUpTime,
                        now().timeIntervalSince(lastUp) < doubleTapWindow {
@@ -419,8 +422,13 @@ final class HotkeyMonitor {
                         armed = true
                         onArm()
                     }
-                    fputs("[hotkey] target key \(targetKeyCode) down\n", stderr)
-                    scheduleTimers()
+                    if tapToToggleEnabled {
+                        fputs("[hotkey] target key \(targetKeyCode) down (tap-to-toggle)\n", stderr)
+                        // Skip hold timers — release will start toggle mode
+                    } else {
+                        fputs("[hotkey] target key \(targetKeyCode) down\n", stderr)
+                        scheduleTimers()
+                    }
                 }
             } else {
                 fputs("[hotkey] target key \(targetKeyCode) up\n", stderr)
@@ -432,6 +440,18 @@ final class HotkeyMonitor {
 
                 if toggleActive {
                     // Don't stop toggle on key-up — only on next key-down
+                    return
+                }
+
+                // Tap-to-toggle: a quick press-and-release (before hold timers
+                // would have fired) starts toggle mode. If recording already
+                // started (user held long enough despite the mode), stop it
+                // normally via the active branch below.
+                if tapToToggleEnabled && wasDown && !active && !otherKeyPressed {
+                    fputs("[hotkey] tap-to-toggle → toggle start\n", stderr)
+                    lastTapWasShort = false
+                    lastTapUpTime = nil
+                    toggleActive = true
                     return
                 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -418,17 +418,25 @@ final class HotkeyMonitor {
                         return
                     }
 
+                    if tapToToggleEnabled {
+                        // Tap-to-toggle: start toggle immediately on key-down.
+                        // Skip arming and hold timers — the toggle persists
+                        // until the next tap stops it.
+                        fputs("[hotkey] tap-to-toggle → toggle start\n", stderr)
+                        lastTapWasShort = false
+                        lastTapUpTime = nil
+                        toggleActive = true
+                        cancelTimers()
+                        onToggleStart?()
+                        return
+                    }
+
                     if let onArm {
                         armed = true
                         onArm()
                     }
-                    if tapToToggleEnabled {
-                        fputs("[hotkey] target key \(targetKeyCode) down (tap-to-toggle)\n", stderr)
-                        // Skip hold timers — release will start toggle mode
-                    } else {
-                        fputs("[hotkey] target key \(targetKeyCode) down\n", stderr)
-                        scheduleTimers()
-                    }
+                    fputs("[hotkey] target key \(targetKeyCode) down\n", stderr)
+                    scheduleTimers()
                 }
             } else {
                 fputs("[hotkey] target key \(targetKeyCode) up\n", stderr)
@@ -443,15 +451,8 @@ final class HotkeyMonitor {
                     return
                 }
 
-                // Tap-to-toggle: a quick press-and-release (before hold timers
-                // would have fired) starts toggle mode. If recording already
-                // started (user held long enough despite the mode), stop it
-                // normally via the active branch below.
-                if tapToToggleEnabled && wasDown && !active && !otherKeyPressed {
-                    fputs("[hotkey] tap-to-toggle → toggle start\n", stderr)
-                    lastTapWasShort = false
-                    lastTapUpTime = nil
-                    toggleActive = true
+                // Tap-to-toggle starts/stops on key-down; key-up is a no-op.
+                if tapToToggleEnabled {
                     return
                 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1258,6 +1258,33 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
     }
 }
 
+/// How the dictation hotkey triggers recording.
+///
+/// - `holdToRecord`: Hold the hotkey to record; release to stop and paste.
+///   Double-tap hands-free mode remains available when enabled.
+/// - `tapToToggle`: A single tap starts hands-free recording; tap again to stop.
+///   No need to hold the key or double-tap.
+enum DictationTriggerMode: String, Codable, CaseIterable {
+    case holdToRecord = "hold_to_record"
+    case tapToToggle = "tap_to_toggle"
+
+    var label: String {
+        switch self {
+        case .holdToRecord: return "Hold to Record"
+        case .tapToToggle: return "Tap to Toggle"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .holdToRecord:
+            return "Hold the hotkey to record, release to paste. Double-tap for hands-free."
+        case .tapToToggle:
+            return "Tap once to start recording, tap again to stop and paste."
+        }
+    }
+}
+
 struct AppConfig: Codable {
     var dictationHotkey: HotkeyConfig = .default
     var computerUseHotkey: HotkeyConfig = .computerUseDefault
@@ -1296,6 +1323,7 @@ struct AppConfig: Codable {
     var waveformCacheOrphanCleanupMigrationApplied: Bool = false
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
+    var dictationTriggerMode: String = DictationTriggerMode.holdToRecord.rawValue
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var computerUseHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var meetingRecordingHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultMeetingThresholdMilliseconds
@@ -1423,6 +1451,7 @@ struct AppConfig: Codable {
         case waveformCacheOrphanCleanupMigrationApplied = "waveform_cache_orphan_cleanup_migration_applied"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
+        case dictationTriggerMode = "dictation_trigger_mode"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case computerUseHotkeyTriggerThresholdMS = "computer_use_hotkey_trigger_threshold_ms"
         case meetingRecordingHotkeyTriggerThresholdMS = "meeting_recording_hotkey_trigger_threshold_ms"
@@ -1577,6 +1606,7 @@ struct AppConfig: Codable {
         iCloudSyncEnabled = (try? c.decode(Bool.self, forKey: .iCloudSyncEnabled)) ?? defaults.iCloudSyncEnabled
         showIOSCompanionPrompt = (try? c.decode(Bool.self, forKey: .showIOSCompanionPrompt)) ?? defaults.showIOSCompanionPrompt
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
+        dictationTriggerMode = (try? c.decode(String.self, forKey: .dictationTriggerMode)) ?? defaults.dictationTriggerMode
         hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
             (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
         )
@@ -1740,6 +1770,10 @@ struct AppConfig: Codable {
 
     var resolvedOnboardingUseCase: OnboardingUseCase {
         OnboardingUseCase.resolved(onboardingUseCase)
+    }
+
+    var resolvedDictationTriggerMode: DictationTriggerMode {
+        DictationTriggerMode(rawValue: dictationTriggerMode) ?? .holdToRecord
     }
 
     var resolvedAutoExportMarkdownContent: MeetingExportContent {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -634,7 +634,12 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.onStart = { [weak self] in self?.handleStart() }
         hotkeyMonitor.onStop = { [weak self] in self?.handleStop() }
         hotkeyMonitor.onCancel = { [weak self] in self?.handleCancel() }
-        hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
+        hotkeyMonitor.onToggleStart = { [weak self] in
+            guard let self else { return }
+            if !self.handleToggleStart() {
+                self.hotkeyMonitor.cancelToggleMode()
+            }
+        }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         hotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
@@ -1540,7 +1545,6 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         hotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
-        computerUseHotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         if hotkeyTriggerThresholdChanged {
             configureHotkeyMonitorTiming()
         }
@@ -7364,7 +7368,6 @@ public final class MuesliController: NSObject {
             return
         }
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
-        computerUseHotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         computerUseHotkeyMonitor.configure(config.computerUseHotkey)
         computerUseHotkeyMonitor.start()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -637,6 +637,7 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        hotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         configureHotkeyMonitorTiming()
         computerUseHotkeyMonitor.onPrepare = { [weak self] in self?.handleComputerUsePrepare() }
         computerUseHotkeyMonitor.onStart = { [weak self] in self?.handleComputerUseStart() }
@@ -1537,7 +1538,9 @@ public final class MuesliController: NSObject {
         statusBarController?.refreshIcon()
         indicator.refreshIcon()
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        hotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        computerUseHotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         if hotkeyTriggerThresholdChanged {
             configureHotkeyMonitorTiming()
         }
@@ -7361,6 +7364,7 @@ public final class MuesliController: NSObject {
             return
         }
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        computerUseHotkeyMonitor.tapToToggleEnabled = config.resolvedDictationTriggerMode == .tapToToggle
         computerUseHotkeyMonitor.configure(config.computerUseHotkey)
         computerUseHotkeyMonitor.start()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -314,6 +314,27 @@ struct ShortcutsView: View {
 
     private var doubleTapSection: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            // Trigger mode picker
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("Dictation Trigger")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text("Choose how the hotkey activates dictation")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+            Picker("", selection: Binding(
+                get: { appState.config.resolvedDictationTriggerMode },
+                set: { newValue in
+                    controller.updateConfig { $0.dictationTriggerMode = newValue.rawValue }
+                }
+            )) {
+                ForEach(DictationTriggerMode.allCases, id: \.self) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text("Hands-Free Mode")
@@ -333,6 +354,7 @@ struct ShortcutsView: View {
                 .toggleStyle(.switch)
                 .tint(MuesliTheme.accent)
                 .labelsHidden()
+                .disabled(appState.config.resolvedDictationTriggerMode == .tapToToggle)
             }
         }
         .padding(MuesliTheme.spacing16)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -2223,31 +2223,56 @@ struct HotkeyMonitorTests {
 
     // MARK: - Tap-to-Toggle Mode
 
-    @Test("tap-to-toggle starts toggle on quick tap")
+    @Test("tap-to-toggle starts toggle on key down")
     @MainActor
-    func tapToToggleStartsOnQuickTap() {
+    func tapToToggleStartsOnKeyDown() {
         let scheduler = ManualHotkeyScheduler()
         let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
         monitor.tapToToggleEnabled = true
         var toggleStartCount = 0
         var startCount = 0
+        var armCount = 0
         monitor.onToggleStart = {
             toggleStartCount += 1
         }
         monitor.onStart = {
             startCount += 1
         }
+        monitor.onArm = {
+            armCount += 1
+        }
 
-        // Quick press and release — should start toggle, not hold recording
+        // Single key-down should start toggle immediately — no release needed
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
-        monitor.handleFlagsChanged(keyCode: 55, flags: [])
 
         #expect(toggleStartCount == 1)
         #expect(startCount == 0)
+        #expect(armCount == 0)
         #expect(monitor.isToggleRecording)
     }
 
-    @Test("tap-to-toggle stops toggle on next tap")
+    @Test("tap-to-toggle key-up does not stop toggle")
+    @MainActor
+    func tapToToggleKeyUpDoesNotStop() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStopCount = 0
+        monitor.onToggleStop = {
+            toggleStopCount += 1
+        }
+
+        // Start toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(monitor.isToggleRecording)
+
+        // Key-up should NOT stop toggle — it persists until next key-down
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(monitor.isToggleRecording)
+        #expect(toggleStopCount == 0)
+    }
+
+    @Test("tap-to-toggle stops toggle on next key down")
     @MainActor
     func tapToToggleStopsOnNextTap() {
         let scheduler = ManualHotkeyScheduler()
@@ -2264,12 +2289,44 @@ struct HotkeyMonitorTests {
 
         // First tap → start
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
-        monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(toggleStartCount == 1)
         #expect(monitor.isToggleRecording)
 
+        // Release (no-op)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+
         // Second tap → stop
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+    }
+
+    @Test("tap-to-toggle does not restart after stop on key-up")
+    @MainActor
+    func tapToToggleDoesNotRestartAfterStop() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        var toggleStopCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+        monitor.onToggleStop = {
+            toggleStopCount += 1
+        }
+
+        // Start → release → stop
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStartCount == 1)
+        #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+
+        // Key-up after stop must NOT restart toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
         #expect(toggleStopCount == 1)
         #expect(!monitor.isToggleRecording)
     }
@@ -2289,7 +2346,7 @@ struct HotkeyMonitorTests {
             startCount += 1
         }
 
-        // Press and hold — timers should not fire in tap-to-toggle mode
+        // Press and hold — hold timers should not fire in tap-to-toggle mode
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
         scheduler.advance(by: 0.50)
 
@@ -2311,10 +2368,10 @@ struct HotkeyMonitorTests {
 
         // First tap → toggle start (not waiting for double-tap)
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
-        monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(toggleStartCount == 1)
 
-        // Wait beyond double-tap window
+        // Release and wait beyond double-tap window
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
         scheduler.advance(by: 0.40)
 
         // No additional toggle start from stale double-tap detection

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -2439,6 +2439,7 @@ struct HotkeyMonitorTests {
         // Another modifier key pressed — should cancel toggle
         monitor.handleFlagsChanged(keyCode: 56, flags: .shift)
 
+        #expect(cancelCount == 1)
         #expect(!monitor.isToggleRecording)
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -882,6 +882,8 @@ struct AppConfigTests {
         #expect(config.contributionLinkedInClicked == false)
         #expect(config.upcomingMeetingsDayCount == UpcomingMeetingsWindow.defaultDayCount)
         #expect(config.hiddenCalendarEventSourceHints.isEmpty)
+        #expect(config.dictationTriggerMode == DictationTriggerMode.holdToRecord.rawValue)
+        #expect(config.resolvedDictationTriggerMode == .holdToRecord)
     }
 
     @Test("LM Studio cleanup readiness requires model and valid URL")
@@ -1079,6 +1081,7 @@ struct AppConfigTests {
             "ek-event-1": UnifiedCalendarEvent.CalendarSource.eventKit.rawValue,
             "google-event-1": UnifiedCalendarEvent.CalendarSource.googleCalendar.rawValue,
         ]
+        config.dictationTriggerMode = DictationTriggerMode.tapToToggle.rawValue
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -1153,6 +1156,8 @@ struct AppConfigTests {
         #expect(decoded.contributionLinkedInClicked == false)
         #expect(decoded.upcomingMeetingsDayCount == UpcomingMeetingsWindow.today.dayCount)
         #expect(decoded.hiddenCalendarEventSourceHints == config.hiddenCalendarEventSourceHints)
+        #expect(decoded.dictationTriggerMode == DictationTriggerMode.tapToToggle.rawValue)
+        #expect(decoded.resolvedDictationTriggerMode == .tapToToggle)
     }
 
     @Test("Automatic diagnostic issue prompts default off when absent")
@@ -2214,6 +2219,132 @@ struct HotkeyMonitorTests {
         scheduler.advance(by: 0.05)
 
         #expect(toggleStartCount == 0)
+    }
+
+    // MARK: - Tap-to-Toggle Mode
+
+    @Test("tap-to-toggle starts toggle on quick tap")
+    @MainActor
+    func tapToToggleStartsOnQuickTap() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        var startCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+        monitor.onStart = {
+            startCount += 1
+        }
+
+        // Quick press and release — should start toggle, not hold recording
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+
+        #expect(toggleStartCount == 1)
+        #expect(startCount == 0)
+        #expect(monitor.isToggleRecording)
+    }
+
+    @Test("tap-to-toggle stops toggle on next tap")
+    @MainActor
+    func tapToToggleStopsOnNextTap() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        var toggleStopCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+        monitor.onToggleStop = {
+            toggleStopCount += 1
+        }
+
+        // First tap → start
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
+        #expect(monitor.isToggleRecording)
+
+        // Second tap → stop
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+    }
+
+    @Test("tap-to-toggle does not start hold timers on key down")
+    @MainActor
+    func tapToToggleSkipsHoldTimers() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var prepareCount = 0
+        var startCount = 0
+        monitor.onPrepare = {
+            prepareCount += 1
+        }
+        monitor.onStart = {
+            startCount += 1
+        }
+
+        // Press and hold — timers should not fire in tap-to-toggle mode
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        scheduler.advance(by: 0.50)
+
+        #expect(prepareCount == 0)
+        #expect(startCount == 0)
+    }
+
+    @Test("tap-to-toggle ignores double-tap detection")
+    @MainActor
+    func tapToToggleIgnoresDoubleTap() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        monitor.doubleTapEnabled = true
+        var toggleStartCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+
+        // First tap → toggle start (not waiting for double-tap)
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
+
+        // Wait beyond double-tap window
+        scheduler.advance(by: 0.40)
+
+        // No additional toggle start from stale double-tap detection
+        #expect(toggleStartCount == 1)
+    }
+
+    @Test("hold-to-record mode still works when tap-to-toggle is disabled")
+    @MainActor
+    func holdToRecordStillWorksWhenTapToToggleDisabled() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = false
+        monitor.doubleTapEnabled = false
+        var startCount = 0
+        var stopCount = 0
+        monitor.onStart = {
+            startCount += 1
+        }
+        monitor.onStop = {
+            stopCount += 1
+        }
+
+        // Hold past threshold → start
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        scheduler.advance(by: 0.30)
+        #expect(startCount == 1)
+
+        // Release → stop
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(stopCount == 1)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1638,6 +1638,19 @@ struct AppConfigTests {
         #expect(config.resolvedOnboardingUseCase == .dictation)
     }
 
+    @Test("unsupported dictation trigger mode falls back to hold-to-record")
+    func unsupportedDictationTriggerModeFallsBackToHoldToRecord() throws {
+        let json = """
+        {
+          "dictation_trigger_mode": "unknown_mode"
+        }
+        """
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.resolvedDictationTriggerMode == .holdToRecord)
+    }
+
     @Test("voice notes use push-to-talk without paste dictation")
     func voiceNotesUsePushToTalkWithoutPasteDictation() {
         #expect(OnboardingUseCase.voiceNotes.includesVoiceNotes)
@@ -2402,6 +2415,54 @@ struct HotkeyMonitorTests {
         // Release → stop
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(stopCount == 1)
+    }
+
+    @Test("tap-to-toggle cancels when interrupted by another key")
+    @MainActor
+    func tapToToggleCancelsWhenInterruptedByOtherKey() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        var cancelCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        // Key-down starts toggle, then another key interrupts
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStartCount == 1)
+
+        // Another modifier key pressed — should cancel toggle
+        monitor.handleFlagsChanged(keyCode: 56, flags: .shift)
+
+        #expect(!monitor.isToggleRecording)
+    }
+
+    @Test("reconfiguring hotkey during active tap-to-toggle cancels cleanly")
+    @MainActor
+    func configureKeyCodeDuringActiveTapToToggleCancelsCleanly() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStopCount = 0
+        monitor.onToggleStart = {}
+        monitor.onToggleStop = {
+            toggleStopCount += 1
+        }
+
+        // Start toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(monitor.isToggleRecording)
+
+        // Reconfigure key code — should cancel active toggle
+        monitor.configure(keyCode: 56)
+
+        #expect(!monitor.isToggleRecording)
+        #expect(toggleStopCount == 1)
+        #expect(monitor.targetKeyCode == 56)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a `DictationTriggerMode` setting that lets users choose between two ways to trigger dictation:

- **Hold to Record** (default, existing behavior): Hold the hotkey to record, release to paste. Double-tap for hands-free remains available.
- **Tap to Toggle** (new): A single tap of the hotkey starts hands-free recording; tap again to stop. No need to hold the key or double-tap.

## Motivation

Some users find holding the hotkey awkward for longer dictations, and double-tap timing can be finicky. Tap-to-toggle gives a simpler one-tap start/stop that works more like a walkie-talkie toggle.

## Changes

- `DictationTriggerMode` enum (`.holdToRecord` / `.tapToToggle`) in `Models.swift` with `resolvedDictationTriggerMode` helper
- `HotkeyMonitor.tapToToggleEnabled` — when enabled, skips hold timers and double-tap detection; a quick press-and-release enters toggle mode
- Wired through `MuesliController` to both dictation and computer-use hotkey monitors
- Settings UI: segmented picker in Settings → Shortcuts, above the existing Hands-Free Mode toggle (which is disabled when tap-to-toggle is selected since it becomes redundant)
- Config key: `dictation_trigger_mode` (default: `hold_to_record`)

## Tests

- `tapToToggleStartsOnQuickTap` — single tap starts toggle, not hold recording
- `tapToToggleStopsOnNextTap` — second tap stops toggle
- `tapToToggleSkipsHoldTimers` — holding the key does not start hold recording
- `tapToToggleIgnoresDoubleTap` — no stale double-tap detection
- `holdToRecordStillWorksWhenTapToToggleDisabled` — existing behavior preserved
- Config default and JSON round-trip tests

## Test commands run

```bash
swift build --package-path native/MuesliNative
./scripts/test_classify_changed_files.sh
./scripts/test_ci_test_shards.sh
```

Note: `swift test` requires full Xcode (not CommandLineTools) for the Swift Testing module. Build and CI checks pass locally.

## AI Assistance

This PR was created with AI assistance using Sarvam Code. I reviewed and tested the resulting changes. No third-party code, data, or model output is included.

🪷 Generated with Sarvam Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790096778&installation_model_id=422865&pr_number=460&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F460&signature=09cbdeedca3a19f83ad0d0fa600914545e8b8ae4204daa30b80a058c0737288a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Dictation Trigger** setting with **Hold to Record** and **Tap to Toggle** options.
  * Tap to Toggle starts dictation immediately when the configured key is pressed and remains active after release.
  * Press the key again to stop dictation.
  * Pressing another modifier cancels Tap to Toggle.
  * Existing hold-to-record behavior remains available by default.
  * The hands-free double-tap toggle is disabled when Tap to Toggle is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->