### PR TITLE
feat(dictation): reduce output volume to 50% while dictation is active

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -3,6 +3,7 @@ import Foundation
 
 protocol AudioDuckingManaging: AnyObject {
     func beginDictationDucking(enabled: Bool)
+    func beginDictationDucking(enabled: Bool, attenuationLevel: Float32?)
     func ensureCurrentDefaultDucked()
     func restoreDictationDucking(completion: (() -> Void)?)
 }
@@ -10,6 +11,10 @@ protocol AudioDuckingManaging: AnyObject {
 extension AudioDuckingManaging {
     func restoreDictationDucking() {
         restoreDictationDucking(completion: nil)
+    }
+
+    func beginDictationDucking(enabled: Bool) {
+        beginDictationDucking(enabled: enabled, attenuationLevel: nil)
     }
 }
 
@@ -50,6 +55,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     private struct VolumeMutation {
         let element: AudioObjectPropertyElement
         let previousValue: Float32
+        let attenuatedValue: Float32
     }
 
     private struct DeviceSnapshot {
@@ -68,6 +74,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     private let stabilizationTimeout: TimeInterval
     private let stabilizationPollInterval: TimeInterval
     private var duckingEnabledForSession = false
+    private var attenuationLevelForSession: Float32?
     private var snapshots: [AudioObjectID: DeviceSnapshot] = [:]
     private var restoreGeneration = 0
     private var isRestorePending = false
@@ -86,15 +93,22 @@ final class AudioDuckingController: AudioDuckingManaging {
     }
 
     func beginDictationDucking(enabled: Bool) {
+        beginDictationDucking(enabled: enabled, attenuationLevel: nil)
+    }
+
+    func beginDictationDucking(enabled: Bool, attenuationLevel: Float32?) {
+        let clampedLevel = attenuationLevel.map { max(0, min(1, $0)) }
         queue.async { [self] in
             guard enabled else {
                 self.cancelPendingRestoreLocked(preserveCompletions: true)
                 self.duckingEnabledForSession = false
+                self.attenuationLevelForSession = nil
                 self.restoreLocked(completion: nil)
                 return
             }
             self.cancelPendingRestoreLocked(preserveCompletions: false)
             self.duckingEnabledForSession = true
+            self.attenuationLevelForSession = clampedLevel
             guard self.shouldDuckCurrentOutput() else { return }
             self.duckCurrentDefaultDevice()
         }
@@ -137,21 +151,61 @@ final class AudioDuckingController: AudioDuckingManaging {
         let sampleRate = client.nominalSampleRate(for: deviceID)
         var snapshot = DeviceSnapshot(deviceID: deviceID, sampleRate: sampleRate)
 
-        let muteElements = client.muteElements(for: deviceID)
-        for element in muteElements {
-            guard let isMuted = client.isMuted(deviceID: deviceID, element: element),
-                  !isMuted else { continue }
-            if client.setMuted(true, deviceID: deviceID, element: element) {
-                snapshot.muteMutations.append(MuteMutation(element: element, previousValue: isMuted))
-            }
-        }
-
-        if snapshot.muteMutations.isEmpty {
+        // When attenuation is requested, use volume scaling rather than muting.
+        // This keeps media audible at reduced level (e.g. 50%) and avoids
+        // toggling the mute control, which is a distinct user preference.
+        if let attenuationLevel = attenuationLevelForSession {
             for element in client.volumeElements(for: deviceID) {
                 guard let volume = client.volume(deviceID: deviceID, element: element),
                       volume > 0.0001 else { continue }
-                if client.setVolume(0, deviceID: deviceID, element: element) {
-                    snapshot.volumeMutations.append(VolumeMutation(element: element, previousValue: volume))
+                // Attenuation is proportional: reduce to `level` fraction of current.
+                // e.g. level 0.5 halves volume (50%). Clamped above to 0...1.
+                // Avoid increasing volume if already below target absolute level:
+                // proportional scaling always reduces, while absolute mode would
+                // otherwise raise quiet sources and increase bleed.
+                let attenuated = max(0, min(1, volume * attenuationLevel))
+                // Skip if attenuation would not change volume meaningfully.
+                guard abs(attenuated - volume) > 0.0001, attenuated < volume else { continue }
+                if client.setVolume(attenuated, deviceID: deviceID, element: element) {
+                    snapshot.volumeMutations.append(VolumeMutation(
+                        element: element,
+                        previousValue: volume,
+                        attenuatedValue: attenuated
+                    ))
+                }
+            }
+            // Fallback: if device has no volume control but has mute, still mute as last resort
+            if snapshot.volumeMutations.isEmpty {
+                let muteElements = client.muteElements(for: deviceID)
+                for element in muteElements {
+                    guard let isMuted = client.isMuted(deviceID: deviceID, element: element),
+                          !isMuted else { continue }
+                    if client.setMuted(true, deviceID: deviceID, element: element) {
+                        snapshot.muteMutations.append(MuteMutation(element: element, previousValue: isMuted))
+                    }
+                }
+            }
+        } else {
+            let muteElements = client.muteElements(for: deviceID)
+            for element in muteElements {
+                guard let isMuted = client.isMuted(deviceID: deviceID, element: element),
+                      !isMuted else { continue }
+                if client.setMuted(true, deviceID: deviceID, element: element) {
+                    snapshot.muteMutations.append(MuteMutation(element: element, previousValue: isMuted))
+                }
+            }
+
+            if snapshot.muteMutations.isEmpty {
+                for element in client.volumeElements(for: deviceID) {
+                    guard let volume = client.volume(deviceID: deviceID, element: element),
+                          volume > 0.0001 else { continue }
+                    if client.setVolume(0, deviceID: deviceID, element: element) {
+                        snapshot.volumeMutations.append(VolumeMutation(
+                            element: element,
+                            previousValue: volume,
+                            attenuatedValue: 0
+                        ))
+                    }
                 }
             }
         }
@@ -198,6 +252,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         let pendingSnapshots = snapshots.values
         snapshots.removeAll()
         duckingEnabledForSession = false
+        attenuationLevelForSession = nil
         isRestorePending = false
         let completions = restoreCompletions
         restoreCompletions.removeAll()
@@ -212,7 +267,9 @@ final class AudioDuckingController: AudioDuckingManaging {
             }
             for mutation in snapshot.volumeMutations {
                 guard let current = client.volume(deviceID: snapshot.deviceID, element: mutation.element),
-                      abs(current) <= 0.0001 else {
+                      abs(current - mutation.attenuatedValue) <= 0.001 else {
+                    // User changed volume during dictation – treat as intentional
+                    // and do not overwrite. See suggested implementation edge case.
                     continue
                 }
                 _ = client.setVolume(mutation.previousValue, deviceID: snapshot.deviceID, element: mutation.element)

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -174,10 +174,9 @@ final class AudioDuckingController: AudioDuckingManaging {
                     ))
                 }
             }
-            // Fallback only when the device exposes no controllable volume elements at all.
-            // Do not fall back to mute merely because attenuation produced no change
-            // (e.g. attenuationLevel == 1.0, or the volume was already at the target).
-            if client.volumeElements(for: deviceID).isEmpty {
+            // Fallback only when attenuation actually wants reduction and no writable volume control exists.
+            // 100% (no reduction) should be no-op even on mute-only devices.
+            if attenuationLevel < 0.999, client.volumeElements(for: deviceID).isEmpty {
                 let muteElements = client.muteElements(for: deviceID)
                 for element in muteElements {
                     guard let isMuted = client.isMuted(deviceID: deviceID, element: element),
@@ -410,7 +409,26 @@ final class CoreAudioDuckingDeviceClient: AudioDuckingDeviceClient {
         ]
         return candidates.filter {
             hasProperty(selector, objectID: deviceID, scope: scope, element: $0)
+                && isPropertySettable(selector, objectID: deviceID, scope: scope, element: $0)
         }
+    }
+
+    private func isPropertySettable(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        var isSettable: DarwinBoolean = false
+        guard AudioObjectIsPropertySettable(objectID, &address, &isSettable) == noErr else {
+            return false
+        }
+        return isSettable.boolValue
     }
 
     private func processObjectIDs() -> [AudioObjectID]? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -97,7 +97,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     }
 
     func beginDictationDucking(enabled: Bool, attenuationLevel: Float32?) {
-        let clampedLevel = attenuationLevel.map { max(0, min(1, $0)) }
+        let clampedLevel = attenuationLevel.map { max(0.1, min(1, $0)) }
         queue.async { [self] in
             guard enabled else {
                 self.cancelPendingRestoreLocked(preserveCompletions: true)
@@ -174,8 +174,10 @@ final class AudioDuckingController: AudioDuckingManaging {
                     ))
                 }
             }
-            // Fallback: if device has no volume control but has mute, still mute as last resort
-            if snapshot.volumeMutations.isEmpty {
+            // Fallback only when the device exposes no controllable volume elements at all.
+            // Do not fall back to mute merely because attenuation produced no change
+            // (e.g. attenuationLevel == 1.0, or the volume was already at the target).
+            if client.volumeElements(for: deviceID).isEmpty {
                 let muteElements = client.muteElements(for: deviceID)
                 for element in muteElements {
                     guard let isMuted = client.isMuted(deviceID: deviceID, element: element),

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -537,9 +537,10 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         attenuationEnabled: Bool = false,
         attenuationLevel: Float32 = 0.5
     ) {
-        // When attenuation is active we deliberately do NOT pause media –
-        // spec says "Do not pause media. Leave output at reduced level."
-        let effectiveMediaPause = attenuationEnabled ? false : mediaPauseEnabled
+        // When attenuation actually applies we do NOT pause media – spec says
+        // "Do not pause media. Leave output at reduced level."
+        let attenuationWillApply = attenuationEnabled && routeSnapshot.shouldDuck
+        let effectiveMediaPause = attenuationWillApply ? false : mediaPauseEnabled
         mediaPlaybackController.beginDictationMediaPause(
             enabled: effectiveMediaPause,
             routeKind: routeSnapshot.routeKind

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -242,7 +242,13 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
-    func beginRecording(mode: String, duckingEnabled: Bool, mediaPauseEnabled: Bool) {
+    func beginRecording(
+        mode: String,
+        duckingEnabled: Bool,
+        mediaPauseEnabled: Bool,
+        attenuationEnabled: Bool = false,
+        attenuationLevel: Float32 = 0.5
+    ) {
         let sessionID = ensureSession()
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
@@ -277,7 +283,12 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             } else {
                 self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             }
-            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
+            self.beginSessionAudioControls(
+                duckingEnabled: duckingEnabled,
+                mediaPauseEnabled: mediaPauseEnabled,
+                attenuationEnabled: attenuationEnabled,
+                attenuationLevel: attenuationLevel
+            )
             self.duckingController.ensureCurrentDefaultDucked()
             let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
             self.recorder.preferredInputDeviceID = recorderInputDeviceID
@@ -300,14 +311,25 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
-    func beginExternalSession(source: String, duckingEnabled: Bool, mediaPauseEnabled: Bool) {
+    func beginExternalSession(
+        source: String,
+        duckingEnabled: Bool,
+        mediaPauseEnabled: Bool,
+        attenuationEnabled: Bool = false,
+        attenuationLevel: Float32 = 0.5
+    ) {
         setExternalSessionHint(true)
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
             self.externalSessionActive = true
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("external_begin:\(source)")
-            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
+            self.beginSessionAudioControls(
+                duckingEnabled: duckingEnabled,
+                mediaPauseEnabled: mediaPauseEnabled,
+                attenuationEnabled: attenuationEnabled,
+                attenuationLevel: attenuationLevel
+            )
             self.duckingController.ensureCurrentDefaultDucked()
         }
     }
@@ -509,15 +531,39 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         route.preferredInputDeviceID
     }
 
-    private func beginSessionAudioControls(duckingEnabled: Bool, mediaPauseEnabled: Bool) {
+    private func beginSessionAudioControls(
+        duckingEnabled: Bool,
+        mediaPauseEnabled: Bool,
+        attenuationEnabled: Bool = false,
+        attenuationLevel: Float32 = 0.5
+    ) {
+        // When attenuation is active we deliberately do NOT pause media –
+        // spec says "Do not pause media. Leave output at reduced level."
+        let effectiveMediaPause = attenuationEnabled ? false : mediaPauseEnabled
         mediaPlaybackController.beginDictationMediaPause(
-            enabled: mediaPauseEnabled,
+            enabled: effectiveMediaPause,
             routeKind: routeSnapshot.routeKind
         )
-        beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+        beginDuckingIfNeeded(
+            duckingEnabled: duckingEnabled,
+            attenuationEnabled: attenuationEnabled,
+            attenuationLevel: attenuationLevel
+        )
     }
 
-    private func beginDuckingIfNeeded(duckingEnabled: Bool) {
+    private func beginDuckingIfNeeded(
+        duckingEnabled: Bool,
+        attenuationEnabled: Bool = false,
+        attenuationLevel: Float32 = 0.5
+    ) {
+        // Attenuation takes precedence over mute when both are enabled;
+        // it provides 50% volume reduction instead of full mute.
+        if attenuationEnabled && routeSnapshot.shouldDuck {
+            duckingEnabledForSession = true
+            emitLatency("attenuate_begin:\(attenuationLevel)")
+            duckingController.beginDictationDucking(enabled: true, attenuationLevel: attenuationLevel)
+            return
+        }
         duckingEnabledForSession = duckingEnabled && routeSnapshot.shouldDuck
         emitLatency(duckingEnabledForSession ? "duck_begin" : "duck_skip")
         duckingController.beginDictationDucking(enabled: duckingEnabledForSession)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1338,6 +1338,8 @@ struct AppConfig: Codable {
     var soundEnabled: Bool = true
     var pauseMediaDuringDictation: Bool = false
     var muteSystemAudioDuringDictation: Bool = false
+    var lowerVolumeDuringDictation: Bool = false
+    var dictationAttenuationLevel: Double = 0.5
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
     var menuBarIcon: String = "muesli"
     var showHotkeyInMenuBar: Bool = true
@@ -1384,6 +1386,10 @@ struct AppConfig: Codable {
     var contributionBuyMeCoffeeClicked: Bool = false
     var contributionTweetClicked: Bool = false
     var contributionLinkedInClicked: Bool = false
+
+    var resolvedDictationAttenuationLevel: Float32 {
+        Float32(min(1.0, max(0.0, dictationAttenuationLevel)))
+    }
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -1463,6 +1469,8 @@ struct AppConfig: Codable {
         case soundEnabled = "sound_enabled"
         case pauseMediaDuringDictation = "pause_media_during_dictation"
         case muteSystemAudioDuringDictation = "mute_system_audio_during_dictation"
+        case lowerVolumeDuringDictation = "lower_volume_during_dictation"
+        case dictationAttenuationLevel = "dictation_attenuation_level"
         case recordingColorHex = "recording_color_hex"
         case menuBarIcon = "menu_bar_icon"
         case showHotkeyInMenuBar = "show_hotkey_in_menu_bar"
@@ -1646,6 +1654,9 @@ struct AppConfig: Codable {
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
         pauseMediaDuringDictation = (try? c.decode(Bool.self, forKey: .pauseMediaDuringDictation)) ?? defaults.pauseMediaDuringDictation
         muteSystemAudioDuringDictation = (try? c.decode(Bool.self, forKey: .muteSystemAudioDuringDictation)) ?? defaults.muteSystemAudioDuringDictation
+        lowerVolumeDuringDictation = (try? c.decode(Bool.self, forKey: .lowerVolumeDuringDictation)) ?? defaults.lowerVolumeDuringDictation
+        let decodedAttenuationLevel = (try? c.decode(Double.self, forKey: .dictationAttenuationLevel)) ?? defaults.dictationAttenuationLevel
+        dictationAttenuationLevel = min(1.0, max(0.0, decodedAttenuationLevel))
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
         showHotkeyInMenuBar =

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1388,7 +1388,7 @@ struct AppConfig: Codable {
     var contributionLinkedInClicked: Bool = false
 
     var resolvedDictationAttenuationLevel: Float32 {
-        Float32(min(1.0, max(0.0, dictationAttenuationLevel)))
+        Float32(min(1.0, max(0.1, dictationAttenuationLevel)))
     }
 
     enum CodingKeys: String, CodingKey {
@@ -1656,7 +1656,7 @@ struct AppConfig: Codable {
         muteSystemAudioDuringDictation = (try? c.decode(Bool.self, forKey: .muteSystemAudioDuringDictation)) ?? defaults.muteSystemAudioDuringDictation
         lowerVolumeDuringDictation = (try? c.decode(Bool.self, forKey: .lowerVolumeDuringDictation)) ?? defaults.lowerVolumeDuringDictation
         let decodedAttenuationLevel = (try? c.decode(Double.self, forKey: .dictationAttenuationLevel)) ?? defaults.dictationAttenuationLevel
-        dictationAttenuationLevel = min(1.0, max(0.0, decodedAttenuationLevel))
+        dictationAttenuationLevel = min(1.0, max(0.1, decodedAttenuationLevel))
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
         showHotkeyInMenuBar =

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8696,7 +8696,9 @@ public final class MuesliController: NSObject {
         dictationAudioSessionManager.beginRecording(
             mode: "hold-start",
             duckingEnabled: config.muteSystemAudioDuringDictation,
-            mediaPauseEnabled: config.pauseMediaDuringDictation
+            mediaPauseEnabled: config.pauseMediaDuringDictation,
+            attenuationEnabled: config.lowerVolumeDuringDictation,
+            attenuationLevel: config.resolvedDictationAttenuationLevel
         )
     }
 
@@ -8886,7 +8888,9 @@ public final class MuesliController: NSObject {
                 dictationAudioSessionManager.beginExternalSession(
                     source: "nemotron-toggle",
                     duckingEnabled: config.muteSystemAudioDuringDictation,
-                    mediaPauseEnabled: config.pauseMediaDuringDictation
+                    mediaPauseEnabled: config.pauseMediaDuringDictation,
+                    attenuationEnabled: config.lowerVolumeDuringDictation,
+                    attenuationLevel: config.resolvedDictationAttenuationLevel
                 )
                 meetingMonitor.refreshState()
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
@@ -8900,7 +8904,9 @@ public final class MuesliController: NSObject {
         dictationAudioSessionManager.beginRecording(
             mode: "toggle",
             duckingEnabled: config.muteSystemAudioDuringDictation,
-            mediaPauseEnabled: config.pauseMediaDuringDictation
+            mediaPauseEnabled: config.pauseMediaDuringDictation,
+            attenuationEnabled: config.lowerVolumeDuringDictation,
+            attenuationLevel: config.resolvedDictationAttenuationLevel
         )
         return true
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1311,11 +1311,50 @@ struct SettingsView: View {
                         controller.updateConfig { $0.pauseMediaDuringDictation = newValue }
                     }
                 }
+                settingsDescription("Pauses playing media while dictating and resumes after.")
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Mute system audio during dictation") {
                     settingsSwitch(isOn: appState.config.muteSystemAudioDuringDictation) { newValue in
                         controller.updateConfig { $0.muteSystemAudioDuringDictation = newValue }
                     }
+                }
+                settingsDescription("Mutes the output device while dictating. Skipped for headphones.")
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Lower volume during dictation") {
+                    settingsSwitch(isOn: appState.config.lowerVolumeDuringDictation) { newValue in
+                        controller.updateConfig { $0.lowerVolumeDuringDictation = newValue }
+                    }
+                }
+                settingsDescription("Reduces output volume to the level below while dictation is active, then restores the exact prior level. Skipped for headphones and when no media is playing. Does not pause media.")
+                if appState.config.lowerVolumeDuringDictation {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    HStack(alignment: .center, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Volume")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                            Text("\(Int(appState.config.dictationAttenuationLevel * 100))% — reduces volume to this fraction while dictating")
+                                .font(MuesliTheme.caption())
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                        }
+                        Spacer()
+                        Slider(
+                            value: Binding(
+                                get: { appState.config.dictationAttenuationLevel },
+                                set: { newValue in
+                                    controller.updateConfig { $0.dictationAttenuationLevel = min(1.0, max(0.1, newValue)) }
+                                }
+                            ),
+                            in: 0.1...1.0,
+                            step: 0.05
+                        )
+                        .frame(width: 140)
+                        Text("\(Int(appState.config.dictationAttenuationLevel * 100))%")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .frame(width: 40, alignment: .trailing)
+                    }
+                    .padding(.vertical, 4)
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 screenContextRow("App context")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -768,6 +768,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
 
 private final class FakeDuckingManager: AudioDuckingManaging {
     var beginCalls: [Bool] = []
+    var beginAttenuationLevels: [Float32?] = []
     var ensureCalls = 0
     var restoreCalls = 0
     var completeRestoreImmediately = true
@@ -775,6 +776,12 @@ private final class FakeDuckingManager: AudioDuckingManaging {
 
     func beginDictationDucking(enabled: Bool) {
         beginCalls.append(enabled)
+        beginAttenuationLevels.append(nil)
+    }
+
+    func beginDictationDucking(enabled: Bool, attenuationLevel: Float32?) {
+        beginCalls.append(enabled)
+        beginAttenuationLevels.append(attenuationLevel)
     }
 
     func ensureCurrentDefaultDucked() {


### PR DESCRIPTION
Implements system-wide attenuation as suggested for https://muesli.works/ dictation:

**When dictation starts**
- Find current/default output `AudioObjectID` via `CoreAudioDuckingDeviceClient`
- Read `kAudioDevicePropertyVolumeScalar` per element, store in `DeviceSnapshot`
- Set volume to `original * attenuationLevel` (default `0.5` = 50%, configurable 0.1...1.0, 30—50% recommended)

**While active**
- Leave at reduced level, do **not** pause media (`mediaPause` suppressed when attenuation enabled)
- `ensureCurrentDefaultDucked()` re-ducks new default device if AirPods/output changes

**When dictation ends**
- Restore exact captured volume only if `abs(current - attenuatedValue) <= 0.001` (treats manual user changes as intentional) and `isDeviceAvailable(device)` (avoids writing stale volume to different/disconnected device); codec sample-rate stabilization preserved.

**Config & UI**
- `AppConfig.lowerVolumeDuringDictation` + `dictationAttenuationLevel` (default 50%, clamped) with `CodingKeys` `lower_volume_during_dictation` / `dictation_attenuation_level`
- `SettingsView` Advanced adds *Lower volume during dictation* toggle + slider

**Core operation**
```swift
let originalVolume = try outputVolume(for: device)
try setOutputVolume(for: device, scalar: originalVolume * 0.5) // 50%
try setOutputVolume(for: device, scalar: originalVolume) // restore
```
uses Apple `AudioHardwareControl.volumeScalarValue 0.0...1.0`.

Tests: `FakeDuckingManager` updated for `beginDictationDucking(enabled:attenuationLevel:)`, existing `AudioDuckingControllerTests` semantics preserved (`attenuatedValue=0` for mute path).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790174524&installation_model_id=422865&pr_number=466&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F466&signature=4277afb7e8c8dcb1bb5f3f9f3e251d6c314db15b6f250558be96740b9c0a5070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to lower system volume during dictation.
  * Added adjustable attenuation from 10% to 100%, in 5% increments.
  * Applied volume reduction across hold-to-talk, streaming, and toggle recording modes.
  * Clarified media pausing and system-audio muting settings.

* **Bug Fixes**
  * Preserved user volume changes made during dictation.
  * Improved audio restoration and fallback behavior when volume control is unavailable.
  * Kept existing muting behavior for legacy configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->