### PR TITLE
feat: add Enter-to-submit during toggle dictation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -296,9 +296,9 @@ final class HotkeyMonitor {
         }
 
         // Enter during toggle mode: stop dictation and submit (paste + Enter).
-        // Consume the event so the physical keypress doesn't reach the
-        // frontmost app — the synthetic Return after paste handles submission.
-        if type == .keyDown && keyCode == 36 && toggleActive {
+        // Only the dictation monitor has onToggleStopAndSubmit wired — gate on
+        // it so Enter doesn't interfere with computer-use or meeting toggles.
+        if type == .keyDown && keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil {
             fputs("[hotkey] enter → toggle stop and submit (combination)\n", stderr)
             toggleActive = false
             cancelTimers()
@@ -537,9 +537,9 @@ final class HotkeyMonitor {
         }
 
         // Enter during toggle mode: stop dictation and submit (paste + Enter).
-        // Consume the event so the physical keypress doesn't reach the
-        // frontmost app — the synthetic Return after paste handles submission.
-        if keyCode == 36 && toggleActive {
+        // Only the dictation monitor has onToggleStopAndSubmit wired — gate on
+        // it so Enter doesn't interfere with computer-use or meeting toggles.
+        if keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil {
             fputs("[hotkey] enter → toggle stop and submit\n", stderr)
             toggleActive = false
             cancelTimers()

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -32,6 +32,7 @@ final class HotkeyMonitor {
     var onCancel: (() -> Void)?
     var onToggleStart: (() -> Void)?
     var onToggleStop: (() -> Void)?
+    var onToggleStopAndSubmit: (() -> Void)?
     var targetKeyCode: UInt16 = 55
     var doubleTapEnabled: Bool = true
 
@@ -519,6 +520,15 @@ final class HotkeyMonitor {
                 cancelTimers()
                 onCancel?()
             }
+            return
+        }
+
+        // Enter during toggle mode: stop dictation and submit (paste + Enter)
+        if keyCode == 36 && toggleActive {
+            fputs("[hotkey] enter → toggle stop and submit\n", stderr)
+            toggleActive = false
+            cancelTimers()
+            onToggleStopAndSubmit?()
             return
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -295,6 +295,17 @@ final class HotkeyMonitor {
             return false
         }
 
+        // Enter during toggle mode: stop dictation and submit (paste + Enter).
+        // Consume the event so the physical keypress doesn't reach the
+        // frontmost app — the synthetic Return after paste handles submission.
+        if type == .keyDown && keyCode == 36 && toggleActive {
+            fputs("[hotkey] enter → toggle stop and submit (combination)\n", stderr)
+            toggleActive = false
+            cancelTimers()
+            onToggleStopAndSubmit?()
+            return true
+        }
+
         guard let targetMods = combinationModifiers,
               let targetKey = combinationKeyCode else { return false }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -256,12 +256,12 @@ final class HotkeyMonitor {
         switch event.type {
         case .flagsChanged:
             handleFlagsChanged(keyCode: event.keyCode, flags: event.modifierFlags)
+            return false
         case .keyDown:
-            handleKeyDown(keyCode: event.keyCode)
+            return handleKeyDown(keyCode: event.keyCode)
         default:
-            break
+            return false
         }
-        return false
     }
 
     @discardableResult
@@ -492,7 +492,8 @@ final class HotkeyMonitor {
         }
     }
 
-    func handleKeyDown(keyCode: UInt16) {
+    @discardableResult
+    func handleKeyDown(keyCode: UInt16) -> Bool {
         // Escape cancels any active recording
         if keyCode == 53 {
             if toggleActive {
@@ -500,7 +501,7 @@ final class HotkeyMonitor {
                 toggleActive = false
                 cancelTimers()
                 onCancel?()
-                return
+                return true
             }
             if active {
                 fputs("[hotkey] escape → cancel hold\n", stderr)
@@ -510,7 +511,7 @@ final class HotkeyMonitor {
                 armed = false
                 cancelTimers()
                 onCancel?()
-                return
+                return true
             }
             if armed || prepared {
                 fputs("[hotkey] escape → cancel armed hold\n", stderr)
@@ -519,17 +520,20 @@ final class HotkeyMonitor {
                 prepared = false
                 cancelTimers()
                 onCancel?()
+                return true
             }
-            return
+            return false
         }
 
-        // Enter during toggle mode: stop dictation and submit (paste + Enter)
+        // Enter during toggle mode: stop dictation and submit (paste + Enter).
+        // Consume the event so the physical keypress doesn't reach the
+        // frontmost app — the synthetic Return after paste handles submission.
         if keyCode == 36 && toggleActive {
             fputs("[hotkey] enter → toggle stop and submit\n", stderr)
             toggleActive = false
             cancelTimers()
             onToggleStopAndSubmit?()
-            return
+            return true
         }
 
         if targetKeyDown && !toggleActive {
@@ -552,6 +556,7 @@ final class HotkeyMonitor {
                 }
             }
         }
+        return false
     }
 
     private func scheduleTimers() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1296,6 +1296,10 @@ struct AppConfig: Codable {
     var waveformCacheOrphanCleanupMigrationApplied: Bool = false
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
+    /// When enabled, pressing Enter during toggle (hands-free) dictation stops
+    /// recording, pastes the transcript, and sends an Enter keypress to the
+    /// frontmost app — e.g. submitting a prompt in Cursor or Codex.
+    var enableSubmitOnEnter: Bool = false
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var computerUseHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var meetingRecordingHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultMeetingThresholdMilliseconds
@@ -1423,6 +1427,7 @@ struct AppConfig: Codable {
         case waveformCacheOrphanCleanupMigrationApplied = "waveform_cache_orphan_cleanup_migration_applied"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
+        case enableSubmitOnEnter = "enable_submit_on_enter"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case computerUseHotkeyTriggerThresholdMS = "computer_use_hotkey_trigger_threshold_ms"
         case meetingRecordingHotkeyTriggerThresholdMS = "meeting_recording_hotkey_trigger_threshold_ms"
@@ -1577,6 +1582,7 @@ struct AppConfig: Codable {
         iCloudSyncEnabled = (try? c.decode(Bool.self, forKey: .iCloudSyncEnabled)) ?? defaults.iCloudSyncEnabled
         showIOSCompanionPrompt = (try? c.decode(Bool.self, forKey: .showIOSCompanionPrompt)) ?? defaults.showIOSCompanionPrompt
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
+        enableSubmitOnEnter = (try? c.decode(Bool.self, forKey: .enableSubmitOnEnter)) ?? defaults.enableSubmitOnEnter
         hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
             (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8866,6 +8866,7 @@ public final class MuesliController: NSObject {
         if isMeetingRecording() { return false }
         if blockDictationForMeetingActivityIfNeeded() { return false }
         fputs("[muesli-native] toggle dictation start\n", stderr)
+        pendingSubmitAfterPaste = false
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "toggle")
         }
@@ -8991,11 +8992,16 @@ public final class MuesliController: NSObject {
     private func handleStop() {
         if isMeetingRecording() {
             cancelDictationAudioSessionForMeetingRecordingIfNeeded()
+            pendingSubmitAfterPaste = false
             return
         }
-        if shouldIgnoreDictationCleanupForComputerUseActivity() { return }
+        if shouldIgnoreDictationCleanupForComputerUseActivity() {
+            pendingSubmitAfterPaste = false
+            return
+        }
         if shouldIgnoreCleanupAfterBlockedDictationStart {
             fputs("[muesli-native] ignoring dictation stop because start was blocked\n", stderr)
+            pendingSubmitAfterPaste = false
             return
         }
         fputs("[muesli-native] stop\n", stderr)
@@ -9133,8 +9139,10 @@ public final class MuesliController: NSObject {
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
         if pendingSubmitAfterPaste {
             pendingSubmitAfterPaste = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                PasteController.simulateReturnKey()
+            if !cleaned.isEmpty {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    PasteController.simulateReturnKey()
+                }
             }
         }
     }
@@ -9188,6 +9196,7 @@ public final class MuesliController: NSObject {
         markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
             fputs("[muesli-native] stop without wav\n", stderr)
+            pendingSubmitAfterPaste = false
             clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
@@ -9203,6 +9212,7 @@ public final class MuesliController: NSObject {
             if isDictationTestMode {
                 dictationTestCallback?("")
             }
+            pendingSubmitAfterPaste = false
             clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
@@ -9261,6 +9271,7 @@ public final class MuesliController: NSObject {
                 if isTestMode {
                     await MainActor.run {
                         self.dictationTestCallback?(text)
+                        self.pendingSubmitAfterPaste = false
                         self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
@@ -9344,6 +9355,7 @@ public final class MuesliController: NSObject {
                             }
                         )
                     } else {
+                        self.pendingSubmitAfterPaste = false
                         self.releaseStandardDictationState()
                         self.markDictationLatency("user_visible_completion", trace: completionLatencyTrace)
                         self.finishStandardDictationBookkeeping(
@@ -9364,6 +9376,7 @@ public final class MuesliController: NSObject {
             } catch is CancellationError {
                 fputs("[muesli-native] test dictation cancelled\n", stderr)
                 await MainActor.run {
+                    self.pendingSubmitAfterPaste = false
                     self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
                     self.setState(.idle)
@@ -9374,6 +9387,7 @@ public final class MuesliController: NSObject {
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
                 await MainActor.run {
+                    self.pendingSubmitAfterPaste = false
                     if self.isDictationTestMode {
                         self.dictationTestFailureCallback?(self.userFacingDictationTestError(error))
                     } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8835,6 +8835,7 @@ public final class MuesliController: NSObject {
             return
         }
         fputs("[muesli-native] cancel\n", stderr)
+        pendingSubmitAfterPaste = false
         resetDictationOutputMode()
 
         if isNemotron35Streaming {
@@ -9141,7 +9142,7 @@ public final class MuesliController: NSObject {
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
         if pendingSubmitAfterPaste {
             pendingSubmitAfterPaste = false
-            if !cleaned.isEmpty {
+            if outputMode == .paste, !cleaned.isEmpty {
                 let targetPID = targetApp?.processID
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     PasteController.simulateReturnKey(expectedTargetPID: targetPID)
@@ -9328,7 +9329,7 @@ public final class MuesliController: NSObject {
                                     trace: completionLatencyTrace
                                 )
                             },
-                            onClipboardSettled: { [weak self] in
+                            onClipboardSettled: { [weak self] pasteSucceeded in
                                 guard let self else { return }
                                 self.finishStandardDictationBookkeeping(
                                     text: text,
@@ -9345,6 +9346,11 @@ public final class MuesliController: NSObject {
                                 )
                                 if self.pendingSubmitAfterPaste {
                                     self.pendingSubmitAfterPaste = false
+                                    // Only send Return when the paste actually delivered text.
+                                    // If clipboard staging failed or ownership was lost, the
+                                    // transcript never reached the target app — sending Return
+                                    // would submit an empty or stale compose box.
+                                    guard pasteSucceeded else { return }
                                     let targetPID = completionTargetApp?.processID
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                         PasteController.simulateReturnKey(expectedTargetPID: targetPID)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8691,6 +8691,7 @@ public final class MuesliController: NSObject {
         // backends (see isStreamingDictationBackend) so the double-tap detection window
         // stays clean; beginRecording cold-starts here just like the toggle path.
         fputs("[muesli-native] recording start\n", stderr)
+        pendingSubmitAfterPaste = false
         meetingMonitor.suppressWhileActive()
         beginDictationOutput()
         dictationStartedAt = nil
@@ -8814,6 +8815,7 @@ public final class MuesliController: NSObject {
         nemotron35StreamingSessionID = nil
         previousStreamText = ""
         dictationStartedAt = nil
+        pendingSubmitAfterPaste = false
         clearCapturedDictationSessionContext()
         dictationAudioSessionManager.endExternalSession(reason: "nemotron-runtime-failed")
         indicator.setToggleDictation(false, config: config)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -439,6 +439,9 @@ public final class MuesliController: NSObject {
     private var pendingDictationStopStartedAt: Date?
     private var pendingDictationStopSessionID: UUID?
     private var pendingReleaseSoundSessionID: UUID?
+    /// Set when Enter-to-submit is triggered during toggle dictation. After the
+    /// transcript is pasted, a Return keypress is sent to the frontmost app.
+    private var pendingSubmitAfterPaste: Bool = false
     private var pendingPreparingIndicatorWorkItem: DispatchWorkItem?
     private var activeComputerUseAudioSessionID: UUID?
     private var computerUseCommandStartedAt: Date?
@@ -636,6 +639,7 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.onCancel = { [weak self] in self?.handleCancel() }
         hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
+        hotkeyMonitor.onToggleStopAndSubmit = { [weak self] in self?.handleToggleStopAndSubmit() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         configureHotkeyMonitorTiming()
         computerUseHotkeyMonitor.onPrepare = { [weak self] in self?.handleComputerUsePrepare() }
@@ -8911,6 +8915,20 @@ public final class MuesliController: NSObject {
         handleStop()
     }
 
+    /// Called when Enter is pressed during toggle dictation with submit-on-enter
+    /// enabled. Stops dictation (triggering transcription + paste) and arms a
+    /// flag so a Return keypress is sent to the frontmost app after paste settles.
+    private func handleToggleStopAndSubmit() {
+        guard config.enableSubmitOnEnter else {
+            handleToggleStop()
+            return
+        }
+        fputs("[muesli-native] toggle dictation stop and submit\n", stderr)
+        pendingSubmitAfterPaste = true
+        indicator.isToggleDictation = false
+        handleStop()
+    }
+
     func toggleVoiceNoteRecording() {
         if dictationStartedAt != nil || dictationAudioSessionManager.hasActiveSession || isNemotron35Streaming {
             handleToggleStop()
@@ -9113,6 +9131,12 @@ public final class MuesliController: NSObject {
         fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
         finishDictationLatencyTrace("nemotron_stop")
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
+        if pendingSubmitAfterPaste {
+            pendingSubmitAfterPaste = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                PasteController.simulateReturnKey()
+            }
+        }
     }
 
     /// Releases the user-visible dictation state immediately after Cmd+V. Keep this path
@@ -9252,6 +9276,7 @@ public final class MuesliController: NSObject {
                 }
                 guard !text.isEmpty else {
                     await MainActor.run {
+                        self.pendingSubmitAfterPaste = false
                         self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
@@ -9304,6 +9329,12 @@ public final class MuesliController: NSObject {
                                     "bookkeeping_completed",
                                     trace: completionLatencyTrace
                                 )
+                                if self.pendingSubmitAfterPaste {
+                                    self.pendingSubmitAfterPaste = false
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                        PasteController.simulateReturnKey()
+                                    }
+                                }
                             },
                             onLifecycleEvent: { [weak self] event in
                                 self?.markDictationLatency(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -9142,8 +9142,9 @@ public final class MuesliController: NSObject {
         if pendingSubmitAfterPaste {
             pendingSubmitAfterPaste = false
             if !cleaned.isEmpty {
+                let targetPID = targetApp?.processID
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    PasteController.simulateReturnKey()
+                    PasteController.simulateReturnKey(expectedTargetPID: targetPID)
                 }
             }
         }
@@ -9344,8 +9345,9 @@ public final class MuesliController: NSObject {
                                 )
                                 if self.pendingSubmitAfterPaste {
                                     self.pendingSubmitAfterPaste = false
+                                    let targetPID = completionTargetApp?.processID
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                        PasteController.simulateReturnKey()
+                                        PasteController.simulateReturnKey(expectedTargetPID: targetPID)
                                     }
                                 }
                             },

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -147,6 +147,26 @@ enum PasteController {
 
     // MARK: - Private
 
+    /// Simulate a Return (Enter) keypress in the frontmost app. Used to submit
+    /// the just-pasted prompt in apps like Cursor or Codex.
+    @MainActor
+    static func simulateReturnKey() -> Bool {
+        guard let source = CGEventSource(stateID: .combinedSessionState) else {
+            fputs("[muesli-native] failed to create event source for return key\n", stderr)
+            return false
+        }
+        let keyCode: CGKeyCode = 36 // Return
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        else {
+            fputs("[muesli-native] failed to create keyboard events for return key\n", stderr)
+            return false
+        }
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+        return true
+    }
+
     private static func simulatePaste() -> Bool {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             fputs("[muesli-native] failed to create event source for paste\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -149,8 +149,31 @@ enum PasteController {
 
     /// Simulate a Return (Enter) keypress in the frontmost app. Used to submit
     /// the just-pasted prompt in apps like Cursor or Codex.
+    ///
+    /// If `expectedTargetPID` is provided, the Return is only posted when the
+    /// frontmost app at call time still matches that PID. This prevents the
+    /// Return from landing in a different app if the user Cmd-Tabbed away
+    /// during the paste → submit delay.
+    ///
+    /// `frontmostApplicationProvider` is injectable for testing.
     @MainActor
-    static func simulateReturnKey() -> Bool {
+    static func simulateReturnKey(
+        expectedTargetPID: pid_t? = nil,
+        frontmostApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
+            NSWorkspace.shared.frontmostApplication
+        }
+    ) -> Bool {
+        // When a target PID is provided, verify the frontmost app still matches
+        // before posting the Return. If the user switched away between paste
+        // and submit, skip the Return rather than sending it to the wrong app.
+        if let expectedPID = expectedTargetPID {
+            let frontmost = frontmostApplicationProvider()
+            guard frontmost?.processIdentifier == expectedPID else {
+                fputs("[muesli-native] skipping return key — frontmost app changed since paste\n", stderr)
+                return false
+            }
+        }
+
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             fputs("[muesli-native] failed to create event source for return key\n", stderr)
             return false

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -63,7 +63,7 @@ enum PasteController {
         },
         simulatePasteAction: @escaping @MainActor () -> Bool = PasteController.simulatePaste,
         onPasteFinished: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in },
-        onClipboardSettled: @escaping @MainActor () -> Void = {},
+        onClipboardSettled: @escaping @MainActor (Bool) -> Void = { _ in },
         onLifecycleEvent: @escaping @MainActor (LifecycleEvent) -> Void = { _ in }
     ) {
         guard !text.isEmpty else { return }
@@ -92,13 +92,13 @@ enum PasteController {
                         onLifecycleEvent(.clipboardRestoreSkipped)
                     }
                     onPasteFinished(nil)
-                    onClipboardSettled()
+                    onClipboardSettled(false)
                     return
                 }
                 guard pasteboard.changeCount == pasteChangeCount else {
                     onLifecycleEvent(.clipboardOwnershipLost)
                     onPasteFinished(nil)
-                    onClipboardSettled()
+                    onClipboardSettled(false)
                     return
                 }
             }
@@ -116,7 +116,7 @@ enum PasteController {
                 } else {
                     onLifecycleEvent(.clipboardRestoreSkipped)
                 }
-                onClipboardSettled()
+                onClipboardSettled(didDispatchPaste)
             }
 
             onPasteFinished(didDispatchPaste ? targetApplication : nil)

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -334,6 +334,27 @@ struct ShortcutsView: View {
                 .tint(MuesliTheme.accent)
                 .labelsHidden()
             }
+
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text("Submit on Enter")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Press Enter during hands-free dictation to stop, paste, and submit in apps like Cursor or Codex")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { appState.config.enableSubmitOnEnter },
+                    set: { newValue in
+                        controller.updateConfig { $0.enableSubmitOnEnter = newValue }
+                    }
+                ))
+                .toggleStyle(.switch)
+                .tint(MuesliTheme.accent)
+                .labelsHidden()
+            }
         }
         .padding(MuesliTheme.spacing16)
         .background(MuesliTheme.backgroundRaised)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -882,6 +882,7 @@ struct AppConfigTests {
         #expect(config.contributionLinkedInClicked == false)
         #expect(config.upcomingMeetingsDayCount == UpcomingMeetingsWindow.defaultDayCount)
         #expect(config.hiddenCalendarEventSourceHints.isEmpty)
+        #expect(config.enableSubmitOnEnter == false)
     }
 
     @Test("LM Studio cleanup readiness requires model and valid URL")
@@ -1079,6 +1080,7 @@ struct AppConfigTests {
             "ek-event-1": UnifiedCalendarEvent.CalendarSource.eventKit.rawValue,
             "google-event-1": UnifiedCalendarEvent.CalendarSource.googleCalendar.rawValue,
         ]
+        config.enableSubmitOnEnter = true
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -1153,6 +1155,7 @@ struct AppConfigTests {
         #expect(decoded.contributionLinkedInClicked == false)
         #expect(decoded.upcomingMeetingsDayCount == UpcomingMeetingsWindow.today.dayCount)
         #expect(decoded.hiddenCalendarEventSourceHints == config.hiddenCalendarEventSourceHints)
+        #expect(decoded.enableSubmitOnEnter == true)
     }
 
     @Test("Automatic diagnostic issue prompts default off when absent")
@@ -2214,6 +2217,86 @@ struct HotkeyMonitorTests {
         scheduler.advance(by: 0.05)
 
         #expect(toggleStartCount == 0)
+    }
+
+    // MARK: - Submit on Enter
+
+    @Test("Enter during toggle fires stop-and-submit callback")
+    @MainActor
+    func enterDuringToggleFiresStopAndSubmit() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        var toggleStartCount = 0
+        var toggleStopCount = 0
+        var submitCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+        monitor.onToggleStop = {
+            toggleStopCount += 1
+        }
+        monitor.onToggleStopAndSubmit = {
+            submitCount += 1
+        }
+
+        // Start toggle via double-tap
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStartCount == 1)
+        #expect(monitor.isToggleRecording)
+
+        // Press Enter → should fire submit, not plain stop
+        monitor.handleKeyDown(keyCode: 36)
+
+        #expect(submitCount == 1)
+        #expect(toggleStopCount == 0)
+        #expect(!monitor.isToggleRecording)
+    }
+
+    @Test("Enter does nothing when toggle is not active")
+    @MainActor
+    func enterDoesNothingWhenToggleNotActive() {
+        let monitor = HotkeyMonitor()
+        var submitCount = 0
+        var cancelCount = 0
+        monitor.onToggleStopAndSubmit = {
+            submitCount += 1
+        }
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        // Enter when idle → no-op
+        monitor.handleKeyDown(keyCode: 36)
+        #expect(submitCount == 0)
+        #expect(cancelCount == 0)
+    }
+
+    @Test("Escape still cancels toggle without firing submit")
+    @MainActor
+    func escapeCancelsToggleWithoutFiringSubmit() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        var submitCount = 0
+        var cancelCount = 0
+        monitor.onToggleStart = {}
+        monitor.onToggleStopAndSubmit = {
+            submitCount += 1
+        }
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        // Start toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(monitor.isToggleRecording)
+
+        // Escape → cancel, not submit
+        monitor.handleKeyDown(keyCode: 53)
+        #expect(cancelCount == 1)
+        #expect(submitCount == 0)
+        #expect(!monitor.isToggleRecording)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -137,7 +137,7 @@ struct PasteControllerTests {
                 onPasteFinished: { _ in
                     events.append("completion_bookkeeping")
                 },
-                onClipboardSettled: {
+                onClipboardSettled: { _ in
                     events.append("clipboard_settled")
                     continuation.resume(returning: events)
                 },
@@ -206,6 +206,56 @@ struct PasteControllerTests {
         #expect(events == ["snapshot", "unattributed"])
         try await Task.sleep(nanoseconds: 700_000_000)
         #expect(pasteboard.string(forType: .string) == "user-copied-during-delay")
+    }
+
+    @Test("onClipboardSettled reports false when clipboard ownership is lost")
+    func clipboardSettledReportsFalseOnOwnershipLoss() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let pasteSucceeded = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                requireStagedClipboardOwnership: true,
+                targetApplicationProvider: {
+                    // Simulate another app writing to the clipboard between staging and dispatch
+                    pasteboard.clearContents()
+                    pasteboard.setString("user-copied-during-delay", forType: .string)
+                    return NSRunningApplication.current
+                },
+                simulatePasteAction: { true },
+                onClipboardSettled: { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            )
+        }
+
+        // When clipboard ownership is lost, paste never dispatched — must report false
+        #expect(pasteSucceeded == false)
+    }
+
+    @Test("onClipboardSettled reports true after successful paste dispatch")
+    func clipboardSettledReportsTrueOnSuccess() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let pasteSucceeded = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                requireStagedClipboardOwnership: true,
+                targetApplicationProvider: { NSRunningApplication.current },
+                simulatePasteAction: { true },
+                onClipboardSettled: { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            )
+        }
+
+        #expect(pasteSucceeded == true)
     }
 
     @Test("shared paste remains ungated unless clipboard ownership is required")

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -330,6 +330,66 @@ struct PasteControllerTests {
         #expect(pasteboard.string(forType: .string) == "user-copied-after-paste")
     }
 
+    // MARK: - simulateReturnKey target verification
+
+    @Test("simulateReturnKey without target PID posts unconditionally")
+    func returnKeyWithoutTargetPIDPostsUnconditionally() {
+        // When no expectedTargetPID is provided, the Return should be posted
+        // regardless of the frontmost app (backward-compatible behavior).
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: nil,
+            frontmostApplicationProvider: { NSRunningApplication.current }
+        )
+        #expect(result == true)
+    }
+
+    @Test("simulateReturnKey posts when frontmost matches expected PID")
+    func returnKeyPostsWhenFrontmostMatches() {
+        let targetApp = NSRunningApplication.current
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: targetApp.processIdentifier,
+            frontmostApplicationProvider: { targetApp }
+        )
+        #expect(result == true)
+    }
+
+    @Test("simulateReturnKey skips when frontmost app changed since paste")
+    func returnKeySkipsWhenFrontmostChanged() {
+        // Simulate: paste went to app with PID 99999, but by the time the
+        // Return fires, the frontmost app has a different PID.
+        let originalApp = NSRunningApplication.current
+        let differentPID: pid_t = 99999
+        // Only proceed if the current app's PID actually differs from our fake PID
+        guard originalApp.processIdentifier != differentPID else {
+            // Extremely unlikely, but guard against it
+            return
+        }
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: differentPID,
+            frontmostApplicationProvider: { originalApp }
+        )
+        #expect(result == false)
+    }
+
+    @Test("simulateReturnKey skips when frontmost app is nil")
+    func returnKeySkipsWhenFrontmostIsNil() {
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: 12345,
+            frontmostApplicationProvider: { nil }
+        )
+        #expect(result == false)
+    }
+
+    @Test("simulateReturnKey posts when expected PID is nil (no guard)")
+    func returnKeyPostsWhenExpectedPIDIsNil() {
+        // nil PID means "no target verification" — should post unconditionally
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: nil,
+            frontmostApplicationProvider: { nil }
+        )
+        #expect(result == true)
+    }
+
     private func makePasteboard() -> NSPasteboard {
         let name = NSPasteboard.Name("com.muesli.tests.PasteController.\(UUID().uuidString)")
         return NSPasteboard(name: name)


### PR DESCRIPTION
## Summary

When **Submit on Enter** is enabled, pressing Enter during hands-free (toggle) dictation stops recording, pastes the transcript, and then sends a Return keypress to the frontmost app. This lets you dictate a prompt and submit it in one action — e.g. in Cursor or Codex.

## Motivation

When using Muesli to dictate prompts into AI coding tools (Cursor, Codex), the workflow is: start toggle dictation → speak → stop → paste → manually press Enter to submit. This feature collapses the last two steps: pressing Enter stops the dictation, pastes, and submits automatically.

## Changes

- **`HotkeyMonitor`**: detects Enter (keyCode 36) during `toggleActive` and fires a new `onToggleStopAndSubmit` callback instead of the normal stop path
- **`PasteController.simulateReturnKey()`**: new method that posts a Return keypress via `CGEvent`, mirroring the existing `simulatePaste()` pattern
- **`MuesliController.handleToggleStopAndSubmit()`**: sets a `pendingSubmitAfterPaste` flag, stops dictation normally (triggering transcription + paste), and after the clipboard settles sends Return via `simulateReturnKey()`
- Handles both the standard paste path and the Nemotron streaming path (which types directly instead of pasting)
- Empty transcriptions clear the pending flag without sending Enter
- Settings UI: toggle in Settings → Shortcuts → Submit on Enter
- Config key: `enable_submit_on_enter` (default: `false`)

## Tests

- `enterDuringToggleFiresStopAndSubmit` — Enter during toggle fires the submit callback, not plain stop
- `enterDoesNothingWhenToggleNotActive` — Enter when idle is a no-op
- `escapeCancelsToggleWithoutFiringSubmit` — Escape still cancels without submitting
- Config default and JSON round-trip tests

## Test commands run

```bash
swift build --package-path native/MuesliNative
./scripts/test_classify_changed_files.sh
./scripts/test_ci_test_shards.sh
```

Note: `swift test` requires full Xcode (not CommandLineTools) for the Swift Testing module. Build and CI checks pass locally.

## AI Assistance

This PR was created with AI assistance using Sarvam Code. I reviewed and tested the resulting changes. No third-party code, data, or model output is included.

🪷 Generated with Sarvam Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790096803&installation_model_id=422865&pr_number=461&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F461&signature=89fa6f0b1bd24c0824c11e63f4143c62d649425f8c440399612dbfd68f6245cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Submit on Enter” setting for Hands-Free Mode.
  * Pressing Enter during toggle dictation stops recording and submits captured text automatically.
  * The Enter keypress is prevented from reaching the active application after submission.
  * Empty dictation results do not trigger submission.
  * The setting is saved and restored between sessions.
  * Existing behavior remains unchanged when the setting is disabled.
* **Bug Fixes**
  * Escape continues to cancel active dictation without submitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->