### PR TITLE
refactor: migrate HotkeyMonitor from NSEvent monitors to CGEventTap

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -99,7 +99,7 @@ final class HotkeyMonitor {
         }
     }
 
-    func start() {
+    func start(requestPermissionIfNeeded: Bool = true) {
         guard eventTap == nil else { return }
 
         // CGEventTap with .defaultTap can both observe AND consume events.
@@ -109,7 +109,7 @@ final class HotkeyMonitor {
         // during onboarding).
         let hasListenAccess = CGPreflightListenEventAccess()
         fputs("[hotkey] listen event access: \(hasListenAccess)\n", stderr)
-        if !hasListenAccess {
+        if !hasListenAccess && requestPermissionIfNeeded {
             let requested = CGRequestListenEventAccess()
             fputs("[hotkey] requested listen event access: \(requested)\n", stderr)
         }
@@ -143,7 +143,7 @@ final class HotkeyMonitor {
                 }
                 
                 let consumed = monitor.handle(nsEvent)
-                if consumed {
+                if consumed && type != .flagsChanged {
                     // Returning nil consumes the event — it never reaches
                     // the frontmost app. This is the key capability that
                     // NSEvent.addGlobalMonitorForEvents cannot provide.

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -43,8 +43,8 @@ final class HotkeyMonitor {
         combinationModifiers != nil && combinationKeyCode != nil
     }
 
-    private var globalMonitor: Any?
-    private var localMonitor: Any?
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
     private var prepareWorkItem: DispatchWorkItem?
     private var startWorkItem: DispatchWorkItem?
     private var armCancelWorkItem: DispatchWorkItem?
@@ -100,8 +100,13 @@ final class HotkeyMonitor {
     }
 
     func start() {
-        guard globalMonitor == nil, localMonitor == nil else { return }
+        guard eventTap == nil else { return }
 
+        // CGEventTap with .defaultTap can both observe AND consume events.
+        // This replaces the previous dual NSEvent monitor approach (global
+        // observe-only + local consume) with a single tap that handles all
+        // apps uniformly. Requires Accessibility permission (already requested
+        // during onboarding).
         let hasListenAccess = CGPreflightListenEventAccess()
         fputs("[hotkey] listen event access: \(hasListenAccess)\n", stderr)
         if !hasListenAccess {
@@ -109,36 +114,69 @@ final class HotkeyMonitor {
             fputs("[hotkey] requested listen event access: \(requested)\n", stderr)
         }
 
-        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.flagsChanged, .keyDown, .keyUp]) { [weak self] event in
-            self?.handle(event)
-        }
-        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .keyUp]) { [weak self] event in
-            guard let self else { return event }
-            if self.shouldHandleLocalEvent(event) {
-                let consumed = self.handle(event)
-                if consumed { return nil }
-            }
-            return event
+        let eventMask = (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.keyUp.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: { proxy, type, event, userInfo in
+                guard let userInfo else { return Unmanaged.passUnretained(event) }
+                let monitor = Unmanaged<HotkeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+                
+                // The system can disable the tap if the app becomes unresponsive
+                // or after a timeout. Re-enable it automatically.
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    if let tap = monitor.eventTap {
+                        CGEvent.tapEnable(tap: tap, enable: true)
+                        fputs("[hotkey] CGEventTap re-enabled after timeout\n", stderr)
+                    }
+                    return Unmanaged.passUnretained(event)
+                }
+                
+                // Convert CGEvent to NSEvent for the existing handling logic.
+                guard let nsEvent = NSEvent(cgEvent: event) else {
+                    return Unmanaged.passUnretained(event)
+                }
+                
+                let consumed = monitor.handle(nsEvent)
+                if consumed {
+                    // Returning nil consumes the event — it never reaches
+                    // the frontmost app. This is the key capability that
+                    // NSEvent.addGlobalMonitorForEvents cannot provide.
+                    return nil
+                }
+                return Unmanaged.passUnretained(event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            fputs("[hotkey] failed to create CGEventTap\n", stderr)
+            return
         }
 
-        if globalMonitor != nil || localMonitor != nil {
-            fputs("[hotkey] event monitors started\n", stderr)
-        } else {
-            fputs("[hotkey] failed to start event monitors\n", stderr)
-        }
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        eventTap = tap
+        runLoopSource = source
+        fputs("[hotkey] CGEventTap started\n", stderr)
     }
 
     func stop() {
         finishActiveSessionBeforeReconfigure()
         cancelTimers()
-        if let globalMonitor {
-            NSEvent.removeMonitor(globalMonitor)
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
         }
-        if let localMonitor {
-            NSEvent.removeMonitor(localMonitor)
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
-        globalMonitor = nil
-        localMonitor = nil
+        eventTap = nil
+        runLoopSource = nil
         targetKeyDown = false
         otherKeyPressed = false
         armed = false
@@ -240,7 +278,7 @@ final class HotkeyMonitor {
     }
 
     var isRunning: Bool {
-        globalMonitor != nil || localMonitor != nil
+        eventTap != nil
     }
 
     var isToggleRecording: Bool {
@@ -255,8 +293,11 @@ final class HotkeyMonitor {
         switch event.type {
         case .flagsChanged:
             handleFlagsChanged(keyCode: event.keyCode, flags: event.modifierFlags)
+            // Flags changes are never consumed — the modifier key should still
+            // reach the frontmost app so the OS maintains correct modifier state.
+            return false
         case .keyDown:
-            handleKeyDown(keyCode: event.keyCode)
+            return handleKeyDown(keyCode: event.keyCode)
         default:
             break
         }
@@ -354,31 +395,6 @@ final class HotkeyMonitor {
         }
     }
 
-
-    private func shouldHandleLocalEvent(_ event: NSEvent) -> Bool {
-        shouldHandleLocalEvent(
-            type: event.type,
-            keyCode: event.keyCode,
-            firstResponder: NSApp.keyWindow?.firstResponder
-        )
-    }
-
-    private func shouldHandleLocalEvent(
-        type: NSEvent.EventType,
-        keyCode: UInt16,
-        firstResponder: NSResponder?
-    ) -> Bool {
-        let isTextEditing = firstResponder is NSTextView || firstResponder is NSTextField
-        guard isTextEditing else { return true }
-
-        // Text editing owns fresh hotkey starts, but an already-armed hotkey
-        // session must still receive key-up/Escape cleanup events.
-        if targetKeyDown || armed || prepared || active || toggleActive || combinationKeyDown {
-            return true
-        }
-
-        return type == .keyDown && keyCode == 53
-    }
 
     func handleFlagsChanged(keyCode: UInt16, flags: NSEvent.ModifierFlags) {
         if keyCode == targetKeyCode {
@@ -491,7 +507,8 @@ final class HotkeyMonitor {
         }
     }
 
-    func handleKeyDown(keyCode: UInt16) {
+    @discardableResult
+    func handleKeyDown(keyCode: UInt16) -> Bool {
         // Escape cancels any active recording
         if keyCode == 53 {
             if toggleActive {
@@ -499,7 +516,7 @@ final class HotkeyMonitor {
                 toggleActive = false
                 cancelTimers()
                 onCancel?()
-                return
+                return true
             }
             if active {
                 fputs("[hotkey] escape → cancel hold\n", stderr)
@@ -509,7 +526,7 @@ final class HotkeyMonitor {
                 armed = false
                 cancelTimers()
                 onCancel?()
-                return
+                return true
             }
             if armed || prepared {
                 fputs("[hotkey] escape → cancel armed hold\n", stderr)
@@ -518,8 +535,9 @@ final class HotkeyMonitor {
                 prepared = false
                 cancelTimers()
                 onCancel?()
+                return true
             }
-            return
+            return false
         }
 
         if targetKeyDown && !toggleActive {
@@ -540,8 +558,10 @@ final class HotkeyMonitor {
                 } else if wasArmed {
                     onCancel?()
                 }
+                return true
             }
         }
+        return false
     }
 
     private func scheduleTimers() {
@@ -619,14 +639,6 @@ final class HotkeyMonitor {
     func setHoldRecordingActiveForTests() {
         targetKeyDown = true
         active = true
-    }
-
-    func shouldHandleLocalEventForTests(
-        type: NSEvent.EventType,
-        keyCode: UInt16,
-        firstResponder: NSResponder?
-    ) -> Bool {
-        shouldHandleLocalEvent(type: type, keyCode: keyCode, firstResponder: firstResponder)
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3863,7 +3863,7 @@ public final class MuesliController: NSObject {
             hotkeyMonitor.configure(keyCode: keyCode)
         }
         hotkeyMonitor.start(requestPermissionIfNeeded: requestPermissionIfNeeded)
-        startComputerUseHotkeyMonitorIfNeeded()
+        startComputerUseHotkeyMonitorIfNeeded(requestPermissionIfNeeded: requestPermissionIfNeeded)
     }
 
     func stopHotkeyMonitor() {
@@ -7340,7 +7340,7 @@ public final class MuesliController: NSObject {
         meetingRecordingHotkeyMonitor.configureTriggerThreshold(milliseconds: config.meetingRecordingHotkeyTriggerThresholdMS)
     }
 
-    private func startComputerUseHotkeyMonitorIfNeeded() {
+    private func startComputerUseHotkeyMonitorIfNeeded(requestPermissionIfNeeded: Bool = true) {
         guard config.enableComputerUseHotkey else {
             computerUseHotkeyMonitor.stop()
             return
@@ -7362,7 +7362,7 @@ public final class MuesliController: NSObject {
         }
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         computerUseHotkeyMonitor.configure(config.computerUseHotkey)
-        computerUseHotkeyMonitor.start()
+        computerUseHotkeyMonitor.start(requestPermissionIfNeeded: requestPermissionIfNeeded)
     }
 
     private func startMeetingRecordingHotkeyMonitorIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3858,11 +3858,11 @@ public final class MuesliController: NSObject {
         setState(.idle)
     }
 
-    func startHotkeyMonitor(keyCode: UInt16? = nil) {
+    func startHotkeyMonitor(keyCode: UInt16? = nil, requestPermissionIfNeeded: Bool = true) {
         if let keyCode {
             hotkeyMonitor.configure(keyCode: keyCode)
         }
-        hotkeyMonitor.start()
+        hotkeyMonitor.start(requestPermissionIfNeeded: requestPermissionIfNeeded)
         startComputerUseHotkeyMonitorIfNeeded()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1653,7 +1653,7 @@ struct OnboardingView: View {
             dictationTestError = nil
             controller.dictationTestBackend = selectedBackend
             controller.dictationTestCohereLanguage = selectedCohereLanguage
-            controller.startHotkeyMonitor(keyCode: selectedHotkey.keyCode)
+            controller.startHotkeyMonitor(keyCode: selectedHotkey.keyCode, requestPermissionIfNeeded: false)
             isDictationTestMonitorActive = true
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1893,61 +1893,30 @@ struct HotkeyMonitorTests {
         #expect(cancelCount == 1)
     }
 
-    @Test("local monitor skips fresh hotkey starts while editing text")
+    @Test("CGEventTap consumes Escape during active hold recording")
     @MainActor
-    func localMonitorSkipsFreshHotkeyStartsWhileEditingText() async throws {
+    func cgeventtapConsumesEscapeDuringActiveHold() async throws {
         let monitor = HotkeyMonitor()
-        let textView = NSTextView()
-
-        #expect(
-            monitor.shouldHandleLocalEventForTests(
-                type: .flagsChanged,
-                keyCode: 55,
-                firstResponder: textView
-            ) == false
-        )
-    }
-
-    @Test("local monitor preserves key-up cleanup after hotkey session is armed")
-    @MainActor
-    func localMonitorPreservesKeyUpCleanupAfterHotkeySessionIsArmed() async throws {
-        let monitor = HotkeyMonitor()
-        let textView = NSTextView()
-        var stopCount = 0
-        monitor.onStop = {
-            stopCount += 1
+        var cancelCount = 0
+        monitor.onCancel = {
+            cancelCount += 1
         }
 
         monitor.setHoldRecordingActiveForTests()
+        let consumed = monitor.handleKeyDown(keyCode: 53)
 
-        #expect(
-            monitor.shouldHandleLocalEventForTests(
-                type: .flagsChanged,
-                keyCode: 55,
-                firstResponder: textView
-            ) == true
-        )
-
-        monitor.handleFlagsChanged(keyCode: 55, flags: [])
-
-        #expect(stopCount == 1)
+        #expect(consumed == true)
+        #expect(cancelCount == 1)
     }
 
-    @Test("local monitor still lets escape cancel active hold dictation while editing text")
+    @Test("CGEventTap does not consume keys when idle")
     @MainActor
-    func localMonitorLetsEscapeCancelActiveHoldDictationWhileEditingText() async throws {
+    func cgeventtapDoesNotConsumeWhenIdle() async throws {
         let monitor = HotkeyMonitor()
-        let textView = NSTextView()
 
-        monitor.setHoldRecordingActiveForTests()
-
-        #expect(
-            monitor.shouldHandleLocalEventForTests(
-                type: .keyDown,
-                keyCode: 53,
-                firstResponder: textView
-            ) == true
-        )
+        // When idle, Escape should not be consumed
+        let consumed = monitor.handleKeyDown(keyCode: 53)
+        #expect(consumed == false)
     }
 
     @Test("trigger threshold derives prepare and start delays")


### PR DESCRIPTION
## Summary

Replaces the dual NSEvent monitor architecture (global observe-only + local consume) with a single CGEvent.tapCreate using .defaultTap.

## Problem

NSEvent.addGlobalMonitorForEvents can observe keyboard events system-wide but cannot consume them — events always reach the frontmost app. This was the root cause of several issues in the tap-to-toggle and enter-to-submit feature PRs:

- Physical Enter during toggle dictation reached the target app before transcription completed, causing double submission
- The shouldHandleLocalEvent / isTextEditing / firstResponder logic existed solely as a workaround for the local monitor's limited scope — it tried to avoid interfering with text editing in Muesli's own windows while still handling key-up/Escape cleanup

## Solution

CGEventTap with .defaultTap can both observe and consume events by returning nil from the callback. This is the same mechanism used by apps like Spokenly to intercept keys system-wide. Requires Accessibility permission, which Muesli already requests during onboarding.

## Changes

- start()/stop() now create/destroy a CGEventTap on the main run loop instead of installing NSEvent monitors
- handle() returns Bool; true causes the tap to consume the event by returning nil
- handleKeyDown() now returns Bool for consumption decisions (Escape during recording, other-key cancellation during hold)
- shouldHandleLocalEvent and its test helper removed — no longer needed since the tap handles all apps uniformly
- CGEventTap auto-re-enables after system timeout
- Tests updated: removed 3 shouldHandleLocalEvent tests, added 2 new CGEventTap consumption tests

## Validation

- `swift build --package-path native/MuesliNative` — passes
- `swift test --filter HotkeyMonitorTests` — 16 tests pass
- All existing hotkey state machine tests (toggle, combination, double-tap, threshold) pass unchanged

## Contribution Certification

- [x] I certify that I have the right to submit this contribution and that it does not violate any existing licenses or agreements.
- [x] I have reviewed the contribution guidelines and followed the coding standards.
- [x] This contribution does not include any third-party materials.

🪷 Generated with Sarvam Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790248716&installation_model_id=422865&pr_number=474&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F474&signature=a53f48e29a0b3eea8567699a466d0251fd4a0ffcb6609b5041c7cd91f4404bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotkey monitoring across applications for more consistent behavior.
  * Modifier-key events now continue reaching the active application as expected.
  * Escape reliably cancels active hold-based dictation while remaining available to the system when idle.
  * Dictation testing no longer unnecessarily prompts for listening permissions.
  * Hotkey behavior is now more reliable during active recording and across different application states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->