### PR TITLE
feat: dictation pipeline inspector with raw ASR vs filtered view

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -34,7 +34,7 @@ public final class DictationStore {
     private let databaseURL: URL
     private static let dictationColumns = """
     d.id, d.timestamp, d.duration_seconds, d.raw_text, d.app_context, d.word_count, d.source,
-    d.target_app_name, d.target_app_bundle_id,
+    d.target_app_name, d.target_app_bundle_id, d.asr_text,
     t.id, t.final_status, t.final_message, t.trace_json, t.created_at
     """
     private static let meetingColumns = """
@@ -72,6 +72,7 @@ public final class DictationStore {
             source TEXT NOT NULL DEFAULT 'dictation',
             target_app_name TEXT,
             target_app_bundle_id TEXT,
+            asr_text TEXT,
             started_at TEXT,
             ended_at TEXT,
             updated_at REAL NOT NULL DEFAULT 0,
@@ -240,6 +241,7 @@ public final class DictationStore {
             "ALTER TABLE dictations ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1",
             "ALTER TABLE dictations ADD COLUMN target_app_name TEXT",
             "ALTER TABLE dictations ADD COLUMN target_app_bundle_id TEXT",
+            "ALTER TABLE dictations ADD COLUMN asr_text TEXT",
             "ALTER TABLE meetings ADD COLUMN updated_at REAL NOT NULL DEFAULT 0",
             "ALTER TABLE meetings ADD COLUMN deleted_at REAL",
             "ALTER TABLE meetings ADD COLUMN cloud_record_name TEXT",
@@ -398,6 +400,7 @@ public final class DictationStore {
         source: String = "dictation",
         targetAppName: String? = nil,
         targetAppBundleID: String? = nil,
+        asrText: String? = nil,
         startedAt: Date,
         endedAt: Date
     ) throws -> Int64 {
@@ -407,8 +410,8 @@ public final class DictationStore {
         let sql = """
         INSERT INTO dictations
         (timestamp, duration_seconds, raw_text, app_context, word_count, source,
-         target_app_name, target_app_bundle_id, started_at, ended_at, updated_at, sync_dirty)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+         target_app_name, target_app_bundle_id, asr_text, started_at, ended_at, updated_at, sync_dirty)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
@@ -427,14 +430,48 @@ public final class DictationStore {
         sqlite3_bind_text(statement, 6, (source as NSString).utf8String, -1, nil)
         bindOptionalText(targetAppName, at: 7, statement: statement)
         bindOptionalText(targetAppBundleID, at: 8, statement: statement)
-        sqlite3_bind_text(statement, 9, (started as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(statement, 10, (ended as NSString).utf8String, -1, nil)
-        sqlite3_bind_double(statement, 11, Date().timeIntervalSince1970)
+        bindOptionalText(asrText, at: 9, statement: statement)
+        sqlite3_bind_text(statement, 10, (started as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 11, (ended as NSString).utf8String, -1, nil)
+        sqlite3_bind_double(statement, 12, Date().timeIntervalSince1970)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
         return sqlite3_last_insert_rowid(db)
+    }
+
+    /// Updates the final text (and word count) for an existing dictation.
+    /// Used by the pipeline inspector to apply re-run post-processing results.
+    public func updateDictationText(id: Int64, text: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        UPDATE dictations
+        SET raw_text = ?,
+            word_count = ?,
+            updated_at = ?,
+            sync_dirty = 1
+        WHERE id = ? AND deleted_at IS NULL
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        sqlite3_bind_text(statement, 1, (text as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(statement, 2, Int32(Self.countWords(in: text)))
+        sqlite3_bind_double(statement, 3, Date().timeIntervalSince1970)
+        sqlite3_bind_int64(statement, 4, id)
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.dictationNotFound(id: id)
+        }
     }
 
     public func recentDictations(
@@ -4699,21 +4736,21 @@ public final class DictationStore {
 
     private func makeDictationRecord(_ statement: OpaquePointer?) -> DictationRecord {
         let trace: ComputerUseTraceRecord?
-        if sqlite3_column_type(statement, 9) == SQLITE_NULL {
+        if sqlite3_column_type(statement, 10) == SQLITE_NULL {
             trace = nil
         } else {
-            let traceJSON = stringColumn(statement, index: 12)
+            let traceJSON = stringColumn(statement, index: 13)
             let events = (try? JSONDecoder().decode(
                 [ComputerUseTraceEvent].self,
                 from: Data(traceJSON.utf8)
             )) ?? []
             trace = ComputerUseTraceRecord(
-                id: sqlite3_column_int64(statement, 9),
+                id: sqlite3_column_int64(statement, 10),
                 dictationID: sqlite3_column_int64(statement, 0),
-                finalStatus: stringColumn(statement, index: 10),
-                finalMessage: stringColumn(statement, index: 11),
+                finalStatus: stringColumn(statement, index: 11),
+                finalMessage: stringColumn(statement, index: 12),
                 events: events,
-                createdAt: stringColumn(statement, index: 13)
+                createdAt: stringColumn(statement, index: 14)
             )
         }
 
@@ -4727,6 +4764,7 @@ public final class DictationStore {
             source: stringColumn(statement, index: 6),
             targetAppName: optionalStringColumn(statement, index: 7),
             targetAppBundleID: optionalStringColumn(statement, index: 8),
+            asrText: optionalStringColumn(statement, index: 9),
             computerUseTrace: trace
         )
     }

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -3502,7 +3502,7 @@ public final class DictationStore {
         let dictationSQL = """
         SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
                duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
-               cloud_system_fields
+               cloud_system_fields, asr_text
         FROM dictations
         WHERE cloud_record_name IN (\(placeholders))
         """
@@ -3816,7 +3816,7 @@ public final class DictationStore {
         let dictationSQL = """
         SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
                duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
-               cloud_system_fields
+               cloud_system_fields, asr_text
         FROM dictations
         WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL
         ORDER BY updated_at DESC, id DESC
@@ -3922,7 +3922,7 @@ public final class DictationStore {
         let dictationSQL = """
         SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
                duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
-               cloud_system_fields
+               cloud_system_fields, asr_text
         FROM dictations
         WHERE cloud_record_name IS NOT NULL
         ORDER BY updated_at DESC, id DESC
@@ -4434,7 +4434,8 @@ public final class DictationStore {
             wordCount: Int(sqlite3_column_int(statement, 7)),
             isDeleted: sqlite3_column_type(statement, 10) != SQLITE_NULL,
             cloudChangeTag: optionalStringColumn(statement, index: 11),
-            cloudSystemFields: optionalDataColumn(statement, index: 12)
+            cloudSystemFields: optionalDataColumn(statement, index: 12),
+            asrText: optionalStringColumn(statement, index: 13)
         )
     }
 
@@ -4596,9 +4597,9 @@ public final class DictationStore {
         INSERT INTO dictations (
             timestamp, duration_seconds, raw_text, app_context, word_count, source,
             started_at, ended_at, updated_at, deleted_at, cloud_record_name,
-            cloud_change_tag, cloud_system_fields, last_synced_at, sync_dirty
+            cloud_change_tag, cloud_system_fields, last_synced_at, sync_dirty, asr_text
         )
-        VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+        VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
         ON CONFLICT(cloud_record_name) DO UPDATE SET
             timestamp = excluded.timestamp,
             duration_seconds = excluded.duration_seconds,
@@ -4612,7 +4613,8 @@ public final class DictationStore {
             cloud_change_tag = excluded.cloud_change_tag,
             cloud_system_fields = excluded.cloud_system_fields,
             last_synced_at = excluded.last_synced_at,
-            sync_dirty = 0
+            sync_dirty = 0,
+            asr_text = COALESCE(excluded.asr_text, dictations.asr_text)
         WHERE excluded.updated_at > dictations.updated_at
            OR (excluded.updated_at = dictations.updated_at AND dictations.sync_dirty = 0)
         """
@@ -4636,6 +4638,7 @@ public final class DictationStore {
         bindOptionalText(record.cloudChangeTag, at: 11, statement: statement)
         bindOptionalBlob(record.cloudSystemFields, at: 12, statement: statement)
         sqlite3_bind_double(statement, 13, Date().timeIntervalSince1970)
+        bindOptionalText(record.asrText, at: 14, statement: statement)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -57,6 +57,9 @@ public struct SyncTextRecord: Identifiable, Codable, Sendable, Equatable {
     public var localSource: String?
     public var meetingStatus: MeetingStatus?
     public var engineIdentifier: String?
+    /// Raw ASR text for dictations, preserved across iCloud sync so the
+    /// pipeline inspector can re-run post-processing on the receiving device.
+    public var asrText: String?
     public var createdAt: Date
     public var updatedAt: Date
     public var startedAt: Date?
@@ -91,7 +94,8 @@ public struct SyncTextRecord: Identifiable, Codable, Sendable, Equatable {
         isDeleted: Bool = false,
         cloudChangeTag: String? = nil,
         cloudSystemFields: Data? = nil,
-        followUpToRecordName: String? = nil
+        followUpToRecordName: String? = nil,
+        asrText: String? = nil
     ) {
         self.id = id
         self.kind = kind
@@ -114,6 +118,7 @@ public struct SyncTextRecord: Identifiable, Codable, Sendable, Equatable {
         self.cloudChangeTag = cloudChangeTag
         self.cloudSystemFields = cloudSystemFields
         self.followUpToRecordName = followUpToRecordName
+        self.asrText = asrText
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -166,6 +166,7 @@ public struct DictationRecord: Identifiable, Codable, Sendable {
     public let source: String
     public let targetAppName: String?
     public let targetAppBundleID: String?
+    public let asrText: String?
     public let computerUseTrace: ComputerUseTraceRecord?
 
     public init(
@@ -178,6 +179,7 @@ public struct DictationRecord: Identifiable, Codable, Sendable {
         source: String = "dictation",
         targetAppName: String? = nil,
         targetAppBundleID: String? = nil,
+        asrText: String? = nil,
         computerUseTrace: ComputerUseTraceRecord? = nil
     ) {
         self.id = id
@@ -189,6 +191,7 @@ public struct DictationRecord: Identifiable, Codable, Sendable {
         self.source = source
         self.targetAppName = targetAppName
         self.targetAppBundleID = targetAppBundleID
+        self.asrText = asrText
         self.computerUseTrace = computerUseTrace
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationDetailView.swift
@@ -1,0 +1,193 @@
+import AppKit
+import SwiftUI
+import MuesliCore
+
+struct DictationDetailView: View {
+    let record: DictationRecord
+    let controller: MuesliController
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var filteredText: String
+    @State private var isRerunning = false
+    @State private var copiedRaw = false
+    @State private var copiedFiltered = false
+
+    init(record: DictationRecord, controller: MuesliController) {
+        self.record = record
+        self.controller = controller
+        _filteredText = State(initialValue: record.rawText)
+    }
+
+    private var hasRawASR: Bool {
+        record.asrText != nil && !(record.asrText?.isEmpty ?? true)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            if hasRawASR {
+                twoPanelLayout
+            } else {
+                singlePanelLayout
+            }
+
+            Divider()
+            footer
+        }
+        .frame(width: 720, height: 520)
+        .background(MuesliTheme.backgroundDeep)
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Transcription Pipeline")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(formatTimestamp(record.timestamp))
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            Spacer()
+            Button("Done") { dismiss() }
+                .buttonStyle(.bordered)
+        }
+        .padding(.horizontal, MuesliTheme.spacing24)
+        .padding(.top, MuesliTheme.spacing20)
+        .padding(.bottom, MuesliTheme.spacing16)
+    }
+
+    private var twoPanelLayout: some View {
+        HStack(spacing: MuesliTheme.spacing16) {
+            panel(
+                title: "Raw ASR",
+                subtitle: "Before post-processing",
+                text: record.asrText ?? "",
+                isCopied: copiedRaw,
+                onCopy: {
+                    controller.copyToClipboard(record.asrText ?? "")
+                    copiedRaw = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        copiedRaw = false
+                    }
+                }
+            )
+
+            panel(
+                title: "Filtered",
+                subtitle: "After post-processing",
+                text: filteredText,
+                isCopied: copiedFiltered,
+                onCopy: {
+                    controller.copyToClipboard(filteredText)
+                    copiedFiltered = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        copiedFiltered = false
+                    }
+                }
+            )
+        }
+        .padding(.horizontal, MuesliTheme.spacing24)
+        .padding(.bottom, MuesliTheme.spacing16)
+    }
+
+    private var singlePanelLayout: some View {
+        VStack(spacing: MuesliTheme.spacing8) {
+            panel(
+                title: "Transcript",
+                subtitle: "Raw ASR was not captured for this dictation",
+                text: filteredText,
+                isCopied: copiedFiltered,
+                onCopy: {
+                    controller.copyToClipboard(filteredText)
+                    copiedFiltered = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        copiedFiltered = false
+                    }
+                }
+            )
+        }
+        .padding(.horizontal, MuesliTheme.spacing24)
+        .padding(.bottom, MuesliTheme.spacing16)
+    }
+
+    private func panel(title: String, subtitle: String, text: String, isCopied: Bool, onCopy: @escaping () -> Void) -> some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text(subtitle)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+                Spacer()
+                Button(action: onCopy) {
+                    Label(isCopied ? "Copied" : "Copy", systemImage: isCopied ? "checkmark" : "doc.on.doc")
+                        .font(MuesliTheme.caption())
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            ScrollView {
+                Text(text.isEmpty ? "(empty)" : text)
+                    .font(.system(size: 13, weight: .regular, design: .monospaced))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding(MuesliTheme.spacing12)
+            }
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            if hasRawASR {
+                Button {
+                    Task {
+                        isRerunning = true
+                        let result = await controller.rerunPostProcessing(for: record.id)
+                        if let result {
+                            filteredText = result
+                        }
+                        isRerunning = false
+                    }
+                } label: {
+                    if isRerunning {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Re-running…")
+                        }
+                    } else {
+                        Label("Re-run filtering", systemImage: "arrow.clockwise")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(isRerunning)
+            }
+            Spacer()
+            Text("\(record.wordCount) words")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+        }
+        .padding(.horizontal, MuesliTheme.spacing24)
+        .padding(.vertical, MuesliTheme.spacing12)
+    }
+
+    private func formatTimestamp(_ iso: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: iso) ?? Date()
+        let display = DateFormatter()
+        display.locale = Locale.current
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationDetailView.swift
@@ -8,6 +8,7 @@ struct DictationDetailView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var filteredText: String
+    @State private var wordCount: Int
     @State private var isRerunning = false
     @State private var copiedRaw = false
     @State private var copiedFiltered = false
@@ -16,6 +17,7 @@ struct DictationDetailView: View {
         self.record = record
         self.controller = controller
         _filteredText = State(initialValue: record.rawText)
+        _wordCount = State(initialValue: record.wordCount)
     }
 
     private var hasRawASR: Bool {
@@ -154,6 +156,7 @@ struct DictationDetailView: View {
                         let result = await controller.rerunPostProcessing(for: record.id)
                         if let result {
                             filteredText = result
+                            wordCount = result.split(whereSeparator: \.isWhitespace).count
                         }
                         isRerunning = false
                     }
@@ -172,7 +175,7 @@ struct DictationDetailView: View {
                 .disabled(isRerunning)
             }
             Spacer()
-            Text("\(record.wordCount) words")
+            Text("\(wordCount) words")
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textTertiary)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -5,6 +5,7 @@ struct DictationsView: View {
     let appState: AppState
     let controller: MuesliController
     @State private var selectedFilter: HistoryDateFilter = .all
+    @State private var selectedRecord: DictationRecord?
 
     private var groupedDictations: [(id: Date, header: String, records: [DictationRecord])] {
         let calendar = Calendar.current
@@ -125,7 +126,16 @@ struct DictationsView: View {
                                                 controller.deleteDictation(id: record.id)
                                             }
                                         )
+                                        .contentShape(Rectangle())
+                                        .onTapGesture {
+                                            selectedRecord = record
+                                        }
                                         .contextMenu {
+                                            Button {
+                                                selectedRecord = record
+                                            } label: {
+                                                Label("View Pipeline", systemImage: "waveform.path")
+                                            }
                                             Button {
                                                 controller.copyToClipboard(record.rawText)
                                             } label: {
@@ -162,6 +172,9 @@ struct DictationsView: View {
                     .padding(.bottom, MuesliTheme.spacing24)
                 }
             }
+        }
+        .sheet(item: $selectedRecord) { record in
+            DictationDetailView(record: record, controller: controller)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8934,7 +8934,13 @@ public final class MuesliController: NSObject {
             customWords: serializedCustomWords()
         )
         guard !result.isEmpty else { return nil }
-        try? dictationStore.updateDictationText(id: dictationID, text: result)
+        do {
+            try dictationStore.updateDictationText(id: dictationID, text: result)
+        } catch {
+            fputs("[muesli-native] rerun post-processing DB update failed: \(error)\n", stderr)
+            return nil
+        }
+        scheduleICloudSyncAfterLocalChange()
         syncAppState()
         return result
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8919,6 +8919,26 @@ public final class MuesliController: NSObject {
         }
     }
 
+    /// Re-runs the post-processor on a stored raw ASR text and updates the
+    /// dictation's final text in the database. Called by the pipeline inspector.
+    @MainActor
+    func rerunPostProcessing(for dictationID: Int64) async -> String? {
+        guard let record = try? dictationStore.dictation(id: dictationID),
+              let asrText = record.asrText,
+              !asrText.isEmpty else {
+            return nil
+        }
+        let result = await transcriptionCoordinator.rerunPostProcessing(
+            rawText: asrText,
+            backend: selectedBackend,
+            customWords: serializedCustomWords()
+        )
+        guard !result.isEmpty else { return nil }
+        try? dictationStore.updateDictationText(id: dictationID, text: result)
+        syncAppState()
+        return result
+    }
+
     /// Hands-free dictation start for Shortcuts/App Intents. No-op (returns
     /// false) if dictation is already active or a meeting is recording or
     /// still starting, mirroring the admission guards the hotkey path uses.
@@ -9079,6 +9099,11 @@ public final class MuesliController: NSObject {
         fputs("[muesli-native] Nemotron streaming stop, got \(finalText.count) chars\n", stderr)
         let cleaned = FillerWordFilter.apply(finalText)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        // For Nemotron streaming, the raw ASR text is the pre-filler-filter
+        // output. Store it so the pipeline inspector can show the difference.
+        let nemotronRawASRText = cleaned == finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+            ? nil
+            : finalText.trimmingCharacters(in: .whitespacesAndNewlines)
         let shouldPersistTargetApp = DictationAttributionPolicy.shouldPersist(
             isPasteOutput: outputMode == .paste,
             source: "dictation",
@@ -9097,6 +9122,7 @@ public final class MuesliController: NSObject {
                 durationSeconds: duration,
                 targetAppName: targetApp?.appName,
                 targetAppBundleID: targetApp?.bundleID,
+                asrText: nemotronRawASRText,
                 startedAt: startedAt,
                 endedAt: Date()
             )
@@ -9135,7 +9161,8 @@ public final class MuesliController: NSObject {
         startedAt: Date,
         outputMode: DictationOutputMode,
         targetApp: DictationCorrectionTargetApp?,
-        backend: String
+        backend: String,
+        asrText: String? = nil
     ) {
         _ = try? dictationStore.insertDictation(
             text: text,
@@ -9143,6 +9170,7 @@ public final class MuesliController: NSObject {
             appContext: appContext,
             targetAppName: targetApp?.appName,
             targetAppBundleID: targetApp?.bundleID,
+            asrText: asrText,
             startedAt: startedAt,
             endedAt: Date()
         )
@@ -9229,6 +9257,7 @@ public final class MuesliController: NSObject {
                 // Drop result if test was cancelled (user navigated away)
                 try Task.checkCancellation()
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                let rawASRText = result.rawASRText
                 await MainActor.run {
                     self.markDictationLatency("transcription_completed", trace: completionLatencyTrace)
                 }
@@ -9298,7 +9327,8 @@ public final class MuesliController: NSObject {
                                     startedAt: startedAt,
                                     outputMode: outputMode,
                                     targetApp: completionTargetApp,
-                                    backend: transcriptionBackend.backend
+                                    backend: transcriptionBackend.backend,
+                                    asrText: rawASRText
                                 )
                                 self.finishDictationLatencyTrace(
                                     "bookkeeping_completed",
@@ -9322,7 +9352,8 @@ public final class MuesliController: NSObject {
                             startedAt: startedAt,
                             outputMode: outputMode,
                             targetApp: nil,
-                            backend: transcriptionBackend.backend
+                            backend: transcriptionBackend.backend,
+                            asrText: rawASRText
                         )
                         self.finishDictationLatencyTrace(
                             "bookkeeping_completed",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -1280,6 +1280,7 @@ final class MuesliICloudSyncEngine {
             cloud["summaryText"] = nil as NSString?
             cloud["manualNotes"] = nil as NSString?
             cloud["followUpToRecordName"] = nil as NSString?
+            cloud["asrText"] = nil as NSString?
             return cloud
         }
         cloud["title"] = record.title as NSString?
@@ -1287,6 +1288,7 @@ final class MuesliICloudSyncEngine {
         cloud["speakerTranscript"] = record.speakerTranscript as NSString?
         cloud["summaryText"] = record.summaryText as NSString?
         cloud["manualNotes"] = record.manualNotes as NSString?
+        cloud["asrText"] = record.asrText as NSString?
         return cloud
     }
 
@@ -1329,7 +1331,8 @@ final class MuesliICloudSyncEngine {
             isDeleted: isDeleted,
             cloudChangeTag: record.recordChangeTag,
             cloudSystemFields: encodedSystemFields(for: record),
-            followUpToRecordName: record["followUpToRecordName"] as? String
+            followUpToRecordName: record["followUpToRecordName"] as? String,
+            asrText: record["asrText"] as? String
         )
     }
 
@@ -1535,6 +1538,7 @@ final class MuesliICloudSyncEngine {
             "meetingStatus",
             "followUpToRecordName",
             "engineIdentifier",
+            "asrText",
             "createdAt",
             "updatedAt",
             "startedAt",

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -11,6 +11,16 @@ struct SpeechSegment: Sendable {
 struct SpeechTranscriptionResult: Sendable {
     let text: String
     let segments: [SpeechSegment]
+    /// The raw ASR output before post-processing, captured for the pipeline
+    /// inspector. Nil when post-processing is disabled (no point storing a
+    /// duplicate) or for meeting transcriptions (which skip post-processing).
+    var rawASRText: String?
+
+    init(text: String, segments: [SpeechSegment], rawASRText: String? = nil) {
+        self.text = text
+        self.segments = segments
+        self.rawASRText = rawASRText
+    }
 }
 
 actor AppleSpeechUseLifecycle {
@@ -845,6 +855,13 @@ actor TranscriptionCoordinator {
         if !result.text.isEmpty {
             Qwen3PostProcessorLogging.logVerbose("Dictation raw transcript after artifact cleanup: \(result.text)")
         }
+        // Capture the raw ASR text before post-processing so the pipeline
+        // inspector can show what the model heard vs. what the filter produced.
+        // Only store it when post-processing is actually going to run —
+        // otherwise the final text IS the raw text and storing a copy is waste.
+        let rawASRText: String? = enablePostProcessor && !result.text.isEmpty
+            ? result.text
+            : nil
         // Capture this after ASR awaits. The snapshot is then passed through the
         // complete cleanup path, so a model switch cannot change the model or
         // empty-output policy for this dictation.
@@ -856,11 +873,34 @@ actor TranscriptionCoordinator {
             postProcessorSnapshot: postProcessorSnapshot,
             appContext: appContext
         ) ?? removeFillersWithLogging(result)
+        result.rawASRText = rawASRText
         let final = applyCustomWords(result, customWords: customWords)
         if !final.text.isEmpty {
             Qwen3PostProcessorLogging.logVerbose("Dictation final transcript: \(final.text)")
         }
         return final
+    }
+
+    /// Re-runs post-processing on a previously captured raw ASR text.
+    /// Used by the pipeline inspector to re-filter with current settings.
+    func rerunPostProcessing(
+        rawText: String,
+        backend: BackendOption,
+        customWords: [[String: Any]] = [],
+        appContext: String? = nil
+    ) async -> String {
+        var result = SpeechTranscriptionResult(text: rawText, segments: [])
+        result = removeArtifacts(result)
+        let postProcessorSnapshot = currentPostProcessorSnapshot()
+        result = await postProcessDictationIfNeeded(
+            result,
+            backend: backend,
+            enabled: true,
+            postProcessorSnapshot: postProcessorSnapshot,
+            appContext: appContext
+        ) ?? removeFillersWithLogging(result)
+        let final = applyCustomWords(result, customWords: customWords)
+        return final.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     func transcribeMeeting(


### PR DESCRIPTION
## What this does

Adds a transcription pipeline inspector that shows the raw ASR text alongside the post-processed text for each dictation, with copy and re-run filtering capabilities.

## Why

When the model messes up, there's currently no way to see what the ASR actually heard vs. what the post-processor produced. This makes it easy to:

- Compare raw ASR output vs. filtered output side by side
- Copy either version independently
- Re-run the post-processor on the stored raw text with current settings

## Changes

### Database
- Add `asr_text` column to `dictations` table (nullable for backward compatibility — old dictations show final text only)
- Add `updateDictationText` method for re-run filtering updates
- Migration: `ALTER TABLE dictations ADD COLUMN asr_text TEXT`

### Pipeline
- Capture raw ASR text after artifact removal, before post-processing runs
- Store only when post-processing is enabled (avoids duplicate storage when the final text IS the raw text)
- `SpeechTranscriptionResult` gains `rawASRText` field

### Controller
- Pass `asrText` through both standard and Nemotron stop paths
- Add `rerunPostProcessing(for:)` method that re-runs the current post-processor on stored raw ASR text and updates the DB

### UI
- New `DictationDetailView` with side-by-side raw/filtered panels
- Copy buttons on each panel
- Re-run filtering button using current post-processor settings
- Opens via row click or context menu in dictation history
- Falls back to single-panel view for old dictations without `asrText`

## What doesn't change
- No audio retention — audio is still deleted after transcription
- No re-running ASR — only re-running the post-processing filter
- Existing history stays intact — old dictations show final text only

🪷 Generated with Sarvam Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790230922&installation_model_id=422865&pr_number=470&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F470&signature=e85a8651a9d88410144cabae52eaa4b96c58c38a5b2e4c7fe23f4c14a929b9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - View individual dictation pipelines with raw speech-recognition and filtered transcript text.
  - Copy raw or filtered text directly from dictation details.
  - Re-run transcript filtering with current processing settings.
  - Select dictations from the list to open detailed views.
- **Improvements**
  - Dictations retain raw speech-recognition text for inspection and reprocessing.
  - Updated transcripts refresh word counts and synchronization status.
  - Raw transcription data is preserved during cloud synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->