### PR TITLE
feat: add Enter-to-submit during toggle dictation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -3,6 +3,21 @@ import ApplicationServices
 import Foundation
 import MuesliCore
 
+/// How the dictation hotkey triggers recording.
+enum DictationTriggerMode: String, CaseIterable, Codable, Sendable {
+    /// Hold the hotkey to record; release to stop and transcribe.
+    case holdToRecord
+    /// Tap the hotkey to start recording; tap again to stop and transcribe.
+    case tapToToggle
+
+    var displayName: String {
+        switch self {
+        case .holdToRecord: "Hold to Record"
+        case .tapToToggle: "Tap to Toggle"
+        }
+    }
+}
+
 enum HotkeyTriggerTiming {
     static let defaultThresholdMilliseconds = 250
     static let defaultMeetingThresholdMilliseconds = 600
@@ -34,6 +49,7 @@ final class HotkeyMonitor {
     var onToggleStop: (() -> Void)?
     var targetKeyCode: UInt16 = 55
     var doubleTapEnabled: Bool = true
+    var tapToToggleEnabled: Bool = false
 
     // Combination mode (e.g. Cmd+Shift+R)
     var combinationModifiers: NSEvent.ModifierFlags?
@@ -416,6 +432,19 @@ final class HotkeyMonitor {
                         return
                     }
 
+                    // Tap-to-toggle: start toggle immediately on key-down.
+                    // Skip arming, hold timers, and double-tap detection —
+                    // a single tap toggles, the next tap stops.
+                    if tapToToggleEnabled {
+                        fputs("[hotkey] tap-to-toggle → toggle start\n", stderr)
+                        lastTapWasShort = false
+                        lastTapUpTime = nil
+                        toggleActive = true
+                        cancelTimers()
+                        onToggleStart?()
+                        return
+                    }
+
                     // Check for double-tap
                     if doubleTapEnabled,
                        lastTapWasShort,
@@ -493,6 +522,12 @@ final class HotkeyMonitor {
             } else if wasArmed {
                 onCancel?()
             }
+        } else if toggleActive {
+            // Another modifier key while toggle is active — cancel toggle
+            fputs("[hotkey] canceled by other modifier key \(keyCode) during toggle\n", stderr)
+            toggleActive = false
+            cancelTimers()
+            onCancel?()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -77,6 +77,9 @@ final class HotkeyMonitor {
     private var lastTapUpTime: Date?
     private var lastTapWasShort = false
     private var toggleActive = false
+    // Set when a key-down stops an active toggle. Prevents the matching
+    // key-up from immediately re-starting the toggle in tap-to-toggle mode.
+    private var toggleStoppedViaKeyPress = false
 
     private var prepareDelay: TimeInterval
     private var startDelay: TimeInterval
@@ -217,6 +220,7 @@ final class HotkeyMonitor {
         prepared = false
         active = false
         toggleActive = false
+        toggleStoppedViaKeyPress = false
         combinationKeyDown = false
         combinationTriggered = false
     }
@@ -279,6 +283,7 @@ final class HotkeyMonitor {
         prepared = false
         active = false
         toggleActive = false
+        toggleStoppedViaKeyPress = false
         combinationKeyDown = false
         combinationTriggered = false
         lastTapWasShort = false
@@ -463,6 +468,7 @@ final class HotkeyMonitor {
                     if toggleActive {
                         fputs("[hotkey] toggle stop via keypress\n", stderr)
                         toggleActive = false
+                        toggleStoppedViaKeyPress = true
                         cancelTimers()
                         onToggleStop?()
                         return
@@ -522,12 +528,19 @@ final class HotkeyMonitor {
                 // Cmd+C produces Cmd-down → C-down → C-up → Cmd-up, and
                 // otherKeyPressed is true by the time Cmd releases, so the
                 // toggle doesn't fire. A deliberate tap has no intervening keys.
-                if tapToToggleEnabled && wasDown && !otherKeyPressed {
+                //
+                // Also skip if this key-up is the release of a press that
+                // stopped a toggle — otherwise the stop press would immediately
+                // re-start the toggle.
+                if tapToToggleEnabled && wasDown && !otherKeyPressed && !toggleStoppedViaKeyPress {
                     fputs("[hotkey] tap-to-toggle → toggle start (release)\n", stderr)
                     toggleActive = true
                     onToggleStart?()
                     return
                 }
+                // Clear the stop-press flag now that the matching key-up has
+                // been processed. The next key-down/key-up cycle starts fresh.
+                toggleStoppedViaKeyPress = false
 
                 // Track tap timing for double-tap detection. Low trigger thresholds can
                 // enter the prepared state quickly, but a release before recording starts

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -51,6 +51,10 @@ final class HotkeyMonitor {
     var targetKeyCode: UInt16 = 55
     var doubleTapEnabled: Bool = true
     var tapToToggleEnabled: Bool = false
+    /// When false, Enter during toggle mode stops recording without submitting
+    /// (no synthetic Return). The physical Enter is NOT consumed, so it passes
+    /// through to the frontmost app normally.
+    var submitOnEnterEnabled: Bool = false
 
     // Combination mode (e.g. Cmd+Shift+R)
     var combinationModifiers: NSEvent.ModifierFlags?
@@ -396,7 +400,7 @@ final class HotkeyMonitor {
         // Enter during toggle mode: stop dictation and submit (paste + Enter).
         // Only the dictation monitor has onToggleStopAndSubmit wired — gate on
         // it so Enter doesn't interfere with computer-use or meeting toggles.
-        if type == .keyDown && keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil {
+        if type == .keyDown && keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil, submitOnEnterEnabled {
             fputs("[hotkey] enter → toggle stop and submit (combination)\n", stderr)
             toggleActive = false
             cancelTimers()
@@ -657,7 +661,7 @@ final class HotkeyMonitor {
         // it so Enter doesn't interfere with computer-use or meeting toggles.
         // The CGEventTap consumes this event so the physical Enter never
         // reaches the frontmost app.
-        if keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil {
+        if keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil, submitOnEnterEnabled {
             fputs("[hotkey] enter → toggle stop and submit\n", stderr)
             toggleActive = false
             cancelTimers()

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -99,7 +99,7 @@ final class HotkeyMonitor {
         }
     }
 
-    func start() {
+    func start(requestPermissionIfNeeded: Bool = true) {
         guard eventTap == nil else { return }
 
         // CGEventTap with .defaultTap can both observe AND consume events.
@@ -109,7 +109,7 @@ final class HotkeyMonitor {
         // during onboarding).
         let hasListenAccess = CGPreflightListenEventAccess()
         fputs("[hotkey] listen event access: \(hasListenAccess)\n", stderr)
-        if !hasListenAccess {
+        if !hasListenAccess && requestPermissionIfNeeded {
             let requested = CGRequestListenEventAccess()
             fputs("[hotkey] requested listen event access: \(requested)\n", stderr)
         }
@@ -143,7 +143,7 @@ final class HotkeyMonitor {
                 }
                 
                 let consumed = monitor.handle(nsEvent)
-                if consumed {
+                if consumed && type != .flagsChanged {
                     // Returning nil consumes the event — it never reaches
                     // the frontmost app. This is the key capability that
                     // NSEvent.addGlobalMonitorForEvents cannot provide.

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -468,16 +468,17 @@ final class HotkeyMonitor {
                         return
                     }
 
-                    // Tap-to-toggle: start toggle immediately on key-down.
-                    // Skip arming, hold timers, and double-tap detection —
-                    // a single tap toggles, the next tap stops.
+                    // Tap-to-toggle: defer the toggle-start decision to key-up.
+                    // We arm on key-down but only fire on release if no other key
+                    // was pressed while the modifier was held. This filters out
+                    // incidental modifier presses during keyboard shortcuts like
+                    // Cmd+C / Cmd+V — the maintainer's phantom-press concern.
                     if tapToToggleEnabled {
-                        fputs("[hotkey] tap-to-toggle → toggle start\n", stderr)
+                        fputs("[hotkey] tap-to-toggle armed (waiting for release)\n", stderr)
                         lastTapWasShort = false
                         lastTapUpTime = nil
-                        toggleActive = true
-                        cancelTimers()
-                        onToggleStart?()
+                        // Don't arm or schedule timers — just track the press.
+                        // The toggle fires on key-up if no other key intervened.
                         return
                     }
 
@@ -513,6 +514,18 @@ final class HotkeyMonitor {
 
                 if toggleActive {
                     // Don't stop toggle on key-up — only on next key-down
+                    return
+                }
+
+                // Tap-to-toggle: fire on key-up only if no other key was pressed
+                // while the modifier was held. This is the phantom-press filter:
+                // Cmd+C produces Cmd-down → C-down → C-up → Cmd-up, and
+                // otherKeyPressed is true by the time Cmd releases, so the
+                // toggle doesn't fire. A deliberate tap has no intervening keys.
+                if tapToToggleEnabled && wasDown && !otherKeyPressed {
+                    fputs("[hotkey] tap-to-toggle → toggle start (release)\n", stderr)
+                    toggleActive = true
+                    onToggleStart?()
                     return
                 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -47,6 +47,7 @@ final class HotkeyMonitor {
     var onCancel: (() -> Void)?
     var onToggleStart: (() -> Void)?
     var onToggleStop: (() -> Void)?
+    var onToggleStopAndSubmit: (() -> Void)?
     var targetKeyCode: UInt16 = 55
     var doubleTapEnabled: Bool = true
     var tapToToggleEnabled: Bool = false
@@ -392,6 +393,17 @@ final class HotkeyMonitor {
             return false
         }
 
+        // Enter during toggle mode: stop dictation and submit (paste + Enter).
+        // Only the dictation monitor has onToggleStopAndSubmit wired — gate on
+        // it so Enter doesn't interfere with computer-use or meeting toggles.
+        if type == .keyDown && keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil {
+            fputs("[hotkey] enter → toggle stop and submit (combination)\n", stderr)
+            toggleActive = false
+            cancelTimers()
+            onToggleStopAndSubmit?()
+            return true
+        }
+
         guard let targetMods = combinationModifiers,
               let targetKey = combinationKeyCode else { return false }
 
@@ -638,6 +650,19 @@ final class HotkeyMonitor {
                 return true
             }
             return false
+        }
+
+        // Enter during toggle mode: stop dictation and submit (paste + Enter).
+        // Only the dictation monitor has onToggleStopAndSubmit wired — gate on
+        // it so Enter doesn't interfere with computer-use or meeting toggles.
+        // The CGEventTap consumes this event so the physical Enter never
+        // reaches the frontmost app.
+        if keyCode == 36 && toggleActive, onToggleStopAndSubmit != nil {
+            fputs("[hotkey] enter → toggle stop and submit\n", stderr)
+            toggleActive = false
+            cancelTimers()
+            onToggleStopAndSubmit?()
+            return true
         }
 
         if targetKeyDown && !toggleActive {

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -121,13 +121,22 @@ final class HotkeyMonitor {
         // CGEventTap with .defaultTap can both observe AND consume events.
         // This replaces the previous dual NSEvent monitor approach (global
         // observe-only + local consume) with a single tap that handles all
-        // apps uniformly. Requires Accessibility permission (already requested
-        // during onboarding).
+        // apps uniformly. Requires Accessibility permission.
         let hasListenAccess = CGPreflightListenEventAccess()
         fputs("[hotkey] listen event access: \(hasListenAccess)\n", stderr)
         if !hasListenAccess && requestPermissionIfNeeded {
             let requested = CGRequestListenEventAccess()
             fputs("[hotkey] requested listen event access: \(requested)\n", stderr)
+        }
+
+        // .defaultTap (consume) requires Accessibility, not just Input Monitoring.
+        // Request it if not already granted so the tap can initialize.
+        let hasAxAccess = AXIsProcessTrusted()
+        fputs("[hotkey] accessibility access: \(hasAxAccess)\n", stderr)
+        if !hasAxAccess && requestPermissionIfNeeded {
+            let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
+            _ = AXIsProcessTrustedWithOptions(options)
+            fputs("[hotkey] requested accessibility access\n", stderr)
         }
 
         let eventMask = (1 << CGEventType.flagsChanged.rawValue)
@@ -155,6 +164,14 @@ final class HotkeyMonitor {
                 
                 // Convert CGEvent to NSEvent for the existing handling logic.
                 guard let nsEvent = NSEvent(cgEvent: event) else {
+                    return Unmanaged.passUnretained(event)
+                }
+                
+                // Preserve the text-editor guard from the old local monitor:
+                // when Muesli's own text field has focus, ignore fresh hotkey
+                // starts so the modifier key works normally for text input.
+                // An already-armed session still receives cleanup events.
+                if !monitor.shouldHandleEvent(nsEvent) {
                     return Unmanaged.passUnretained(event)
                 }
                 
@@ -187,6 +204,7 @@ final class HotkeyMonitor {
         cancelTimers()
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
         }
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
@@ -299,6 +317,24 @@ final class HotkeyMonitor {
 
     var isToggleRecording: Bool {
         toggleActive
+    }
+
+    /// When Muesli's own text field has focus, ignore fresh hotkey starts so the
+    /// modifier key works normally for text input. An already-armed session still
+    /// receives key-up/Escape cleanup events. This preserves the guard that the
+    /// old NSEvent local monitor provided.
+    private func shouldHandleEvent(_ event: NSEvent) -> Bool {
+        let firstResponder = NSApp.keyWindow?.firstResponder
+        let isTextEditing = firstResponder is NSTextView || firstResponder is NSTextField
+        guard isTextEditing else { return true }
+
+        // Text editing owns fresh hotkey starts, but an already-armed hotkey
+        // session must still receive key-up/Escape cleanup events.
+        if targetKeyDown || armed || prepared || active || toggleActive || combinationKeyDown {
+            return true
+        }
+
+        return event.type == .keyDown && event.keyCode == 53
     }
 
     @discardableResult
@@ -522,8 +558,11 @@ final class HotkeyMonitor {
             } else if wasArmed {
                 onCancel?()
             }
-        } else if toggleActive {
-            // Another modifier key while toggle is active — cancel toggle
+        } else if toggleActive && !tapToToggleEnabled {
+            // In double-tap toggle mode, another modifier key cancels the toggle.
+            // In tap-to-toggle mode, only the target key or Escape stops recording —
+            // unrelated modifier releases (e.g. releasing Shift after Cmd+Tab) must
+            // not cancel an active toggle session.
             fputs("[hotkey] canceled by other modifier key \(keyCode) during toggle\n", stderr)
             toggleActive = false
             cancelTimers()

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -43,8 +43,8 @@ final class HotkeyMonitor {
         combinationModifiers != nil && combinationKeyCode != nil
     }
 
-    private var globalMonitor: Any?
-    private var localMonitor: Any?
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
     private var prepareWorkItem: DispatchWorkItem?
     private var startWorkItem: DispatchWorkItem?
     private var armCancelWorkItem: DispatchWorkItem?
@@ -100,8 +100,13 @@ final class HotkeyMonitor {
     }
 
     func start() {
-        guard globalMonitor == nil, localMonitor == nil else { return }
+        guard eventTap == nil else { return }
 
+        // CGEventTap with .defaultTap can both observe AND consume events.
+        // This replaces the previous dual NSEvent monitor approach (global
+        // observe-only + local consume) with a single tap that handles all
+        // apps uniformly. Requires Accessibility permission (already requested
+        // during onboarding).
         let hasListenAccess = CGPreflightListenEventAccess()
         fputs("[hotkey] listen event access: \(hasListenAccess)\n", stderr)
         if !hasListenAccess {
@@ -109,36 +114,69 @@ final class HotkeyMonitor {
             fputs("[hotkey] requested listen event access: \(requested)\n", stderr)
         }
 
-        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.flagsChanged, .keyDown, .keyUp]) { [weak self] event in
-            self?.handle(event)
-        }
-        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .keyUp]) { [weak self] event in
-            guard let self else { return event }
-            if self.shouldHandleLocalEvent(event) {
-                let consumed = self.handle(event)
-                if consumed { return nil }
-            }
-            return event
+        let eventMask = (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.keyUp.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: { proxy, type, event, userInfo in
+                guard let userInfo else { return Unmanaged.passUnretained(event) }
+                let monitor = Unmanaged<HotkeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+                
+                // The system can disable the tap if the app becomes unresponsive
+                // or after a timeout. Re-enable it automatically.
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    if let tap = monitor.eventTap {
+                        CGEvent.tapEnable(tap: tap, enable: true)
+                        fputs("[hotkey] CGEventTap re-enabled after timeout\n", stderr)
+                    }
+                    return Unmanaged.passUnretained(event)
+                }
+                
+                // Convert CGEvent to NSEvent for the existing handling logic.
+                guard let nsEvent = NSEvent(cgEvent: event) else {
+                    return Unmanaged.passUnretained(event)
+                }
+                
+                let consumed = monitor.handle(nsEvent)
+                if consumed {
+                    // Returning nil consumes the event — it never reaches
+                    // the frontmost app. This is the key capability that
+                    // NSEvent.addGlobalMonitorForEvents cannot provide.
+                    return nil
+                }
+                return Unmanaged.passUnretained(event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            fputs("[hotkey] failed to create CGEventTap\n", stderr)
+            return
         }
 
-        if globalMonitor != nil || localMonitor != nil {
-            fputs("[hotkey] event monitors started\n", stderr)
-        } else {
-            fputs("[hotkey] failed to start event monitors\n", stderr)
-        }
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        eventTap = tap
+        runLoopSource = source
+        fputs("[hotkey] CGEventTap started\n", stderr)
     }
 
     func stop() {
         finishActiveSessionBeforeReconfigure()
         cancelTimers()
-        if let globalMonitor {
-            NSEvent.removeMonitor(globalMonitor)
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
         }
-        if let localMonitor {
-            NSEvent.removeMonitor(localMonitor)
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
-        globalMonitor = nil
-        localMonitor = nil
+        eventTap = nil
+        runLoopSource = nil
         targetKeyDown = false
         otherKeyPressed = false
         armed = false
@@ -240,7 +278,7 @@ final class HotkeyMonitor {
     }
 
     var isRunning: Bool {
-        globalMonitor != nil || localMonitor != nil
+        eventTap != nil
     }
 
     var isToggleRecording: Bool {
@@ -255,8 +293,11 @@ final class HotkeyMonitor {
         switch event.type {
         case .flagsChanged:
             handleFlagsChanged(keyCode: event.keyCode, flags: event.modifierFlags)
+            // Flags changes are never consumed — the modifier key should still
+            // reach the frontmost app so the OS maintains correct modifier state.
+            return false
         case .keyDown:
-            handleKeyDown(keyCode: event.keyCode)
+            return handleKeyDown(keyCode: event.keyCode)
         default:
             break
         }
@@ -354,31 +395,6 @@ final class HotkeyMonitor {
         }
     }
 
-
-    private func shouldHandleLocalEvent(_ event: NSEvent) -> Bool {
-        shouldHandleLocalEvent(
-            type: event.type,
-            keyCode: event.keyCode,
-            firstResponder: NSApp.keyWindow?.firstResponder
-        )
-    }
-
-    private func shouldHandleLocalEvent(
-        type: NSEvent.EventType,
-        keyCode: UInt16,
-        firstResponder: NSResponder?
-    ) -> Bool {
-        let isTextEditing = firstResponder is NSTextView || firstResponder is NSTextField
-        guard isTextEditing else { return true }
-
-        // Text editing owns fresh hotkey starts, but an already-armed hotkey
-        // session must still receive key-up/Escape cleanup events.
-        if targetKeyDown || armed || prepared || active || toggleActive || combinationKeyDown {
-            return true
-        }
-
-        return type == .keyDown && keyCode == 53
-    }
 
     func handleFlagsChanged(keyCode: UInt16, flags: NSEvent.ModifierFlags) {
         if keyCode == targetKeyCode {
@@ -491,7 +507,8 @@ final class HotkeyMonitor {
         }
     }
 
-    func handleKeyDown(keyCode: UInt16) {
+    @discardableResult
+    func handleKeyDown(keyCode: UInt16) -> Bool {
         // Escape cancels any active recording
         if keyCode == 53 {
             if toggleActive {
@@ -499,7 +516,7 @@ final class HotkeyMonitor {
                 toggleActive = false
                 cancelTimers()
                 onCancel?()
-                return
+                return true
             }
             if active {
                 fputs("[hotkey] escape → cancel hold\n", stderr)
@@ -509,7 +526,7 @@ final class HotkeyMonitor {
                 armed = false
                 cancelTimers()
                 onCancel?()
-                return
+                return true
             }
             if armed || prepared {
                 fputs("[hotkey] escape → cancel armed hold\n", stderr)
@@ -518,8 +535,9 @@ final class HotkeyMonitor {
                 prepared = false
                 cancelTimers()
                 onCancel?()
+                return true
             }
-            return
+            return false
         }
 
         if targetKeyDown && !toggleActive {
@@ -540,8 +558,10 @@ final class HotkeyMonitor {
                 } else if wasArmed {
                     onCancel?()
                 }
+                return true
             }
         }
+        return false
     }
 
     private func scheduleTimers() {
@@ -619,14 +639,6 @@ final class HotkeyMonitor {
     func setHoldRecordingActiveForTests() {
         targetKeyDown = true
         active = true
-    }
-
-    func shouldHandleLocalEventForTests(
-        type: NSEvent.EventType,
-        keyCode: UInt16,
-        firstResponder: NSResponder?
-    ) -> Bool {
-        shouldHandleLocalEvent(type: type, keyCode: keyCode, firstResponder: firstResponder)
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1296,6 +1296,7 @@ struct AppConfig: Codable {
     var waveformCacheOrphanCleanupMigrationApplied: Bool = false
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
+    var dictationTriggerMode: DictationTriggerMode = .holdToRecord
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var computerUseHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var meetingRecordingHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultMeetingThresholdMilliseconds
@@ -1423,6 +1424,7 @@ struct AppConfig: Codable {
         case waveformCacheOrphanCleanupMigrationApplied = "waveform_cache_orphan_cleanup_migration_applied"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
+        case dictationTriggerMode = "dictation_trigger_mode"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case computerUseHotkeyTriggerThresholdMS = "computer_use_hotkey_trigger_threshold_ms"
         case meetingRecordingHotkeyTriggerThresholdMS = "meeting_recording_hotkey_trigger_threshold_ms"
@@ -1577,6 +1579,8 @@ struct AppConfig: Codable {
         iCloudSyncEnabled = (try? c.decode(Bool.self, forKey: .iCloudSyncEnabled)) ?? defaults.iCloudSyncEnabled
         showIOSCompanionPrompt = (try? c.decode(Bool.self, forKey: .showIOSCompanionPrompt)) ?? defaults.showIOSCompanionPrompt
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
+        dictationTriggerMode = (try? c.decode(DictationTriggerMode.self, forKey: .dictationTriggerMode))
+            ?? defaults.dictationTriggerMode
         hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
             (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1297,6 +1297,7 @@ struct AppConfig: Codable {
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
     var dictationTriggerMode: DictationTriggerMode = .holdToRecord
+    var enableSubmitOnEnter: Bool = false
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var computerUseHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var meetingRecordingHotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultMeetingThresholdMilliseconds
@@ -1425,6 +1426,7 @@ struct AppConfig: Codable {
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
         case dictationTriggerMode = "dictation_trigger_mode"
+        case enableSubmitOnEnter = "enable_submit_on_enter"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case computerUseHotkeyTriggerThresholdMS = "computer_use_hotkey_trigger_threshold_ms"
         case meetingRecordingHotkeyTriggerThresholdMS = "meeting_recording_hotkey_trigger_threshold_ms"
@@ -1581,6 +1583,7 @@ struct AppConfig: Codable {
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
         dictationTriggerMode = (try? c.decode(DictationTriggerMode.self, forKey: .dictationTriggerMode))
             ?? defaults.dictationTriggerMode
+        enableSubmitOnEnter = (try? c.decode(Bool.self, forKey: .enableSubmitOnEnter)) ?? defaults.enableSubmitOnEnter
         hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
             (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -439,6 +439,9 @@ public final class MuesliController: NSObject {
     private var pendingDictationStopStartedAt: Date?
     private var pendingDictationStopSessionID: UUID?
     private var pendingReleaseSoundSessionID: UUID?
+    /// Set when Enter-to-submit is triggered during toggle dictation. After the
+    /// transcript is pasted, a Return keypress is sent to the frontmost app.
+    private var pendingSubmitAfterPaste: Bool = false
     private var pendingPreparingIndicatorWorkItem: DispatchWorkItem?
     private var activeComputerUseAudioSessionID: UUID?
     private var computerUseCommandStartedAt: Date?
@@ -636,6 +639,7 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.onCancel = { [weak self] in self?.handleCancel() }
         hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
+        hotkeyMonitor.onToggleStopAndSubmit = { [weak self] in self?.handleToggleStopAndSubmit() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         hotkeyMonitor.tapToToggleEnabled = config.dictationTriggerMode == .tapToToggle
         configureHotkeyMonitorTiming()
@@ -8689,6 +8693,7 @@ public final class MuesliController: NSObject {
         // backends (see isStreamingDictationBackend) so the double-tap detection window
         // stays clean; beginRecording cold-starts here just like the toggle path.
         fputs("[muesli-native] recording start\n", stderr)
+        pendingSubmitAfterPaste = false
         meetingMonitor.suppressWhileActive()
         beginDictationOutput()
         dictationStartedAt = nil
@@ -8831,6 +8836,7 @@ public final class MuesliController: NSObject {
             return
         }
         fputs("[muesli-native] cancel\n", stderr)
+        pendingSubmitAfterPaste = false
         resetDictationOutputMode()
 
         if isNemotron35Streaming {
@@ -8879,6 +8885,7 @@ public final class MuesliController: NSObject {
             return false
         }
         fputs("[muesli-native] toggle dictation start\n", stderr)
+        pendingSubmitAfterPaste = false
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "toggle")
         }
@@ -8924,6 +8931,22 @@ public final class MuesliController: NSObject {
 
     private func handleToggleStop() {
         fputs("[muesli-native] toggle dictation stop\n", stderr)
+        indicator.isToggleDictation = false
+        handleStop()
+    }
+
+    /// Called when Enter is pressed during toggle dictation with submit-on-enter
+    /// enabled. Stops dictation (triggering transcription + paste) and arms a
+    /// flag so a Return keypress is sent to the frontmost app after paste settles.
+    /// The physical Enter is consumed by the CGEventTap, so only the synthetic
+    /// Return after paste reaches the target app.
+    private func handleToggleStopAndSubmit() {
+        guard config.enableSubmitOnEnter else {
+            handleToggleStop()
+            return
+        }
+        fputs("[muesli-native] toggle dictation stop and submit\n", stderr)
+        pendingSubmitAfterPaste = true
         indicator.isToggleDictation = false
         handleStop()
     }
@@ -8990,11 +9013,16 @@ public final class MuesliController: NSObject {
     private func handleStop() {
         if isMeetingRecording() {
             cancelDictationAudioSessionForMeetingRecordingIfNeeded()
+            pendingSubmitAfterPaste = false
             return
         }
-        if shouldIgnoreDictationCleanupForComputerUseActivity() { return }
+        if shouldIgnoreDictationCleanupForComputerUseActivity() {
+            pendingSubmitAfterPaste = false
+            return
+        }
         if shouldIgnoreCleanupAfterBlockedDictationStart {
             fputs("[muesli-native] ignoring dictation stop because start was blocked\n", stderr)
+            pendingSubmitAfterPaste = false
             return
         }
         fputs("[muesli-native] stop\n", stderr)
@@ -9130,6 +9158,15 @@ public final class MuesliController: NSObject {
         fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
         finishDictationLatencyTrace("nemotron_stop")
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
+        if pendingSubmitAfterPaste {
+            pendingSubmitAfterPaste = false
+            if outputMode == .paste, !cleaned.isEmpty {
+                let targetPID = targetApp?.processID
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    PasteController.simulateReturnKey(expectedTargetPID: targetPID)
+                }
+            }
+        }
     }
 
     /// Releases the user-visible dictation state immediately after Cmd+V. Keep this path
@@ -9181,6 +9218,7 @@ public final class MuesliController: NSObject {
         markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
             fputs("[muesli-native] stop without wav\n", stderr)
+            pendingSubmitAfterPaste = false
             clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
@@ -9192,6 +9230,7 @@ public final class MuesliController: NSObject {
         let duration = max(Date().timeIntervalSince(startedAt), 0)
         if duration < 0.3 {
             fputs("[muesli-native] discarded short recording\n", stderr)
+            pendingSubmitAfterPaste = false
             try? FileManager.default.removeItem(at: wavURL)
             if isDictationTestMode {
                 dictationTestCallback?("")
@@ -9254,6 +9293,7 @@ public final class MuesliController: NSObject {
                 if isTestMode {
                     await MainActor.run {
                         self.dictationTestCallback?(text)
+                        self.pendingSubmitAfterPaste = false
                         self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
@@ -9269,6 +9309,7 @@ public final class MuesliController: NSObject {
                 }
                 guard !text.isEmpty else {
                     await MainActor.run {
+                        self.pendingSubmitAfterPaste = false
                         self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
@@ -9288,7 +9329,8 @@ public final class MuesliController: NSObject {
                                 guard let self else { return }
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)
                                 completionTargetApp = targetApp
-                                self.releaseStandardDictationState()
+                                self.pendingSubmitAfterPaste = false
+                        self.releaseStandardDictationState()
                                 if self.config.enableDictionaryCorrectionPrompts {
                                     // This opt-in monitor only schedules its first Accessibility
                                     // poll after 100 ms, so starting it here captures immediate
@@ -9306,7 +9348,7 @@ public final class MuesliController: NSObject {
                                     trace: completionLatencyTrace
                                 )
                             },
-                            onClipboardSettled: { [weak self] in
+                            onClipboardSettled: { [weak self] pasteSucceeded in
                                 guard let self else { return }
                                 self.finishStandardDictationBookkeeping(
                                     text: text,
@@ -9321,6 +9363,14 @@ public final class MuesliController: NSObject {
                                     "bookkeeping_completed",
                                     trace: completionLatencyTrace
                                 )
+                                if self.pendingSubmitAfterPaste {
+                                    self.pendingSubmitAfterPaste = false
+                                    guard pasteSucceeded else { return }
+                                    let targetPID = completionTargetApp?.processID
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                        PasteController.simulateReturnKey(expectedTargetPID: targetPID)
+                                    }
+                                }
                             },
                             onLifecycleEvent: { [weak self] event in
                                 self?.markDictationLatency(
@@ -9330,6 +9380,7 @@ public final class MuesliController: NSObject {
                             }
                         )
                     } else {
+                        self.pendingSubmitAfterPaste = false
                         self.releaseStandardDictationState()
                         self.markDictationLatency("user_visible_completion", trace: completionLatencyTrace)
                         self.finishStandardDictationBookkeeping(
@@ -9350,6 +9401,7 @@ public final class MuesliController: NSObject {
             } catch is CancellationError {
                 fputs("[muesli-native] test dictation cancelled\n", stderr)
                 await MainActor.run {
+                    self.pendingSubmitAfterPaste = false
                     self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
                     self.setState(.idle)
@@ -9360,6 +9412,7 @@ public final class MuesliController: NSObject {
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
                 await MainActor.run {
+                    self.pendingSubmitAfterPaste = false
                     if self.isDictationTestMode {
                         self.dictationTestFailureCallback?(self.userFacingDictationTestError(error))
                     } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3863,7 +3863,7 @@ public final class MuesliController: NSObject {
             hotkeyMonitor.configure(keyCode: keyCode)
         }
         hotkeyMonitor.start(requestPermissionIfNeeded: requestPermissionIfNeeded)
-        startComputerUseHotkeyMonitorIfNeeded()
+        startComputerUseHotkeyMonitorIfNeeded(requestPermissionIfNeeded: requestPermissionIfNeeded)
     }
 
     func stopHotkeyMonitor() {
@@ -7340,7 +7340,7 @@ public final class MuesliController: NSObject {
         meetingRecordingHotkeyMonitor.configureTriggerThreshold(milliseconds: config.meetingRecordingHotkeyTriggerThresholdMS)
     }
 
-    private func startComputerUseHotkeyMonitorIfNeeded() {
+    private func startComputerUseHotkeyMonitorIfNeeded(requestPermissionIfNeeded: Bool = true) {
         guard config.enableComputerUseHotkey else {
             computerUseHotkeyMonitor.stop()
             return
@@ -7362,7 +7362,7 @@ public final class MuesliController: NSObject {
         }
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         computerUseHotkeyMonitor.configure(config.computerUseHotkey)
-        computerUseHotkeyMonitor.start()
+        computerUseHotkeyMonitor.start(requestPermissionIfNeeded: requestPermissionIfNeeded)
     }
 
     private func startMeetingRecordingHotkeyMonitorIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -637,6 +637,7 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        hotkeyMonitor.tapToToggleEnabled = config.dictationTriggerMode == .tapToToggle
         configureHotkeyMonitorTiming()
         computerUseHotkeyMonitor.onPrepare = { [weak self] in self?.handleComputerUsePrepare() }
         computerUseHotkeyMonitor.onStart = { [weak self] in self?.handleComputerUseStart() }
@@ -1537,6 +1538,7 @@ public final class MuesliController: NSObject {
         statusBarController?.refreshIcon()
         indicator.refreshIcon()
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        hotkeyMonitor.tapToToggleEnabled = config.dictationTriggerMode == .tapToToggle
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         if hotkeyTriggerThresholdChanged {
             configureHotkeyMonitorTiming()
@@ -8856,11 +8858,26 @@ public final class MuesliController: NSObject {
 
     @discardableResult
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) -> Bool {
-        if shouldRejectDictationForComputerUseActivity() { return false }
-        guard canBeginDictationInteraction else { return false }
-        guard ensureDictationBackendReady() else { return false }
-        if isMeetingRecording() { return false }
-        if blockDictationForMeetingActivityIfNeeded() { return false }
+        if shouldRejectDictationForComputerUseActivity() {
+            hotkeyMonitor.cancelToggleMode()
+            return false
+        }
+        guard canBeginDictationInteraction else {
+            hotkeyMonitor.cancelToggleMode()
+            return false
+        }
+        guard ensureDictationBackendReady() else {
+            hotkeyMonitor.cancelToggleMode()
+            return false
+        }
+        if isMeetingRecording() {
+            hotkeyMonitor.cancelToggleMode()
+            return false
+        }
+        if blockDictationForMeetingActivityIfNeeded() {
+            hotkeyMonitor.cancelToggleMode()
+            return false
+        }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "toggle")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -442,6 +442,10 @@ public final class MuesliController: NSObject {
     /// Set when Enter-to-submit is triggered during toggle dictation. After the
     /// transcript is pasted, a Return keypress is sent to the frontmost app.
     private var pendingSubmitAfterPaste: Bool = false
+    /// The PID of the app that was frontmost when Enter-to-submit was triggered.
+    /// The synthetic Return is gated on this so focus changes during transcription
+    /// don't send Enter to the wrong app.
+    private var pendingSubmitTargetPID: pid_t?
     private var pendingPreparingIndicatorWorkItem: DispatchWorkItem?
     private var activeComputerUseAudioSessionID: UUID?
     private var computerUseCommandStartedAt: Date?
@@ -642,6 +646,7 @@ public final class MuesliController: NSObject {
         hotkeyMonitor.onToggleStopAndSubmit = { [weak self] in self?.handleToggleStopAndSubmit() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         hotkeyMonitor.tapToToggleEnabled = config.dictationTriggerMode == .tapToToggle
+        hotkeyMonitor.submitOnEnterEnabled = config.enableSubmitOnEnter
         configureHotkeyMonitorTiming()
         computerUseHotkeyMonitor.onPrepare = { [weak self] in self?.handleComputerUsePrepare() }
         computerUseHotkeyMonitor.onStart = { [weak self] in self?.handleComputerUseStart() }
@@ -1447,7 +1452,16 @@ public final class MuesliController: NSObject {
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
         let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         let previousEnableLiveStreamingPartials = config.enableLiveStreamingPartials
+        let previousDictationTriggerMode = config.dictationTriggerMode
         mutate(&config)
+        if previousDictationTriggerMode != config.dictationTriggerMode {
+            // Switching trigger modes during an active toggle session leaves
+            // stale toggleActive state. Stop the toggle cleanly so the first
+            // hotkey press in the new mode starts fresh.
+            if hotkeyMonitor.isToggleRecording {
+                hotkeyMonitor.stopToggleMode()
+            }
+        }
         if previousEnableLiveStreamingPartials, !config.enableLiveStreamingPartials {
             preparingMeetingSession?.stopStreamingPartials()
             activeMeetingSession?.stopStreamingPartials()
@@ -1543,6 +1557,7 @@ public final class MuesliController: NSObject {
         indicator.refreshIcon()
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         hotkeyMonitor.tapToToggleEnabled = config.dictationTriggerMode == .tapToToggle
+        hotkeyMonitor.submitOnEnterEnabled = config.enableSubmitOnEnter
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         if hotkeyTriggerThresholdChanged {
             configureHotkeyMonitorTiming()
@@ -8947,6 +8962,7 @@ public final class MuesliController: NSObject {
         }
         fputs("[muesli-native] toggle dictation stop and submit\n", stderr)
         pendingSubmitAfterPaste = true
+        pendingSubmitTargetPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
         indicator.isToggleDictation = false
         handleStop()
     }
@@ -9160,10 +9176,11 @@ public final class MuesliController: NSObject {
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
         if pendingSubmitAfterPaste {
             pendingSubmitAfterPaste = false
-            if outputMode == .paste, !cleaned.isEmpty {
-                let targetPID = targetApp?.processID
+            let submitPID = pendingSubmitTargetPID
+            pendingSubmitTargetPID = nil
+            if outputMode == .paste, !cleaned.isEmpty, let submitPID {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    PasteController.simulateReturnKey(expectedTargetPID: targetPID)
+                    PasteController.simulateReturnKey(expectedTargetPID: submitPID)
                 }
             }
         }
@@ -9322,6 +9339,7 @@ public final class MuesliController: NSObject {
                 await MainActor.run {
                     if outputMode == .paste {
                         var completionTargetApp: DictationCorrectionTargetApp?
+                        var shouldSubmitAfterPaste = false
                         PasteController.paste(
                             text: text,
                             requireStagedClipboardOwnership: true,
@@ -9329,6 +9347,7 @@ public final class MuesliController: NSObject {
                                 guard let self else { return }
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)
                                 completionTargetApp = targetApp
+                                shouldSubmitAfterPaste = self.pendingSubmitAfterPaste
                                 self.pendingSubmitAfterPaste = false
                         self.releaseStandardDictationState()
                                 if self.config.enableDictionaryCorrectionPrompts {
@@ -9363,10 +9382,10 @@ public final class MuesliController: NSObject {
                                     "bookkeeping_completed",
                                     trace: completionLatencyTrace
                                 )
-                                if self.pendingSubmitAfterPaste {
-                                    self.pendingSubmitAfterPaste = false
+                                if shouldSubmitAfterPaste {
                                     guard pasteSucceeded else { return }
-                                    let targetPID = completionTargetApp?.processID
+                                    let targetPID = self.pendingSubmitTargetPID ?? completionTargetApp?.processID
+                                    self.pendingSubmitTargetPID = nil
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                         PasteController.simulateReturnKey(expectedTargetPID: targetPID)
                                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3858,11 +3858,11 @@ public final class MuesliController: NSObject {
         setState(.idle)
     }
 
-    func startHotkeyMonitor(keyCode: UInt16? = nil) {
+    func startHotkeyMonitor(keyCode: UInt16? = nil, requestPermissionIfNeeded: Bool = true) {
         if let keyCode {
             hotkeyMonitor.configure(keyCode: keyCode)
         }
-        hotkeyMonitor.start()
+        hotkeyMonitor.start(requestPermissionIfNeeded: requestPermissionIfNeeded)
         startComputerUseHotkeyMonitorIfNeeded()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1653,7 +1653,7 @@ struct OnboardingView: View {
             dictationTestError = nil
             controller.dictationTestBackend = selectedBackend
             controller.dictationTestCohereLanguage = selectedCohereLanguage
-            controller.startHotkeyMonitor(keyCode: selectedHotkey.keyCode)
+            controller.startHotkeyMonitor(keyCode: selectedHotkey.keyCode, requestPermissionIfNeeded: false)
             isDictationTestMonitorActive = true
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -63,7 +63,7 @@ enum PasteController {
         },
         simulatePasteAction: @escaping @MainActor () -> Bool = PasteController.simulatePaste,
         onPasteFinished: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in },
-        onClipboardSettled: @escaping @MainActor () -> Void = {},
+        onClipboardSettled: @escaping @MainActor (Bool) -> Void = { _ in },
         onLifecycleEvent: @escaping @MainActor (LifecycleEvent) -> Void = { _ in }
     ) {
         guard !text.isEmpty else { return }
@@ -92,13 +92,13 @@ enum PasteController {
                         onLifecycleEvent(.clipboardRestoreSkipped)
                     }
                     onPasteFinished(nil)
-                    onClipboardSettled()
+                    onClipboardSettled(false)
                     return
                 }
                 guard pasteboard.changeCount == pasteChangeCount else {
                     onLifecycleEvent(.clipboardOwnershipLost)
                     onPasteFinished(nil)
-                    onClipboardSettled()
+                    onClipboardSettled(false)
                     return
                 }
             }
@@ -116,7 +116,7 @@ enum PasteController {
                 } else {
                     onLifecycleEvent(.clipboardRestoreSkipped)
                 }
-                onClipboardSettled()
+                onClipboardSettled(didDispatchPaste)
             }
 
             onPasteFinished(didDispatchPaste ? targetApplication : nil)
@@ -146,6 +146,44 @@ enum PasteController {
     }
 
     // MARK: - Private
+
+    /// Simulate a Return (Enter) keypress in the frontmost app. Used to submit
+    /// the just-pasted prompt in apps like Cursor or Codex.
+    ///
+    /// If `expectedTargetPID` is provided, the Return is only posted when the
+    /// frontmost app at call time still matches that PID. This prevents the
+    /// Return from landing in a different app if the user Cmd-Tabbed away
+    /// during the paste → submit delay.
+    @MainActor
+    static func simulateReturnKey(
+        expectedTargetPID: pid_t? = nil,
+        frontmostApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
+            NSWorkspace.shared.frontmostApplication
+        }
+    ) -> Bool {
+        if let expectedPID = expectedTargetPID {
+            let frontmost = frontmostApplicationProvider()
+            guard frontmost?.processIdentifier == expectedPID else {
+                fputs("[muesli-native] skipping return key — frontmost app changed since paste\n", stderr)
+                return false
+            }
+        }
+
+        guard let source = CGEventSource(stateID: .combinedSessionState) else {
+            fputs("[muesli-native] failed to create event source for return key\n", stderr)
+            return false
+        }
+        let keyCode: CGKeyCode = 36 // Return
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        else {
+            fputs("[muesli-native] failed to create keyboard events for return key\n", stderr)
+            return false
+        }
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+        return true
+    }
 
     private static func simulatePaste() -> Bool {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -356,6 +356,30 @@ struct ShortcutsView: View {
                     .labelsHidden()
                 }
             }
+
+            if appState.config.dictationTriggerMode == .tapToToggle {
+                Divider()
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                        Text("Submit on Enter")
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                        Text("Press Enter to stop dictation and automatically submit the pasted text")
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { appState.config.enableSubmitOnEnter },
+                        set: { newValue in
+                            controller.updateConfig { $0.enableSubmitOnEnter = newValue }
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .tint(MuesliTheme.accent)
+                    .labelsHidden()
+                }
+            }
         }
         .padding(MuesliTheme.spacing16)
         .background(MuesliTheme.backgroundRaised)

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -314,25 +314,47 @@ struct ShortcutsView: View {
 
     private var doubleTapSection: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                    Text("Hands-Free Mode")
-                        .font(MuesliTheme.headline())
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("Double-tap dictation or CUA to start, tap again to stop")
-                        .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.textSecondary)
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("Dictation Trigger")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text("Choose how the hotkey starts and stops dictation")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+            Picker("", selection: Binding(
+                get: { appState.config.dictationTriggerMode },
+                set: { newValue in
+                    controller.updateConfig { $0.dictationTriggerMode = newValue }
                 }
-                Spacer()
-                Toggle("", isOn: Binding(
-                    get: { appState.config.enableDoubleTapDictation },
-                    set: { newValue in
-                        controller.updateConfig { $0.enableDoubleTapDictation = newValue }
+            )) {
+                ForEach(DictationTriggerMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if appState.config.dictationTriggerMode == .holdToRecord {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                        Text("Hands-Free Mode")
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                        Text("Double-tap dictation or CUA to start, tap again to stop")
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textSecondary)
                     }
-                ))
-                .toggleStyle(.switch)
-                .tint(MuesliTheme.accent)
-                .labelsHidden()
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { appState.config.enableDoubleTapDictation },
+                        set: { newValue in
+                            controller.updateConfig { $0.enableDoubleTapDictation = newValue }
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .tint(MuesliTheme.accent)
+                    .labelsHidden()
+                }
             }
         }
         .padding(MuesliTheme.spacing16)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -882,6 +882,7 @@ struct AppConfigTests {
         #expect(config.contributionLinkedInClicked == false)
         #expect(config.upcomingMeetingsDayCount == UpcomingMeetingsWindow.defaultDayCount)
         #expect(config.hiddenCalendarEventSourceHints.isEmpty)
+        #expect(config.dictationTriggerMode == .holdToRecord)
     }
 
     @Test("LM Studio cleanup readiness requires model and valid URL")
@@ -1079,6 +1080,7 @@ struct AppConfigTests {
             "ek-event-1": UnifiedCalendarEvent.CalendarSource.eventKit.rawValue,
             "google-event-1": UnifiedCalendarEvent.CalendarSource.googleCalendar.rawValue,
         ]
+        config.dictationTriggerMode = .tapToToggle
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -1153,6 +1155,7 @@ struct AppConfigTests {
         #expect(decoded.contributionLinkedInClicked == false)
         #expect(decoded.upcomingMeetingsDayCount == UpcomingMeetingsWindow.today.dayCount)
         #expect(decoded.hiddenCalendarEventSourceHints == config.hiddenCalendarEventSourceHints)
+        #expect(decoded.dictationTriggerMode == .tapToToggle)
     }
 
     @Test("Automatic diagnostic issue prompts default off when absent")
@@ -2184,9 +2187,89 @@ struct HotkeyMonitorTests {
 
         #expect(toggleStartCount == 0)
     }
-}
 
-@Suite("MeetingResummarizationPolicy")
+    // MARK: - Tap-to-Toggle
+
+    @Test("tap-to-toggle starts on first key-down")
+    @MainActor
+    func tapToToggleStartsOnFirstKeyDown() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStartCount == 1)
+        #expect(monitor.isToggleRecording)
+    }
+
+    @Test("tap-to-toggle stops on next key-down")
+    @MainActor
+    func tapToToggleStopsOnNextKeyDown() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStopCount = 0
+        monitor.onToggleStart = {}
+        monitor.onToggleStop = {
+            toggleStopCount += 1
+        }
+
+        // Start toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(monitor.isToggleRecording)
+
+        // Key-up is a no-op in toggle mode
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(monitor.isToggleRecording)
+
+        // Next key-down stops toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+    }
+
+    @Test("tap-to-toggle ignores double-tap detection")
+    @MainActor
+    func tapToToggleIgnoresDoubleTapDetection() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        var toggleStopCount = 0
+        monitor.onToggleStart = { toggleStartCount += 1 }
+        monitor.onToggleStop = { toggleStopCount += 1 }
+
+        // First tap starts toggle immediately — no double-tap needed
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
+
+        // Second tap stops — not starts a new toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStopCount == 1)
+        #expect(toggleStartCount == 1)
+    }
+
+    @Test("tap-to-toggle cancels on other modifier key")
+    @MainActor
+    func tapToToggleCancelsOnOtherModifier() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var cancelCount = 0
+        monitor.onToggleStart = {}
+        monitor.onCancel = { cancelCount += 1 }
+
+        // Start toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(monitor.isToggleRecording)
+
+        // Another modifier key cancels toggle
+        monitor.handleFlagsChanged(keyCode: 56, flags: .shift)
+        #expect(cancelCount == 1)
+        #expect(!monitor.isToggleRecording)
+    }
+}
 struct MeetingResummarizationPolicyTests {
 
     @Test("resummarize preserves the existing meeting title")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -2292,8 +2292,35 @@ struct HotkeyMonitorTests {
         #expect(cancelCount == 0)
         #expect(monitor.isToggleRecording)
     }
+
+    @Test("tap-to-toggle stop press does not re-start toggle on key-up")
+    @MainActor
+    func tapToToggleStopPressDoesNotRestartOnKeyUp() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        var toggleStopCount = 0
+        monitor.onToggleStart = { toggleStartCount += 1 }
+        monitor.onToggleStop = { toggleStopCount += 1 }
+
+        // Start toggle (down + up)
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
+        #expect(monitor.isToggleRecording)
+
+        // Key-down stops the toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+
+        // Key-up must NOT re-start the toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
+        #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+    }
 }
-struct MeetingResummarizationPolicyTests {
 
     @Test("resummarize preserves the existing meeting title")
     func preservesExistingMeetingTitle() {

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -883,6 +883,7 @@ struct AppConfigTests {
         #expect(config.upcomingMeetingsDayCount == UpcomingMeetingsWindow.defaultDayCount)
         #expect(config.hiddenCalendarEventSourceHints.isEmpty)
         #expect(config.dictationTriggerMode == .holdToRecord)
+        #expect(config.enableSubmitOnEnter == false)
     }
 
     @Test("LM Studio cleanup readiness requires model and valid URL")
@@ -1081,6 +1082,7 @@ struct AppConfigTests {
             "google-event-1": UnifiedCalendarEvent.CalendarSource.googleCalendar.rawValue,
         ]
         config.dictationTriggerMode = .tapToToggle
+        config.enableSubmitOnEnter = true
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -1156,6 +1158,7 @@ struct AppConfigTests {
         #expect(decoded.upcomingMeetingsDayCount == UpcomingMeetingsWindow.today.dayCount)
         #expect(decoded.hiddenCalendarEventSourceHints == config.hiddenCalendarEventSourceHints)
         #expect(decoded.dictationTriggerMode == .tapToToggle)
+        #expect(decoded.enableSubmitOnEnter == true)
     }
 
     @Test("Automatic diagnostic issue prompts default off when absent")
@@ -2318,6 +2321,73 @@ struct HotkeyMonitorTests {
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(toggleStartCount == 1)
         #expect(toggleStopCount == 1)
+        #expect(!monitor.isToggleRecording)
+    }
+
+    // MARK: - Submit on Enter
+
+    @Test("Enter during toggle fires stop-and-submit callback")
+    @MainActor
+    func enterDuringToggleFiresStopAndSubmit() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        monitor.submitOnEnterEnabled = true
+        var toggleStartCount = 0
+        var toggleStopCount = 0
+        var submitCount = 0
+        monitor.onToggleStart = { toggleStartCount += 1 }
+        monitor.onToggleStop = { toggleStopCount += 1 }
+        monitor.onToggleStopAndSubmit = { submitCount += 1 }
+
+        // Start toggle (down + up — tap-to-toggle fires on release)
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 1)
+        #expect(monitor.isToggleRecording)
+
+        // Press Enter → should fire submit, not plain stop
+        let consumed = monitor.handleKeyDown(keyCode: 36)
+        #expect(consumed == true)
+        #expect(submitCount == 1)
+        #expect(toggleStopCount == 0)
+        #expect(!monitor.isToggleRecording)
+    }
+
+    @Test("Enter does nothing when toggle is not active")
+    @MainActor
+    func enterDoesNothingWhenToggleNotActive() {
+        let monitor = HotkeyMonitor()
+        monitor.submitOnEnterEnabled = true
+        var submitCount = 0
+        monitor.onToggleStopAndSubmit = { submitCount += 1 }
+
+        let consumed = monitor.handleKeyDown(keyCode: 36)
+        #expect(consumed == false)
+        #expect(submitCount == 0)
+    }
+
+    @Test("Escape still cancels toggle without firing submit")
+    @MainActor
+    func escapeCancelsToggleWithoutFiringSubmit() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        monitor.submitOnEnterEnabled = true
+        var submitCount = 0
+        var cancelCount = 0
+        monitor.onToggleStart = {}
+        monitor.onToggleStopAndSubmit = { submitCount += 1 }
+        monitor.onCancel = { cancelCount += 1 }
+
+        // Start toggle (down + up)
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(monitor.isToggleRecording)
+
+        // Escape → cancel, not submit
+        let consumed = monitor.handleKeyDown(keyCode: 53)
+        #expect(consumed == true)
+        #expect(cancelCount == 1)
+        #expect(submitCount == 0)
         #expect(!monitor.isToggleRecording)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1893,61 +1893,30 @@ struct HotkeyMonitorTests {
         #expect(cancelCount == 1)
     }
 
-    @Test("local monitor skips fresh hotkey starts while editing text")
+    @Test("CGEventTap consumes Escape during active hold recording")
     @MainActor
-    func localMonitorSkipsFreshHotkeyStartsWhileEditingText() async throws {
+    func cgeventtapConsumesEscapeDuringActiveHold() async throws {
         let monitor = HotkeyMonitor()
-        let textView = NSTextView()
-
-        #expect(
-            monitor.shouldHandleLocalEventForTests(
-                type: .flagsChanged,
-                keyCode: 55,
-                firstResponder: textView
-            ) == false
-        )
-    }
-
-    @Test("local monitor preserves key-up cleanup after hotkey session is armed")
-    @MainActor
-    func localMonitorPreservesKeyUpCleanupAfterHotkeySessionIsArmed() async throws {
-        let monitor = HotkeyMonitor()
-        let textView = NSTextView()
-        var stopCount = 0
-        monitor.onStop = {
-            stopCount += 1
+        var cancelCount = 0
+        monitor.onCancel = {
+            cancelCount += 1
         }
 
         monitor.setHoldRecordingActiveForTests()
+        let consumed = monitor.handleKeyDown(keyCode: 53)
 
-        #expect(
-            monitor.shouldHandleLocalEventForTests(
-                type: .flagsChanged,
-                keyCode: 55,
-                firstResponder: textView
-            ) == true
-        )
-
-        monitor.handleFlagsChanged(keyCode: 55, flags: [])
-
-        #expect(stopCount == 1)
+        #expect(consumed == true)
+        #expect(cancelCount == 1)
     }
 
-    @Test("local monitor still lets escape cancel active hold dictation while editing text")
+    @Test("CGEventTap does not consume keys when idle")
     @MainActor
-    func localMonitorLetsEscapeCancelActiveHoldDictationWhileEditingText() async throws {
+    func cgeventtapDoesNotConsumeWhenIdle() async throws {
         let monitor = HotkeyMonitor()
-        let textView = NSTextView()
 
-        monitor.setHoldRecordingActiveForTests()
-
-        #expect(
-            monitor.shouldHandleLocalEventForTests(
-                type: .keyDown,
-                keyCode: 53,
-                firstResponder: textView
-            ) == true
-        )
+        // When idle, Escape should not be consumed
+        let consumed = monitor.handleKeyDown(keyCode: 53)
+        #expect(consumed == false)
     }
 
     @Test("trigger threshold derives prepare and start delays")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -2190,9 +2190,9 @@ struct HotkeyMonitorTests {
 
     // MARK: - Tap-to-Toggle
 
-    @Test("tap-to-toggle starts on first key-down")
+    @Test("tap-to-toggle starts on key-up, not key-down")
     @MainActor
-    func tapToToggleStartsOnFirstKeyDown() {
+    func tapToToggleStartsOnKeyUp() {
         let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
         monitor.tapToToggleEnabled = true
         var toggleStartCount = 0
@@ -2200,9 +2200,33 @@ struct HotkeyMonitorTests {
             toggleStartCount += 1
         }
 
+        // Key-down arms but does not fire — phantom-press filter
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(toggleStartCount == 0)
+        #expect(!monitor.isToggleRecording)
+
+        // Key-up with no intervening keys fires the toggle
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(toggleStartCount == 1)
         #expect(monitor.isToggleRecording)
+    }
+
+    @Test("tap-to-toggle does not fire when another key is pressed during the hold")
+    @MainActor
+    func tapToToggleFiltersKeyboardShortcuts() {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.tapToToggleEnabled = true
+        var toggleStartCount = 0
+        monitor.onToggleStart = { toggleStartCount += 1 }
+
+        // Cmd down
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        // Another key pressed (e.g. Cmd+C) — sets otherKeyPressed
+        monitor.handleKeyDown(keyCode: 8) // 'C' key
+        // Cmd up — should NOT toggle because another key was pressed
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(toggleStartCount == 0)
+        #expect(!monitor.isToggleRecording)
     }
 
     @Test("tap-to-toggle stops on next key-down")
@@ -2216,11 +2240,8 @@ struct HotkeyMonitorTests {
             toggleStopCount += 1
         }
 
-        // Start toggle
+        // Start toggle (down + up)
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
-        #expect(monitor.isToggleRecording)
-
-        // Key-up is a no-op in toggle mode
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(monitor.isToggleRecording)
 
@@ -2240,7 +2261,7 @@ struct HotkeyMonitorTests {
         monitor.onToggleStart = { toggleStartCount += 1 }
         monitor.onToggleStop = { toggleStopCount += 1 }
 
-        // First tap starts toggle immediately — no double-tap needed
+        // First tap (down + up) starts toggle — no double-tap needed
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(toggleStartCount == 1)
@@ -2251,23 +2272,25 @@ struct HotkeyMonitorTests {
         #expect(toggleStartCount == 1)
     }
 
-    @Test("tap-to-toggle cancels on other modifier key")
+    @Test("tap-to-toggle does not cancel on other modifier key during active toggle")
     @MainActor
-    func tapToToggleCancelsOnOtherModifier() {
+    func tapToToggleIgnoresOtherModifierDuringToggle() {
         let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
         monitor.tapToToggleEnabled = true
         var cancelCount = 0
         monitor.onToggleStart = {}
         monitor.onCancel = { cancelCount += 1 }
 
-        // Start toggle
+        // Start toggle (down + up)
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(monitor.isToggleRecording)
 
-        // Another modifier key cancels toggle
+        // Another modifier key during active toggle should NOT cancel
+        // (tap-to-toggle mode only stops on the target key or Escape)
         monitor.handleFlagsChanged(keyCode: 56, flags: .shift)
-        #expect(cancelCount == 1)
-        #expect(!monitor.isToggleRecording)
+        #expect(cancelCount == 0)
+        #expect(monitor.isToggleRecording)
     }
 }
 struct MeetingResummarizationPolicyTests {

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -137,7 +137,7 @@ struct PasteControllerTests {
                 onPasteFinished: { _ in
                     events.append("completion_bookkeeping")
                 },
-                onClipboardSettled: {
+                onClipboardSettled: { _ in
                     events.append("clipboard_settled")
                     continuation.resume(returning: events)
                 },
@@ -328,6 +328,98 @@ struct PasteControllerTests {
         try await Task.sleep(nanoseconds: 700_000_000)
 
         #expect(pasteboard.string(forType: .string) == "user-copied-after-paste")
+    }
+
+    // MARK: - simulateReturnKey target verification
+
+    @Test("simulateReturnKey without target PID posts unconditionally")
+    func returnKeyWithoutTargetPIDPostsUnconditionally() {
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: nil,
+            frontmostApplicationProvider: { NSRunningApplication.current }
+        )
+        #expect(result == true)
+    }
+
+    @Test("simulateReturnKey posts when frontmost matches expected PID")
+    func returnKeyPostsWhenFrontmostMatches() {
+        let targetApp = NSRunningApplication.current
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: targetApp.processIdentifier,
+            frontmostApplicationProvider: { targetApp }
+        )
+        #expect(result == true)
+    }
+
+    @Test("simulateReturnKey skips when frontmost app changed since paste")
+    func returnKeySkipsWhenFrontmostChanged() {
+        let originalApp = NSRunningApplication.current
+        let differentPID: pid_t = 99999
+        guard originalApp.processIdentifier != differentPID else { return }
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: differentPID,
+            frontmostApplicationProvider: { originalApp }
+        )
+        #expect(result == false)
+    }
+
+    @Test("simulateReturnKey skips when frontmost app is nil")
+    func returnKeySkipsWhenFrontmostIsNil() {
+        let result = PasteController.simulateReturnKey(
+            expectedTargetPID: 12345,
+            frontmostApplicationProvider: { nil }
+        )
+        #expect(result == false)
+    }
+
+    // MARK: - onClipboardSettled paste success propagation
+
+    @Test("onClipboardSettled reports false when clipboard ownership is lost")
+    func clipboardSettledReportsFalseOnOwnershipLoss() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let pasteSucceeded = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                requireStagedClipboardOwnership: true,
+                targetApplicationProvider: {
+                    pasteboard.clearContents()
+                    pasteboard.setString("user-copied-during-delay", forType: .string)
+                    return NSRunningApplication.current
+                },
+                simulatePasteAction: { true },
+                onClipboardSettled: { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            )
+        }
+
+        #expect(pasteSucceeded == false)
+    }
+
+    @Test("onClipboardSettled reports true after successful paste dispatch")
+    func clipboardSettledReportsTrueOnSuccess() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let pasteSucceeded = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                requireStagedClipboardOwnership: true,
+                targetApplicationProvider: { NSRunningApplication.current },
+                simulatePasteAction: { true },
+                onClipboardSettled: { succeeded in
+                    continuation.resume(returning: succeeded)
+                }
+            )
+        }
+
+        #expect(pasteSucceeded == true)
     }
 
     private func makePasteboard() -> NSPasteboard {


### PR DESCRIPTION
## Summary

When enabled, pressing Enter during toggle dictation stops recording, waits for transcription and paste to complete, then simulates a Return keypress to submit the pasted text in apps like Cursor or Codex.

Built on the CGEventTap foundation (#474), the physical Enter key is **consumed by the event tap** — it never reaches the target app. Only the synthetic Return after paste is delivered, eliminating the double-submission issue that affected the previous NSEvent-based implementation.

## Defense-in-depth

Even though the physical Enter is now consumed, several safety measures remain:

- **PID verification**: synthetic Return only fires if the frontmost app still matches the one that received the paste (user could Cmd-Tab during the paste delay)
- **pasteSucceeded gating**: Return is skipped if clipboard staging failed or ownership was lost (no text was actually pasted)
- **pendingSubmitAfterPaste** cleared on every terminal path: cancel, no-WAV, short-recording, empty-text, test-mode, error, non-paste output, voice-note output
- **outputMode == .paste** gating on Nemotron streaming path

## Changes

- `AppConfig.enableSubmitOnEnter` persisted as `enable_submit_on_enter`
- `HotkeyMonitor.onToggleStopAndSubmit` callback; Enter (keyCode 36) consumed during toggle in both standard and combination modes
- `PasteController.simulateReturnKey` with `expectedTargetPID` and injectable `frontmostApplicationProvider`
- `PasteController.onClipboardSettled` now propagates `Bool` (pasteSucceeded)
- `MuesliController.handleToggleStopAndSubmit` arms `pendingSubmitAfterPaste`
- ShortcutsView: toggle visible only when tap-to-toggle is selected
- 3 enter-to-submit hotkey tests + 4 simulateReturnKey tests + 2 pasteSucceeded propagation tests + config round-trip tests

## Validation

- `swift build --package-path native/MuesliNative` — passes
- `swift test --filter HotkeyMonitorTests` — 23 tests pass
- `swift test --filter PasteControllerTests` — 23 tests pass

## Depends on

- #474 (CGEventTap foundation)
- #475 (tap-to-toggle)

## Contribution Certification

- [x] I certify that I have the right to submit this contribution and that it does not violate any existing licenses or agreements.
- [x] I have reviewed the contribution guidelines and followed the coding standards.
- [x] This contribution does not include any third-party materials.

🪷 Generated with Sarvam Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790254852&installation_model_id=422865&pr_number=476&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F476&signature=ab44dafff67223bacfa79847fb50f6e10c506979a74cf503e786d94d32d969c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose between hold-to-record and tap-to-toggle dictation.
  * Optionally submit tap-to-toggle dictation with Enter.
  * Return completed transcriptions to the active app automatically.
  * Settings are saved and restored between sessions.

* **Bug Fixes**
  * Escape now reliably cancels active dictation.
  * Prevented unintended submissions when the active app changes during paste.
  * Improved shortcut monitoring and accessibility permission handling.

* **Tests**
  * Added coverage for trigger modes, submission behavior, shortcut handling, and paste outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->