### PR TITLE
Add R2-backed model download fallback

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/HuggingFaceModelManifestResolver.swift
+++ b/native/MuesliNative/Sources/MuesliCore/HuggingFaceModelManifestResolver.swift
@@ -183,6 +183,10 @@ public final class HuggingFaceModelManifestResolver: @unchecked Sendable {
                     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
                 }
                 let result = try await session.data(for: request)
+                // URLSession can complete successfully in the narrow window
+                // after its parent task is cancelled. Do not turn that late
+                // discovery response into a new file transfer.
+                try Task.checkCancellation()
                 if let http = result.1 as? HTTPURLResponse,
                    (http.statusCode == 429 || (500..<600).contains(http.statusCode)),
                    attempt < 2 {

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -235,6 +235,9 @@ public enum ManagedASRModelPlans {
             repository: "FluidInference/parakeet-tdt-0.6b-v3-coreml",
             directoryName: "parakeet-tdt-0.6b-v3",
             required: required,
+            mirror: muesliMirror(
+                "models/fluidaudio/parakeet-tdt-0.6b-v3/legacy-local-v1/manifest.json"
+            ),
             modelsRoot: modelsRoot
         )
     }
@@ -254,6 +257,9 @@ public enum ManagedASRModelPlans {
             repository: "FluidInference/parakeet-unified-en-0.6b-coreml",
             directoryName: "parakeet-unified-en-0.6b-coreml",
             required: required,
+            mirror: muesliMirror(
+                "models/fluidaudio/parakeet-unified-en-0.6b/legacy-local-v1/manifest.json"
+            ),
             modelsRoot: modelsRoot
         )
     }
@@ -342,8 +348,29 @@ public enum ManagedASRModelPlans {
                 remoteDirectory: fullName,
                 includedPaths: Set(requiredFiles)
             )],
-            requiredArtifactAlternatives: completenessRequirements(for: requiredFiles)
+            requiredArtifactAlternatives: completenessRequirements(for: requiredFiles),
+            mirror: whisperKitMirror(fullName: fullName)
         )
+    }
+
+    private static func muesliMirror(_ path: String) -> MuesliModelMirror {
+        MuesliModelMirror(manifestURL: URL(string: "https://assets.muesli.works/\(path)")!)
+    }
+
+    /// Only variants that Muesli has copied and checksum-pinned in R2 are
+    /// eligible for the first-party transport. Unknown WhisperKit paths keep
+    /// using the normal Hugging Face discovery flow.
+    private static func whisperKitMirror(fullName: String) -> MuesliModelMirror? {
+        let mirroredVariants: Set<String> = [
+            "openai_whisper-tiny",
+            "openai_whisper-tiny.en",
+            "openai_whisper-small",
+            "openai_whisper-small.en",
+            "openai_whisper-medium.en",
+            "openai_whisper-large-v3-v20240930_626MB",
+        ]
+        guard mirroredVariants.contains(fullName) else { return nil }
+        return muesliMirror("models/whisperkit/\(fullName)/legacy-local-v1/manifest.json")
     }
 
     private static func fluidAudioPlan(

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -551,7 +551,7 @@ public enum ManagedASRModelDownloader {
             }
         }
 
-        var mirrorDownloadWasAttempted = false
+        var failedMirrorManifest: ModelDownloadManifest?
         if let mirror = plan.mirror {
             do {
                 report("Checking Muesli model mirror...")
@@ -560,16 +560,29 @@ public enum ManagedASRModelDownloader {
                     mirror: mirror,
                     maximumConcurrency: plan.maximumConcurrency
                 )
-                mirrorDownloadWasAttempted = true
+                // Preserve the exact mirror manifest until this transfer has
+                // succeeded. If the mirror fails partway through, it is the
+                // only complete record of files that may need removing before
+                // a Hugging Face fallback begins.
+                failedMirrorManifest = manifest
                 try await download(manifest)
                 try plan.recordSuccessfulInstallation(manifest)
                 guard plan.isComplete() else {
                     throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
                 }
                 return plan.cacheDirectory
-            } catch is CancellationError {
-                throw CancellationError()
             } catch {
+                if isCancellation(error) { throw CancellationError() }
+                if let failedMirrorManifest {
+                    // Never resume a mirror's partial bytes against a Hugging
+                    // Face revision. The mirror manifest includes files that
+                    // may not exist in the fallback manifest, so clean it
+                    // before resolving Hugging Face.
+                    try? await coordinator.removeDownload(
+                        failedMirrorManifest,
+                        at: plan.cacheDirectory
+                    )
+                }
                 report("Muesli mirror unavailable; trying Hugging Face...")
             }
         } else {
@@ -583,17 +596,18 @@ public enum ManagedASRModelDownloader {
             selections: plan.selections,
             maximumConcurrency: plan.maximumConcurrency
         )
-        if mirrorDownloadWasAttempted {
-            // Do not resume bytes from a failed mirror against a mutable Hugging Face
-            // revision. A fresh fallback avoids mixing two independently served files.
-            try? await coordinator.removeDownload(manifest, at: plan.cacheDirectory)
-        }
         try await download(manifest)
         try plan.recordSuccessfulInstallation(manifest)
         guard plan.isComplete() else {
             throw HuggingFaceModelManifestError.emptySelection(plan.repository)
         }
         return plan.cacheDirectory
+    }
+
+    private static func isCancellation(_ error: Error) -> Bool {
+        Task.isCancelled
+            || error is CancellationError
+            || (error as? URLError)?.code == .cancelled
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -23,6 +23,8 @@ public struct ManagedASRModelPlan: Sendable {
     public let revision: String
     public let cacheDirectory: URL
     public let selections: [HuggingFaceModelSelection]
+    /// Optional immutable Muesli mirror used before Hugging Face discovery.
+    public let mirror: MuesliModelMirror?
     /// Every inner group is an either/or requirement; every group must be satisfied.
     public let requiredArtifactAlternatives: [[String]]
     public let maximumConcurrency: Int
@@ -34,6 +36,7 @@ public struct ManagedASRModelPlan: Sendable {
         cacheDirectory: URL,
         selections: [HuggingFaceModelSelection],
         requiredArtifactAlternatives: [[String]],
+        mirror: MuesliModelMirror? = nil,
         maximumConcurrency: Int = 2
     ) {
         self.modelID = modelID
@@ -42,6 +45,7 @@ public struct ManagedASRModelPlan: Sendable {
         self.cacheDirectory = cacheDirectory
         self.selections = selections
         self.requiredArtifactAlternatives = requiredArtifactAlternatives
+        self.mirror = mirror
         self.maximumConcurrency = maximumConcurrency
     }
 
@@ -216,6 +220,7 @@ public enum ManagedASRModelPlans {
             repository: "FluidInference/parakeet-tdt-0.6b-v2-coreml",
             directoryName: "parakeet-tdt-0.6b-v2",
             required: required,
+            mirror: MuesliModelMirror(manifestURL: URL(string: "https://assets.muesli.works/models/fluidaudio/parakeet-tdt-0.6b-v2/legacy-local-v1/manifest.json")!),
             modelsRoot: modelsRoot
         )
     }
@@ -346,6 +351,7 @@ public enum ManagedASRModelPlans {
         repository: String,
         directoryName: String,
         required: [String],
+        mirror: MuesliModelMirror? = nil,
         modelsRoot: URL?
     ) -> ManagedASRModelPlan {
         let directory = (modelsRoot ?? fluidAudioModelsRoot())
@@ -355,7 +361,8 @@ public enum ManagedASRModelPlans {
             repository: repository,
             cacheDirectory: directory,
             selections: [HuggingFaceModelSelection(includedPaths: Set(required))],
-            requiredArtifactAlternatives: completenessRequirements(for: required)
+            requiredArtifactAlternatives: completenessRequirements(for: required),
+            mirror: mirror
         )
     }
 
@@ -382,6 +389,7 @@ public enum ManagedASRModelDownloader {
         progress: ((Double, String?) -> Void)? = nil,
         progressSnapshot: ModelDownloadProgressHandler? = nil,
         resolver: HuggingFaceModelManifestResolver = .shared,
+        mirrorResolver: MuesliModelMirrorManifestResolver = .shared,
         coordinator: ModelDownloadCoordinator = .shared
     ) async throws -> URL {
         try await operations.run(modelID: plan.modelID) {
@@ -392,6 +400,7 @@ public enum ManagedASRModelDownloader {
                 progress: progress,
                 progressSnapshot: progressSnapshot,
                 resolver: resolver,
+                mirrorResolver: mirrorResolver,
                 coordinator: coordinator
             )
         }
@@ -406,6 +415,7 @@ public enum ManagedASRModelDownloader {
         progress: ((Double, String?) -> Void)? = nil,
         progressSnapshot: ModelDownloadProgressHandler? = nil,
         resolver: HuggingFaceModelManifestResolver = .shared,
+        mirrorResolver: MuesliModelMirrorManifestResolver = .shared,
         coordinator: ModelDownloadCoordinator = .shared,
         load: (URL) async throws -> T
     ) async throws -> T {
@@ -415,6 +425,7 @@ public enum ManagedASRModelDownloader {
             progress: progress,
             progressSnapshot: progressSnapshot,
             resolver: resolver,
+            mirrorResolver: mirrorResolver,
             coordinator: coordinator
         )
 
@@ -446,6 +457,7 @@ public enum ManagedASRModelDownloader {
                 progress: progress,
                 progressSnapshot: progressSnapshot,
                 resolver: resolver,
+                mirrorResolver: mirrorResolver,
                 coordinator: coordinator
             )
             return try await load(repairedDirectory)
@@ -490,16 +502,53 @@ public enum ManagedASRModelDownloader {
         progress: ((Double, String?) -> Void)?,
         progressSnapshot: ModelDownloadProgressHandler?,
         resolver: HuggingFaceModelManifestResolver,
+        mirrorResolver: MuesliModelMirrorManifestResolver,
         coordinator: ModelDownloadCoordinator
     ) async throws -> URL {
         try Task.checkCancellation()
 
         let scalarProgress = ManagedASRScalarProgressRelay(progress)
-        scalarProgress.call(0.01, "Finding model files...")
-        progressSnapshot?(ModelDownloadProgress.preparing(
-            modelID: plan.modelID,
-            message: "Finding model files..."
-        ))
+        func report(_ message: String) {
+            scalarProgress.call(0.01, message)
+            progressSnapshot?(ModelDownloadProgress.preparing(
+                modelID: plan.modelID,
+                message: message
+            ))
+        }
+        func download(_ manifest: ModelDownloadManifest) async throws {
+            try await coordinator.download(manifest, to: plan.cacheDirectory) { snapshot in
+                if let fraction = snapshot.fractionCompleted {
+                    scalarProgress.call(fraction, snapshot.message)
+                }
+                progressSnapshot?(snapshot)
+            }
+        }
+
+        var mirrorDownloadWasAttempted = false
+        if let mirror = plan.mirror {
+            do {
+                report("Checking Muesli model mirror...")
+                let manifest = try await mirrorResolver.resolve(
+                    modelID: plan.modelID,
+                    mirror: mirror,
+                    maximumConcurrency: plan.maximumConcurrency
+                )
+                mirrorDownloadWasAttempted = true
+                try await download(manifest)
+                try plan.recordSuccessfulInstallation(manifest)
+                guard plan.isComplete() else {
+                    throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
+                }
+                return plan.cacheDirectory
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                report("Muesli mirror unavailable; trying Hugging Face...")
+            }
+        } else {
+            report("Finding model files...")
+        }
+
         let manifest = try await resolver.resolve(
             modelID: plan.modelID,
             repository: plan.repository,
@@ -507,12 +556,12 @@ public enum ManagedASRModelDownloader {
             selections: plan.selections,
             maximumConcurrency: plan.maximumConcurrency
         )
-        try await coordinator.download(manifest, to: plan.cacheDirectory) { snapshot in
-            if let fraction = snapshot.fractionCompleted {
-                scalarProgress.call(fraction, snapshot.message)
-            }
-            progressSnapshot?(snapshot)
+        if mirrorDownloadWasAttempted {
+            // Do not resume bytes from a failed mirror against a mutable Hugging Face
+            // revision. A fresh fallback avoids mixing two independently served files.
+            try? await coordinator.removeDownload(manifest, at: plan.cacheDirectory)
         }
+        try await download(manifest)
         try plan.recordSuccessfulInstallation(manifest)
         guard plan.isComplete() else {
             throw HuggingFaceModelManifestError.emptySelection(plan.repository)

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -577,8 +577,9 @@ public enum ManagedASRModelDownloader {
                     // Never resume a mirror's partial bytes against a Hugging
                     // Face revision. The mirror manifest includes files that
                     // may not exist in the fallback manifest, so clean it
-                    // before resolving Hugging Face.
-                    try? await coordinator.removeDownload(
+                    // before resolving Hugging Face. If cleanup cannot
+                    // complete, fail closed rather than mixing revisions.
+                    try await coordinator.removeDownload(
                         failedMirrorManifest,
                         at: plan.cacheDirectory
                     )

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -659,6 +659,7 @@ private actor ManagedASRModelOperations {
     // A model's mirror and fallback state transitions share one cache
     // directory, so callers for the same model must share one operation.
     private var operations: [String: Operation] = [:]
+    private var completionWaiters: [UUID: [UUID: CheckedContinuation<URL, Error>]] = [:]
     private var deletionTokens: [String: UUID] = [:]
 
     func run(
@@ -667,22 +668,23 @@ private actor ManagedASRModelOperations {
     ) async throws -> URL {
         guard deletionTokens[modelID] == nil else { throw CancellationError() }
         if let active = operations[modelID] {
-            return try await active.task.value
+            return try await waitForCompletion(of: active)
         }
 
         let id = UUID()
         let task = Task { try await operation() }
-        operations[modelID] = Operation(id: id, task: task)
-        defer {
-            if operations[modelID]?.id == id {
-                operations[modelID] = nil
+        let active = Operation(id: id, task: task)
+        operations[modelID] = active
+        Task { [weak self] in
+            let result: Result<URL, Error>
+            do {
+                result = .success(try await task.value)
+            } catch {
+                result = .failure(error)
             }
+            await self?.finish(modelID: modelID, operationID: id, result: result)
         }
-        return try await withTaskCancellationHandler {
-            try await task.value
-        } onCancel: {
-            task.cancel()
-        }
+        return try await waitForCompletion(of: active)
     }
 
     func cancel(modelID: String) {
@@ -705,6 +707,46 @@ private actor ManagedASRModelOperations {
     func endDeletion(_ token: ManagedASRModelDeletionToken) {
         guard deletionTokens[token.modelID] == token.id else { return }
         deletionTokens[token.modelID] = nil
+    }
+
+    /// Each caller waits independently. Cancelling a caller therefore detaches
+    /// it from the shared model operation; only explicit model cancellation
+    /// above stops the transfer for every caller.
+    private func waitForCompletion(of operation: Operation) async throws -> URL {
+        let callerID = UUID()
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    completionWaiters[operation.id, default: [:]][callerID] = continuation
+                }
+            }
+        }, onCancel: {
+            Task { await self.cancelWaiter(callerID, for: operation.id) }
+        })
+    }
+
+    private func cancelWaiter(_ callerID: UUID, for operationID: UUID) {
+        guard let continuation = completionWaiters[operationID]?[callerID] else { return }
+        completionWaiters[operationID]?[callerID] = nil
+        if completionWaiters[operationID]?.isEmpty == true {
+            completionWaiters[operationID] = nil
+        }
+        continuation.resume(throwing: CancellationError())
+    }
+
+    private func finish(
+        modelID: String,
+        operationID: UUID,
+        result: Result<URL, Error>
+    ) {
+        guard operations[modelID]?.id == operationID else { return }
+        operations[modelID] = nil
+        let waiters = completionWaiters.removeValue(forKey: operationID) ?? [:]
+        for continuation in waiters.values {
+            continuation.resume(with: result)
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -694,7 +694,19 @@ private actor ManagedASRModelOperations {
     func cancelAndWait(modelID: String) async {
         guard let active = operations[modelID] else { return }
         active.task.cancel()
-        _ = try? await active.task.value
+        let result: Result<URL, Error>
+        do {
+            result = .success(try await active.task.value)
+        } catch {
+            result = .failure(error)
+        }
+
+        // The detached completion observer also calls `finish`, but a caller
+        // that awaits cancellation must not return while this cancelled
+        // operation is still eligible for a new caller to join. The operation
+        // ID guard in `finish` makes this safe if the observer already ran or
+        // a newer operation has since replaced it.
+        finish(modelID: modelID, operationID: active.id, result: result)
     }
 
     func beginDeletion(modelID: String) async -> ManagedASRModelDeletionToken {

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -551,7 +551,7 @@ public enum ManagedASRModelDownloader {
             }
         }
 
-        var failedMirrorManifest: ModelDownloadManifest?
+        var mirrorTransferStarted = false
         if let mirror = plan.mirror {
             do {
                 report("Checking Muesli model mirror...")
@@ -560,11 +560,9 @@ public enum ManagedASRModelDownloader {
                     mirror: mirror,
                     maximumConcurrency: plan.maximumConcurrency
                 )
-                // Preserve the exact mirror manifest until this transfer has
-                // succeeded. If the mirror fails partway through, it is the
-                // only complete record of files that may need removing before
-                // a Hugging Face fallback begins.
-                failedMirrorManifest = manifest
+                // Once a mirror transfer starts, any interrupted cache must
+                // be cleared before Hugging Face is allowed to use it.
+                mirrorTransferStarted = true
                 try await download(manifest)
                 try plan.recordSuccessfulInstallation(manifest)
                 guard plan.isComplete() else {
@@ -573,16 +571,13 @@ public enum ManagedASRModelDownloader {
                 return plan.cacheDirectory
             } catch {
                 if isCancellation(error) { throw CancellationError() }
-                if let failedMirrorManifest {
-                    // Never resume a mirror's partial bytes against a Hugging
-                    // Face revision. The mirror manifest includes files that
-                    // may not exist in the fallback manifest, so clean it
-                    // before resolving Hugging Face. If cleanup cannot
-                    // complete, fail closed rather than mixing revisions.
-                    try await coordinator.removeDownload(
-                        failedMirrorManifest,
-                        at: plan.cacheDirectory
-                    )
+                if mirrorTransferStarted {
+                    // Never resume mirror bytes, or stale partial files from
+                    // an earlier Hugging Face attempt, against the fallback
+                    // revision. The plan owns this cache directory, so clear
+                    // it completely before resolving Hugging Face. If cleanup
+                    // cannot complete, fail closed rather than mixing bytes.
+                    try plan.delete()
                 }
                 report("Muesli mirror unavailable; trying Hugging Face...")
             }

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -656,7 +656,9 @@ private actor ManagedASRModelOperations {
         let task: Task<URL, Error>
     }
 
-    private var operations: [String: [UUID: Operation]] = [:]
+    // A model's mirror and fallback state transitions share one cache
+    // directory, so callers for the same model must share one operation.
+    private var operations: [String: Operation] = [:]
     private var deletionTokens: [String: UUID] = [:]
 
     func run(
@@ -664,10 +666,18 @@ private actor ManagedASRModelOperations {
         operation: @escaping @Sendable () async throws -> URL
     ) async throws -> URL {
         guard deletionTokens[modelID] == nil else { throw CancellationError() }
+        if let active = operations[modelID] {
+            return try await active.task.value
+        }
+
         let id = UUID()
         let task = Task { try await operation() }
-        operations[modelID, default: [:]][id] = Operation(id: id, task: task)
-        defer { operations[modelID]?[id] = nil }
+        operations[modelID] = Operation(id: id, task: task)
+        defer {
+            if operations[modelID]?.id == id {
+                operations[modelID] = nil
+            }
+        }
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
@@ -676,16 +686,13 @@ private actor ManagedASRModelOperations {
     }
 
     func cancel(modelID: String) {
-        guard let active = operations[modelID]?.values else { return }
-        for operation in active {
-            operation.task.cancel()
-        }
+        operations[modelID]?.task.cancel()
     }
 
     func cancelAndWait(modelID: String) async {
-        let active = operations[modelID].map { Array($0.values) } ?? []
-        for operation in active { operation.task.cancel() }
-        for operation in active { _ = try? await operation.task.value }
+        guard let active = operations[modelID] else { return }
+        active.task.cancel()
+        _ = try? await active.task.value
     }
 
     func beginDeletion(modelID: String) async -> ManagedASRModelDeletionToken {

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -552,6 +552,7 @@ public enum ManagedASRModelDownloader {
         }
 
         var mirrorTransferStarted = false
+        var fallbackCacheBackup: URL?
         if let mirror = plan.mirror {
             do {
                 report("Checking Muesli model mirror...")
@@ -560,8 +561,8 @@ public enum ManagedASRModelDownloader {
                     mirror: mirror,
                     maximumConcurrency: plan.maximumConcurrency
                 )
-                // Once a mirror transfer starts, any interrupted cache must
-                // be cleared before Hugging Face is allowed to use it.
+                // Once a mirror transfer starts, Hugging Face must not resume
+                // any files in the same directory against another revision.
                 mirrorTransferStarted = true
                 try await download(manifest)
                 try plan.recordSuccessfulInstallation(manifest)
@@ -572,12 +573,12 @@ public enum ManagedASRModelDownloader {
             } catch {
                 if isCancellation(error) { throw CancellationError() }
                 if mirrorTransferStarted {
-                    // Never resume mirror bytes, or stale partial files from
-                    // an earlier Hugging Face attempt, against the fallback
-                    // revision. The plan owns this cache directory, so clear
-                    // it completely before resolving Hugging Face. If cleanup
-                    // cannot complete, fail closed rather than mixing bytes.
-                    try plan.delete()
+                    // Download the fallback into a new directory so it cannot
+                    // resume mirror bytes or stale partial files. Keep the
+                    // prior directory aside until the fallback succeeds: valid
+                    // files reused by the failed mirror remain available if
+                    // Hugging Face is unavailable too.
+                    fallbackCacheBackup = try moveCacheAside(plan.cacheDirectory)
                 }
                 report("Muesli mirror unavailable; trying Hugging Face...")
             }
@@ -585,19 +586,56 @@ public enum ManagedASRModelDownloader {
             report("Finding model files...")
         }
 
-        let manifest = try await resolver.resolve(
-            modelID: plan.modelID,
-            repository: plan.repository,
-            revision: plan.revision,
-            selections: plan.selections,
-            maximumConcurrency: plan.maximumConcurrency
-        )
-        try await download(manifest)
-        try plan.recordSuccessfulInstallation(manifest)
-        guard plan.isComplete() else {
-            throw HuggingFaceModelManifestError.emptySelection(plan.repository)
+        do {
+            let manifest = try await resolver.resolve(
+                modelID: plan.modelID,
+                repository: plan.repository,
+                revision: plan.revision,
+                selections: plan.selections,
+                maximumConcurrency: plan.maximumConcurrency
+            )
+            try await download(manifest)
+            try plan.recordSuccessfulInstallation(manifest)
+            guard plan.isComplete() else {
+                throw HuggingFaceModelManifestError.emptySelection(plan.repository)
+            }
+        } catch {
+            if let fallbackCacheBackup {
+                try restoreCache(from: fallbackCacheBackup, to: plan.cacheDirectory)
+            }
+            throw error
+        }
+
+        // The fallback's completion marker has made the replacement durable.
+        // A failed best-effort cleanup does not invalidate the new install.
+        if let fallbackCacheBackup {
+            try? FileManager.default.removeItem(at: fallbackCacheBackup)
         }
         return plan.cacheDirectory
+    }
+
+    /// Moves a plan-owned cache out of the fallback's destination directory.
+    /// The unique sibling avoids sharing resumable state between origins.
+    private static func moveCacheAside(_ cacheDirectory: URL) throws -> URL? {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: cacheDirectory.path) else { return nil }
+
+        let backup = cacheDirectory.deletingLastPathComponent().appendingPathComponent(
+            ".\(cacheDirectory.lastPathComponent).muesli-mirror-fallback-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.moveItem(at: cacheDirectory, to: backup)
+        return backup
+    }
+
+    /// Restores a pre-fallback cache after Hugging Face fails. Removing the
+    /// fallback attempt first prevents incomplete fallback bytes surviving.
+    private static func restoreCache(from backup: URL, to cacheDirectory: URL) throws {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: cacheDirectory.path) {
+            try fileManager.removeItem(at: cacheDirectory)
+        }
+        try fileManager.moveItem(at: backup, to: cacheDirectory)
     }
 
     private static func isCancellation(_ error: Error) -> Bool {

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -419,7 +419,7 @@ public enum ManagedASRModelDownloader {
         mirrorResolver: MuesliModelMirrorManifestResolver = .shared,
         coordinator: ModelDownloadCoordinator = .shared
     ) async throws -> URL {
-        try await operations.run(modelID: plan.modelID) {
+        try await operations.run(modelID: plan.modelID) { cancellation in
             if plan.isAvailableLocally() { return plan.cacheDirectory }
 
             return try await performDownload(
@@ -428,7 +428,8 @@ public enum ManagedASRModelDownloader {
                 progressSnapshot: progressSnapshot,
                 resolver: resolver,
                 mirrorResolver: mirrorResolver,
-                coordinator: coordinator
+                coordinator: coordinator,
+                cancellation: cancellation
             )
         }
     }
@@ -497,8 +498,12 @@ public enum ManagedASRModelDownloader {
         modelID: String,
         coordinator: ModelDownloadCoordinator = .shared
     ) async {
-        await operations.cancel(modelID: modelID)
         await coordinator.cancel(modelID: modelID)
+        // Mark the high-level operation last. That makes a download started
+        // immediately after this method returns wait for cancellation cleanup
+        // and begin a fresh attempt, rather than attaching to the cancelled
+        // task during the observer's cleanup window.
+        await operations.cancel(modelID: modelID)
     }
 
     /// Cancels and awaits manifest discovery plus any registered transfer.
@@ -506,6 +511,10 @@ public enum ManagedASRModelDownloader {
         modelID: String,
         coordinator: ModelDownloadCoordinator = .shared
     ) async {
+        // The coordinator owns the actual URLSession tasks. Stop those first
+        // so awaiting the high-level mirror/fallback operation cannot leave a
+        // detached transfer writing its cache in the background.
+        await coordinator.cancel(modelID: modelID)
         await operations.cancelAndWait(modelID: modelID)
         await coordinator.cancelAndWait(modelID: modelID)
     }
@@ -530,9 +539,16 @@ public enum ManagedASRModelDownloader {
         progressSnapshot: ModelDownloadProgressHandler?,
         resolver: HuggingFaceModelManifestResolver,
         mirrorResolver: MuesliModelMirrorManifestResolver,
-        coordinator: ModelDownloadCoordinator
+        coordinator: ModelDownloadCoordinator,
+        cancellation: ManagedASRModelCancellationToken
     ) async throws -> URL {
-        try Task.checkCancellation()
+        func checkCancellation() throws {
+            try Task.checkCancellation()
+            try cancellation.check()
+        }
+
+        try checkCancellation()
+        try recoverInterruptedFallbackCache(for: plan)
 
         let scalarProgress = ManagedASRScalarProgressRelay(progress)
         func report(_ message: String) {
@@ -561,17 +577,19 @@ public enum ManagedASRModelDownloader {
                     mirror: mirror,
                     maximumConcurrency: plan.maximumConcurrency
                 )
+                try checkCancellation()
                 // Once a mirror transfer starts, Hugging Face must not resume
                 // any files in the same directory against another revision.
                 mirrorTransferStarted = true
                 try await download(manifest)
+                try checkCancellation()
                 try plan.recordSuccessfulInstallation(manifest)
                 guard plan.isComplete() else {
                     throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
                 }
                 return plan.cacheDirectory
             } catch {
-                if isCancellation(error) { throw CancellationError() }
+                if isCancellation(error) || cancellation.isCancelled { throw CancellationError() }
                 if mirrorTransferStarted {
                     // Download the fallback into a new directory so it cannot
                     // resume mirror bytes or stale partial files. Keep the
@@ -594,7 +612,9 @@ public enum ManagedASRModelDownloader {
                 selections: plan.selections,
                 maximumConcurrency: plan.maximumConcurrency
             )
+            try checkCancellation()
             try await download(manifest)
+            try checkCancellation()
             try plan.recordSuccessfulInstallation(manifest)
             guard plan.isComplete() else {
                 throw HuggingFaceModelManifestError.emptySelection(plan.repository)
@@ -602,6 +622,9 @@ public enum ManagedASRModelDownloader {
         } catch {
             if let fallbackCacheBackup {
                 try restoreCache(from: fallbackCacheBackup, to: plan.cacheDirectory)
+            }
+            if isCancellation(error) || cancellation.isCancelled {
+                throw CancellationError()
             }
             throw error
         }
@@ -626,6 +649,44 @@ public enum ManagedASRModelDownloader {
         )
         try fileManager.moveItem(at: cacheDirectory, to: backup)
         return backup
+    }
+
+    /// Restores the last mirror cache if the app was terminated while an
+    /// origin-isolated Hugging Face fallback was in progress.  A surviving
+    /// backup is itself the transaction marker: normal fallback completion or
+    /// failure always removes or restores it before returning.  Restoring it
+    /// before another attempt prevents a later mirror download from seeing
+    /// partial bytes that came from Hugging Face.
+    private static func recoverInterruptedFallbackCache(for plan: ManagedASRModelPlan) throws {
+        let fileManager = FileManager.default
+        let cacheDirectory = plan.cacheDirectory
+        let prefix = ".\(cacheDirectory.lastPathComponent).muesli-mirror-fallback-"
+        let parentDirectory = cacheDirectory.deletingLastPathComponent()
+        let contents = (try? fileManager.contentsOfDirectory(
+            at: parentDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey]
+        )) ?? []
+        let backups = contents.filter { url in
+            guard url.lastPathComponent.hasPrefix(prefix) else { return false }
+            return (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+        guard let backup = backups.max(by: { lhs, rhs in
+            let lhsDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let rhsDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return lhsDate < rhsDate
+        }) else { return }
+
+        if fileManager.fileExists(atPath: cacheDirectory.path) {
+            try fileManager.removeItem(at: cacheDirectory)
+        }
+        try fileManager.moveItem(at: backup, to: cacheDirectory)
+
+        // A previous abrupt termination could have left more than one stale
+        // backup. They cannot belong to the active operation (per-model work
+        // is serialized), and retaining them only consumes model storage.
+        for staleBackup in backups where staleBackup != backup {
+            try? fileManager.removeItem(at: staleBackup)
+        }
     }
 
     /// Restores a pre-fallback cache after Hugging Face fails. Removing the
@@ -654,6 +715,8 @@ private actor ManagedASRModelOperations {
     private struct Operation {
         let id: UUID
         let task: Task<URL, Error>
+        let cancellation: ManagedASRModelCancellationToken
+        var cancellationRequested = false
     }
 
     // A model's mirror and fallback state transitions share one cache
@@ -664,16 +727,27 @@ private actor ManagedASRModelOperations {
 
     func run(
         modelID: String,
-        operation: @escaping @Sendable () async throws -> URL
+        operation: @escaping @Sendable (ManagedASRModelCancellationToken) async throws -> URL
     ) async throws -> URL {
         guard deletionTokens[modelID] == nil else { throw CancellationError() }
         if let active = operations[modelID] {
+            // An explicit model cancellation means the next user-initiated
+            // download is a new attempt, not another observer of the task
+            // that is already winding down.  We still wait for that task to
+            // finish before starting it so two attempts cannot mutate the
+            // same cache directory concurrently.
+            if active.cancellationRequested {
+                _ = try? await waitForCompletion(of: active)
+                try Task.checkCancellation()
+                return try await run(modelID: modelID, operation: operation)
+            }
             return try await waitForCompletion(of: active)
         }
 
         let id = UUID()
-        let task = Task { try await operation() }
-        let active = Operation(id: id, task: task)
+        let cancellation = ManagedASRModelCancellationToken()
+        let task = Task { try await operation(cancellation) }
+        let active = Operation(id: id, task: task, cancellation: cancellation)
         operations[modelID] = active
         Task { [weak self] in
             let result: Result<URL, Error>
@@ -688,12 +762,11 @@ private actor ManagedASRModelOperations {
     }
 
     func cancel(modelID: String) {
-        operations[modelID]?.task.cancel()
+        requestCancellation(modelID: modelID)?.task.cancel()
     }
 
     func cancelAndWait(modelID: String) async {
-        guard let active = operations[modelID] else { return }
-        active.task.cancel()
+        guard let active = requestCancellation(modelID: modelID) else { return }
         let result: Result<URL, Error>
         do {
             result = .success(try await active.task.value)
@@ -707,6 +780,14 @@ private actor ManagedASRModelOperations {
         // ID guard in `finish` makes this safe if the observer already ran or
         // a newer operation has since replaced it.
         finish(modelID: modelID, operationID: active.id, result: result)
+    }
+
+    private func requestCancellation(modelID: String) -> Operation? {
+        guard var active = operations[modelID] else { return nil }
+        active.cancellationRequested = true
+        operations[modelID] = active
+        active.cancellation.cancel()
+        return active
     }
 
     func beginDeletion(modelID: String) async -> ManagedASRModelDeletionToken {
@@ -759,6 +840,29 @@ private actor ManagedASRModelOperations {
         for continuation in waiters.values {
             continuation.resume(with: result)
         }
+    }
+}
+
+/// Explicit model cancellation must survive the small URLSession race where a
+/// manifest response completes just as its parent task is cancelled.
+private final class ManagedASRModelCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    func check() throws {
+        guard !isCancelled else { throw CancellationError() }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliCore/ModelDownloadCoordinator.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ModelDownloadCoordinator.swift
@@ -369,13 +369,23 @@ public actor ModelDownloadCoordinator {
             try validatedURL(for: file.relativePath, in: directory)
         }
         let destinationPath = canonicalDirectoryPath(directory)
-        guard !inFlight.keys.contains(where: { $0.destinationPath == destinationPath }) else { return }
+        guard !inFlight.keys.contains(where: { $0.destinationPath == destinationPath }) else {
+            throw ModelDownloadError.conflictingInFlightDownload(manifest.id)
+        }
         let fm = FileManager.default
         for path in paths {
-            try? fm.removeItem(at: path.appendingPathExtension("part"))
-            try? fm.removeItem(at: path)
+            let partialPath = path.appendingPathExtension("part")
+            if fm.fileExists(atPath: partialPath.path) {
+                try fm.removeItem(at: partialPath)
+            }
+            if fm.fileExists(atPath: path.path) {
+                try fm.removeItem(at: path)
+            }
         }
-        try? fm.removeItem(at: stateURL(for: directory))
+        let persistedStateURL = stateURL(for: directory)
+        if fm.fileExists(atPath: persistedStateURL.path) {
+            try fm.removeItem(at: persistedStateURL)
+        }
     }
 
     private func performDownload(

--- a/native/MuesliNative/Sources/MuesliCore/MuesliModelMirrorManifestResolver.swift
+++ b/native/MuesliNative/Sources/MuesliCore/MuesliModelMirrorManifestResolver.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// A pinned, public Muesli model manifest hosted at the trusted asset origin.
+///
+/// The manifest is immutable for a released app build. It supplies the exact
+/// files, sizes, and checksums used by the existing resumable downloader.
+public struct MuesliModelMirror: Hashable, Sendable {
+    public let manifestURL: URL
+
+    public init(manifestURL: URL) {
+        self.manifestURL = manifestURL
+    }
+}
+
+/// Errors raised while validating a Muesli-hosted model manifest.
+public enum MuesliModelMirrorManifestError: Error, LocalizedError, Sendable {
+    case untrustedManifestURL(URL)
+    case invalidHTTPStatus(Int, URL)
+    case invalidManifest(URL)
+    case unexpectedFormat(String)
+    case unexpectedModelID(expected: String, actual: String)
+    case invalidVersion
+    case invalidFile(String)
+    case duplicatePath(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .untrustedManifestURL(let url):
+            return "The model mirror manifest is not hosted at the trusted asset origin: \(url.host ?? url.absoluteString)"
+        case .invalidHTTPStatus(let status, _):
+            return "The model mirror returned HTTP \(status)"
+        case .invalidManifest:
+            return "The model mirror returned an invalid manifest"
+        case .unexpectedFormat(let format):
+            return "The model mirror manifest has an unsupported format: \(format)"
+        case .unexpectedModelID(let expected, let actual):
+            return "The model mirror manifest is for \(actual), not \(expected)"
+        case .invalidVersion:
+            return "The model mirror manifest has no immutable version"
+        case .invalidFile(let path):
+            return "The model mirror has an invalid file entry: \(path)"
+        case .duplicatePath(let path):
+            return "The model mirror lists \(path) more than once"
+        }
+    }
+}
+
+/// Resolves Muesli's immutable R2-backed model manifests into downloader manifests.
+///
+/// This deliberately accepts only the production asset origin and objects below
+/// the manifest's own `files/` directory. A malformed remote manifest therefore
+/// cannot redirect a client to an arbitrary host or another model release.
+public final class MuesliModelMirrorManifestResolver: @unchecked Sendable {
+    public static let shared = MuesliModelMirrorManifestResolver()
+
+    private static let assetHost = "assets.muesli.works"
+    private let session: URLSession
+
+    public init(configuration: URLSessionConfiguration = .default) {
+        let configuration = configuration.copy() as? URLSessionConfiguration ?? configuration
+        configuration.timeoutIntervalForRequest = 8
+        configuration.timeoutIntervalForResource = 15
+        session = URLSession(configuration: configuration)
+    }
+
+    public func resolve(
+        modelID: String,
+        mirror: MuesliModelMirror,
+        maximumConcurrency: Int = 2
+    ) async throws -> ModelDownloadManifest {
+        guard Self.isTrustedAssetURL(mirror.manifestURL) else {
+            throw MuesliModelMirrorManifestError.untrustedManifestURL(mirror.manifestURL)
+        }
+
+        let (data, response) = try await session.data(from: mirror.manifestURL)
+        guard let http = response as? HTTPURLResponse else {
+            throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
+        }
+        guard http.url == mirror.manifestURL else {
+            throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw MuesliModelMirrorManifestError.invalidHTTPStatus(http.statusCode, mirror.manifestURL)
+        }
+
+        let payload: Payload
+        do {
+            payload = try JSONDecoder().decode(Payload.self, from: data)
+        } catch {
+            throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
+        }
+        guard payload.format == "muesli-r2-model-manifest-v1" else {
+            throw MuesliModelMirrorManifestError.unexpectedFormat(payload.format)
+        }
+        guard payload.modelID == modelID else {
+            throw MuesliModelMirrorManifestError.unexpectedModelID(
+                expected: modelID,
+                actual: payload.modelID
+            )
+        }
+        let version = payload.version?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !version.isEmpty else { throw MuesliModelMirrorManifestError.invalidVersion }
+
+        let objectKeyPrefix = Self.objectKeyPrefix(for: mirror.manifestURL)
+        var seenPaths = Set<String>()
+        let files = try payload.files.map { entry -> ModelDownloadFile in
+            guard Self.isSafeRelativePath(entry.relativePath),
+                  entry.bytes > 0,
+                  Self.isSHA256(entry.sha256),
+                  entry.objectKey.hasPrefix(objectKeyPrefix),
+                  Self.isSafeObjectKey(entry.objectKey),
+                  !entry.objectKey.contains("?") && !entry.objectKey.contains("#")
+            else {
+                throw MuesliModelMirrorManifestError.invalidFile(entry.relativePath)
+            }
+            guard seenPaths.insert(entry.relativePath).inserted else {
+                throw MuesliModelMirrorManifestError.duplicatePath(entry.relativePath)
+            }
+            guard let remoteURL = Self.objectURL(for: entry.objectKey, relativeTo: mirror.manifestURL) else {
+                throw MuesliModelMirrorManifestError.invalidFile(entry.relativePath)
+            }
+            return ModelDownloadFile(
+                relativePath: entry.relativePath,
+                remoteURL: remoteURL,
+                expectedByteCount: entry.bytes,
+                sha256: entry.sha256
+            )
+        }
+        guard !files.isEmpty else { throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL) }
+
+        return ModelDownloadManifest(
+            id: modelID,
+            version: version,
+            files: files.sorted { $0.relativePath < $1.relativePath },
+            maximumConcurrency: maximumConcurrency
+        )
+    }
+
+    private struct Payload: Decodable {
+        let format: String
+        let modelID: String
+        let version: String?
+        let files: [File]
+
+        struct File: Decodable {
+            let relativePath: String
+            let objectKey: String
+            let bytes: Int64
+            let sha256: String
+        }
+    }
+
+    private static func isTrustedAssetURL(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "https"
+            && url.host?.caseInsensitiveCompare(assetHost) == .orderedSame
+            && url.query == nil
+            && url.fragment == nil
+            && url.lastPathComponent == "manifest.json"
+    }
+
+    private static func objectKeyPrefix(for manifestURL: URL) -> String {
+        let directory = manifestURL.deletingLastPathComponent().path
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return directory + "/files/"
+    }
+
+    private static func objectURL(for key: String, relativeTo manifestURL: URL) -> URL? {
+        guard var components = URLComponents(url: manifestURL, resolvingAgainstBaseURL: false) else { return nil }
+        components.path = "/" + key
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    private static func isSafeRelativePath(_ path: String) -> Bool {
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        return !path.isEmpty
+            && !path.hasPrefix("/")
+            && !path.contains("\\")
+            && components.allSatisfy { $0 != "." && $0 != ".." && !$0.isEmpty }
+    }
+
+    private static func isSafeObjectKey(_ key: String) -> Bool {
+        let components = key.split(separator: "/", omittingEmptySubsequences: false)
+        return !key.isEmpty
+            && !key.hasPrefix("/")
+            && !key.contains("\\")
+            && components.allSatisfy { $0 != "." && $0 != ".." && !$0.isEmpty }
+    }
+
+    private static func isSHA256(_ value: String) -> Bool {
+        guard value.utf8.count == 64 else { return false }
+        return value.unicodeScalars.allSatisfy { scalar in
+            (48...57).contains(scalar.value)
+                || (65...70).contains(scalar.value)
+                || (97...102).contains(scalar.value)
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/MuesliModelMirrorManifestResolver.swift
+++ b/native/MuesliNative/Sources/MuesliCore/MuesliModelMirrorManifestResolver.swift
@@ -73,6 +73,9 @@ public final class MuesliModelMirrorManifestResolver: @unchecked Sendable {
         }
 
         let (data, response) = try await session.data(from: mirror.manifestURL)
+        // See the Hugging Face resolver: a completed URLSession request does
+        // not by itself mean the enclosing model operation is still wanted.
+        try Task.checkCancellation()
         guard let http = response as? HTTPURLResponse else {
             throw MuesliModelMirrorManifestError.invalidManifest(mirror.manifestURL)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -818,6 +818,7 @@ struct PostProcessorOption: Identifiable, Equatable {
     let downloadURL: URL
     let filename: String
     let inputFormat: InputFormat
+    let isDownloadable: Bool
 
     init(
         id: String,
@@ -826,7 +827,8 @@ struct PostProcessorOption: Identifiable, Equatable {
         description: String,
         downloadURL: URL,
         filename: String,
-        inputFormat: InputFormat = .configurable
+        inputFormat: InputFormat = .configurable,
+        isDownloadable: Bool = true
     ) {
         self.id = id
         self.label = label
@@ -835,6 +837,7 @@ struct PostProcessorOption: Identifiable, Equatable {
         self.downloadURL = downloadURL
         self.filename = filename
         self.inputFormat = inputFormat
+        self.isDownloadable = isDownloadable
     }
 
     var cacheDirectory: URL {
@@ -871,6 +874,19 @@ struct PostProcessorOption: Identifiable, Equatable {
         inputFormat != .s1Mini || transcriptionBackend != .indicASR
     }
 
+    /// Retained only so existing installs keep working. This option is not in
+    /// the download catalogue; once its local cache is deleted, it cannot be
+    /// downloaded again.
+    static let legacyV2 = PostProcessorOption(
+        id: "qwen3-postproc-v2",
+        label: "Muesli Cleanup (Legacy)",
+        sizeLabel: "~390 MB",
+        description: "An earlier cleanup model for Muesli dictation. It handles filler words, corrections, and spoken lists, but is less consistent than the current model.",
+        downloadURL: URL(string: "https://huggingface.co/phequals/qwen3-postproc-v2/resolve/main/qwen3-postproc-v2-q4_k_m.gguf")!,
+        filename: "qwen3-postproc-v2-q4_k_m.gguf",
+        isDownloadable: false
+    )
+
     // Vanilla Qwen3.5-0.8B. Stable for basic cleanup; does not reliably convert spoken list cues.
     static let qwen35_0_8b = PostProcessorOption(
         id: "qwen35-0.8b",
@@ -905,8 +921,13 @@ struct PostProcessorOption: Identifiable, Equatable {
     static let defaultOption: PostProcessorOption = .finetunedV3
     static let defaultQuilOption: PostProcessorOption = .qwen35_0_8b
 
+    /// Includes retired options that remain runnable when they are already
+    /// cached locally. Keep this separate from `all` so retired models never
+    /// appear as downloadable catalogue entries.
+    private static let knownOptions: [PostProcessorOption] = all + [.legacyV2]
+
     static var downloaded: [PostProcessorOption] {
-        all.filter(\.isDownloaded)
+        knownOptions.filter(\.isDownloaded)
     }
 
     static var downloadedIDs: Set<String> {
@@ -914,7 +935,7 @@ struct PostProcessorOption: Identifiable, Equatable {
     }
 
     static func resolve(id: String) -> PostProcessorOption {
-        all.first { $0.id == id } ?? defaultOption
+        knownOptions.first { $0.id == id } ?? defaultOption
     }
 
     static func firstDownloaded(excluding excludedID: String? = nil) -> PostProcessorOption? {
@@ -922,7 +943,7 @@ struct PostProcessorOption: Identifiable, Equatable {
     }
 
     static func firstDownloaded(excluding excludedID: String? = nil, downloadedIDs: Set<String>) -> PostProcessorOption? {
-        all.first { option in
+        knownOptions.first { option in
             option.id != excludedID && downloadedIDs.contains(option.id)
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -871,17 +871,6 @@ struct PostProcessorOption: Identifiable, Equatable {
         inputFormat != .s1Mini || transcriptionBackend != .indicASR
     }
 
-    // Fine-tuned Qwen3-0.6B trained on Muesli dictation correction data.
-    // HF repo must be public (or token-gated) before distributing alpha builds.
-    static let finetunedV2 = PostProcessorOption(
-        id: "qwen3-postproc-v2",
-        label: "Muesli Cleanup (Legacy)",
-        sizeLabel: "~390 MB",
-        description: "An earlier cleanup model for Muesli dictation. It handles filler words, corrections, and spoken lists, but is less consistent than the current model.",
-        downloadURL: URL(string: "https://huggingface.co/phequals/qwen3-postproc-v2/resolve/main/qwen3-postproc-v2-q4_k_m.gguf")!,
-        filename: "qwen3-postproc-v2-q4_k_m.gguf"
-    )
-
     // Vanilla Qwen3.5-0.8B. Stable for basic cleanup; does not reliably convert spoken list cues.
     static let qwen35_0_8b = PostProcessorOption(
         id: "qwen35-0.8b",
@@ -912,7 +901,7 @@ struct PostProcessorOption: Identifiable, Equatable {
         inputFormat: .s1Mini
     )
 
-    static let all: [PostProcessorOption] = [.finetunedV3, .s1Mini, .finetunedV2, .qwen35_0_8b]
+    static let all: [PostProcessorOption] = [.finetunedV3, .s1Mini, .qwen35_0_8b]
     static let defaultOption: PostProcessorOption = .finetunedV3
     static let defaultQuilOption: PostProcessorOption = .qwen35_0_8b
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -628,7 +628,7 @@ struct ModelsView: View {
                     gemmaCleanupModelCard(model)
                 }
 
-                ForEach(PostProcessorOption.all) { option in
+                ForEach(displayedPostProcessorOptions) { option in
                     postProcModelCard(option)
                 }
             }
@@ -750,7 +750,7 @@ struct ModelsView: View {
                             .frame(width: 20, height: 20)
                     }
                     .buttonStyle(.plain)
-                } else {
+                } else if option.isDownloadable {
                     Button("Download") {
                         startPostProcDownload(option)
                     }
@@ -761,6 +761,10 @@ struct ModelsView: View {
                     .padding(.vertical, 4)
                     .background(MuesliTheme.accentSubtle)
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                } else {
+                    Text("No longer available")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
                 }
             }
         }
@@ -1365,6 +1369,7 @@ struct ModelsView: View {
     // MARK: - Post-Processor Actions
 
     private func startPostProcDownload(_ option: PostProcessorOption) {
+        guard option.isDownloadable else { return }
         withAnimation { _ = downloadingPostProcModels.insert(option.id) }
         downloadProgressPostProc[option.id] = 0.02
         downloadMessages.removeValue(forKey: option.id)
@@ -1512,11 +1517,21 @@ struct ModelsView: View {
 
     private func checkDownloadedPostProcModels() {
         downloadedPostProcModels.removeAll()
-        for option in PostProcessorOption.all {
+        for option in PostProcessorOption.downloaded {
             if option.isDownloaded {
                 downloadedPostProcModels.insert(option.id)
             }
         }
+    }
+
+    /// The retired v2 cleanup model stays visible only for people who already
+    /// have it installed. Deleting it removes the card, and the model cannot
+    /// be downloaded again.
+    private var displayedPostProcessorOptions: [PostProcessorOption] {
+        PostProcessorOption.all
+            + (downloadedPostProcModels.contains(PostProcessorOption.legacyV2.id)
+                ? [.legacyV2]
+                : [])
     }
 
     // MARK: - Actions

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -151,7 +151,7 @@ struct ModelsView: View {
                 postProcModelToDelete = nil
             }
         } message: {
-            Text("The downloaded model files will be removed from this Mac. You can download the model again later.")
+            Text(postProcessorDeleteMessage)
         }
         .alert(
             "Delete \"\(MeetingLiveCaptionModelStore.label)\"?",
@@ -171,6 +171,13 @@ struct ModelsView: View {
             get: { appState.selectedModelsCategory },
             set: { appState.selectedModelsCategory = $0 }
         )
+    }
+
+    private var postProcessorDeleteMessage: String {
+        guard let option = postProcModelToDelete, !option.isDownloadable else {
+            return "The downloaded model files will be removed from this Mac. You can download the model again later."
+        }
+        return "The downloaded model files will be removed from this Mac. This legacy model is no longer available to download, so deleting it is permanent."
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -549,16 +549,25 @@ struct ModelDownloadCoordinatorTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let mirroredData = Data("mirror".utf8)
         let fallbackData = Data("fallback".utf8)
+        let mirrorOnlyData = Data("mirror-only".utf8)
         let mirrorManifest = try JSONSerialization.data(withJSONObject: [
             "format": "muesli-r2-model-manifest-v1",
             "modelID": "acme/asr",
             "version": "mirror-v1",
-            "files": [[
-                "relativePath": "model.bin",
-                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
-                "bytes": mirroredData.count,
-                "sha256": sha256(mirroredData),
-            ]],
+            "files": [
+                [
+                    "relativePath": "a-mirror-only.bin",
+                    "objectKey": "models/acme/asr/mirror-v1/files/a-mirror-only.bin",
+                    "bytes": mirrorOnlyData.count,
+                    "sha256": sha256(mirrorOnlyData),
+                ],
+                [
+                    "relativePath": "model.bin",
+                    "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                    "bytes": mirroredData.count,
+                    "sha256": sha256(mirroredData),
+                ],
+            ],
         ])
         let tree = try JSONSerialization.data(withJSONObject: [[
             "type": "file",
@@ -570,6 +579,9 @@ struct ModelDownloadCoordinatorTests {
             guard let url = request.url else { fatalError("Expected request URL") }
             if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
                 return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/a-mirror-only.bin") {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorOnlyData)
             }
             if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
                 return ModelDownloadTestURLProtocol.Response(statusCode: 400)
@@ -601,7 +613,55 @@ struct ModelDownloadCoordinatorTests {
         )
 
         #expect(try Data(contentsOf: directory.appendingPathComponent("model.bin")) == fallbackData)
+        #expect(!FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("a-mirror-only.bin").path
+        ))
         #expect(plan.isComplete())
+    }
+
+    @Test("cancelling mirror manifest resolution does not fall back to Hugging Face")
+    func cancellingMirrorManifestResolutionDoesNotFallBack() async throws {
+        let mirrorTracker = DownloadTestTracker()
+        let fallbackTracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { request in
+            if request.url?.host == "assets.muesli.works" {
+                return ModelDownloadTestURLProtocol.Response(
+                    data: Data(repeating: 0x7B, count: 512 * 1024),
+                    chunkSize: 128,
+                    delay: 0.002,
+                    tracker: mirrorTracker
+                )
+            }
+            return ModelDownloadTestURLProtocol.Response(tracker: fallbackTracker)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let plan = ManagedASRModelPlan(
+            modelID: "mirror-manifest-cancel",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let coordinator = makeCoordinator()
+        let task = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+                mirrorResolver: MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration()),
+                coordinator: coordinator
+            )
+        }
+        #expect(mirrorTracker.waitUntilRequestStarts())
+
+        await ManagedASRModelDownloader.cancel(modelID: plan.modelID, coordinator: coordinator)
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+        #expect(fallbackTracker.requestCount == 0)
     }
 
     @Test("managed ASR plans require complete compiled artifacts")

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 import MuesliCore
@@ -413,6 +414,196 @@ struct ModelDownloadCoordinatorTests {
         #expect(tracker.requestCount == 1)
     }
 
+    @Test("Muesli mirror manifests become checksum-validated downloader manifests")
+    func muesliMirrorManifestResolution() async throws {
+        let data = Data("mirror".utf8)
+        let manifestData = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "acme/asr",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "models/model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/models/model.bin",
+                "bytes": data.count,
+                "sha256": sha256(data),
+            ]],
+        ])
+        ModelDownloadTestURLProtocol.install { request in
+            #expect(request.url?.host == "assets.muesli.works")
+            #expect(request.url?.lastPathComponent == "manifest.json")
+            return ModelDownloadTestURLProtocol.Response(data: manifestData)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let resolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+        let manifest = try await resolver.resolve(
+            modelID: "acme/asr",
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+
+        #expect(manifest.id == "acme/asr")
+        #expect(manifest.version == "mirror-v1")
+        #expect(manifest.files.map(\.relativePath) == ["models/model.bin"])
+        #expect(manifest.files[0].remoteURL.absoluteString == "https://assets.muesli.works/models/acme/asr/mirror-v1/files/models/model.bin")
+        #expect(manifest.files[0].sha256 == sha256(data))
+    }
+
+    @Test("managed downloads prefer the Muesli mirror without contacting Hugging Face")
+    func managedDownloadPrefersMuesliMirror() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = Data("mirror".utf8)
+        let manifestData = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "acme/asr",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": data.count,
+                "sha256": sha256(data),
+            ]],
+        ])
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: manifestData)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(data: data)
+            }
+            Issue.record("Mirror-backed download unexpectedly requested \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+            mirrorResolver: MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration()),
+            coordinator: makeCoordinator()
+        )
+
+        #expect(directory == plan.cacheDirectory)
+        #expect(try Data(contentsOf: directory.appendingPathComponent("model.bin")) == data)
+        #expect(plan.isComplete())
+    }
+
+    @Test("managed downloads fall back to Hugging Face when the Muesli mirror is unavailable")
+    func managedDownloadFallsBackWhenMuesliMirrorFails() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = Data("fallback".utf8)
+        let tree = try JSONSerialization.data(withJSONObject: [[
+            "type": "file",
+            "path": "model.bin",
+            "size": data.count,
+            "oid": "fallback-oid",
+        ]])
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works" {
+                return ModelDownloadTestURLProtocol.Response(statusCode: 503)
+            }
+            if url.path.contains("/tree/") {
+                return ModelDownloadTestURLProtocol.Response(data: tree)
+            }
+            if url.path.contains("/resolve/") {
+                return ModelDownloadTestURLProtocol.Response(data: data)
+            }
+            Issue.record("Unexpected fallback request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+            mirrorResolver: MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration()),
+            coordinator: makeCoordinator()
+        )
+
+        #expect(try Data(contentsOf: directory.appendingPathComponent("model.bin")) == data)
+        #expect(plan.isComplete())
+    }
+
+    @Test("managed downloads fall back to Hugging Face after a mirror transfer failure")
+    func managedDownloadFallsBackWhenMuesliMirrorTransferFails() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mirroredData = Data("mirror".utf8)
+        let fallbackData = Data("fallback".utf8)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "acme/asr",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": mirroredData.count,
+                "sha256": sha256(mirroredData),
+            ]],
+        ])
+        let tree = try JSONSerialization.data(withJSONObject: [[
+            "type": "file",
+            "path": "model.bin",
+            "size": fallbackData.count,
+            "oid": "fallback-oid",
+        ]])
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(statusCode: 400)
+            }
+            if url.path.contains("/tree/") {
+                return ModelDownloadTestURLProtocol.Response(data: tree)
+            }
+            if url.path.contains("/resolve/") {
+                return ModelDownloadTestURLProtocol.Response(data: fallbackData)
+            }
+            Issue.record("Unexpected transfer fallback request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+            mirrorResolver: MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration()),
+            coordinator: makeCoordinator()
+        )
+
+        #expect(try Data(contentsOf: directory.appendingPathComponent("model.bin")) == fallbackData)
+        #expect(plan.isComplete())
+    }
+
     @Test("managed ASR plans require complete compiled artifacts")
     func managedASRPlanCompleteness() throws {
         let root = try makeTemporaryDirectory()
@@ -468,6 +659,9 @@ struct ModelDownloadCoordinatorTests {
         #expect(plan.selections.count == 1)
         #expect(plan.selections[0].remoteDirectory == "int8")
         #expect(plan.selections[0].includedPaths.contains("vocab.json"))
+
+        let parakeet = ManagedASRModelPlans.parakeetV2(modelsRoot: root)
+        #expect(parakeet.mirror?.manifestURL.absoluteString == "https://assets.muesli.works/models/fluidaudio/parakeet-tdt-0.6b-v2/legacy-local-v1/manifest.json")
 
         let whisper = ManagedASRModelPlans.whisperKit(modelName: "tiny", downloadRoot: root)
         #expect(whisper.selections[0].includedPaths.contains("AudioEncoder.mlmodelc"))
@@ -1170,5 +1364,9 @@ struct ModelDownloadCoordinatorTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+
+    private func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -663,11 +663,37 @@ struct ModelDownloadCoordinatorTests {
         let parakeet = ManagedASRModelPlans.parakeetV2(modelsRoot: root)
         #expect(parakeet.mirror?.manifestURL.absoluteString == "https://assets.muesli.works/models/fluidaudio/parakeet-tdt-0.6b-v2/legacy-local-v1/manifest.json")
 
+        let parakeetV3 = ManagedASRModelPlans.parakeetV3(modelsRoot: root)
+        #expect(parakeetV3.mirror?.manifestURL.absoluteString == "https://assets.muesli.works/models/fluidaudio/parakeet-tdt-0.6b-v3/legacy-local-v1/manifest.json")
+
+        let unified = ManagedASRModelPlans.parakeetUnified(modelsRoot: root)
+        #expect(unified.mirror?.manifestURL.absoluteString == "https://assets.muesli.works/models/fluidaudio/parakeet-unified-en-0.6b/legacy-local-v1/manifest.json")
+
         let whisper = ManagedASRModelPlans.whisperKit(modelName: "tiny", downloadRoot: root)
         #expect(whisper.selections[0].includedPaths.contains("AudioEncoder.mlmodelc"))
         #expect(whisper.selections[0].includedPaths.contains("config.json"))
         #expect(whisper.selections[0].includedPaths.contains("generation_config.json"))
         #expect(!whisper.selections[0].includedPaths.contains("AudioEncoder.mlpackage"))
+        #expect(whisper.mirror?.manifestURL.absoluteString == "https://assets.muesli.works/models/whisperkit/openai_whisper-tiny/legacy-local-v1/manifest.json")
+    }
+
+    @Test("supported WhisperKit variants have immutable Muesli mirrors")
+    func mirroredWhisperKitVariants() {
+        let expectedPaths = [
+            "tiny": "openai_whisper-tiny",
+            "tiny.en": "openai_whisper-tiny.en",
+            "small": "openai_whisper-small",
+            "small.en": "openai_whisper-small.en",
+            "medium.en": "openai_whisper-medium.en",
+            "large-v3-v20240930_626MB": "openai_whisper-large-v3-v20240930_626MB",
+        ]
+
+        for (modelName, remoteDirectory) in expectedPaths {
+            let plan = ManagedASRModelPlans.whisperKit(modelName: modelName)
+            #expect(plan.mirror?.manifestURL.absoluteString == "https://assets.muesli.works/models/whisperkit/\(remoteDirectory)/legacy-local-v1/manifest.json")
+        }
+
+        #expect(ManagedASRModelPlans.whisperKit(modelName: "distil-large-v3").mirror == nil)
     }
 
     @Test("English-only Whisper checkpoints use their exact downloadable cache identities")

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -944,6 +944,81 @@ struct ModelDownloadCoordinatorTests {
         #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
     }
 
+    @Test("cancelling and waiting permits an immediate fresh model retry")
+    func cancellingAndWaitingPermitsImmediateFreshModelRetry() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = Data(repeating: 0x7F, count: 512 * 1024)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "cancel-and-retry",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": data.count,
+                "sha256": sha256(data),
+            ]],
+        ])
+        let modelTracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(
+                    data: data,
+                    chunkSize: 4 * 1024,
+                    delay: 0.002,
+                    tracker: modelTracker
+                )
+            }
+            Issue.record("Unexpected cancellation-retry request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "cancel-and-retry",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let mirrorResolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+        let coordinator = makeCoordinator()
+        let first = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                mirrorResolver: mirrorResolver,
+                coordinator: coordinator
+            )
+        }
+        #expect(modelTracker.waitUntilRequestStarts())
+
+        await ManagedASRModelDownloader.cancelAndWait(
+            modelID: plan.modelID,
+            coordinator: coordinator
+        )
+        await #expect(throws: CancellationError.self) {
+            _ = try await first.value
+        }
+
+        let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            resolver: resolver,
+            mirrorResolver: mirrorResolver,
+            coordinator: coordinator
+        )
+        #expect(directory == plan.cacheDirectory)
+        #expect(modelTracker.requestCount == 2)
+        #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
+    }
+
     @Test("cancelling mirror manifest resolution does not fall back to Hugging Face")
     func cancellingMirrorManifestResolutionDoesNotFallBack() async throws {
         let mirrorTracker = DownloadTestTracker()

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -448,6 +448,90 @@ struct ModelDownloadCoordinatorTests {
         #expect(manifest.files[0].sha256 == sha256(data))
     }
 
+    @Test("Muesli mirror manifests reject an untrusted origin")
+    func muesliMirrorManifestRejectsUntrustedOrigin() async throws {
+        let resolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+
+        await #expect(throws: MuesliModelMirrorManifestError.self) {
+            try await resolver.resolve(
+                modelID: "acme/asr",
+                mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://example.com/models/acme/asr/mirror-v1/manifest.json")))
+            )
+        }
+    }
+
+    @Test("Muesli mirror manifests reject unsafe entries")
+    func muesliMirrorManifestRejectsUnsafeEntries() async throws {
+        let manifestURL = try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json"))
+        let validSHA256 = String(repeating: "a", count: 64)
+        let cases: [(name: String, files: [[String: Any]])] = [
+            (
+                "path traversal",
+                [[
+                    "relativePath": "../escape.bin",
+                    "objectKey": "models/acme/asr/mirror-v1/files/escape.bin",
+                    "bytes": 1,
+                    "sha256": validSHA256,
+                ]]
+            ),
+            (
+                "cross-release object key",
+                [[
+                    "relativePath": "model.bin",
+                    "objectKey": "models/acme/other/mirror-v1/files/model.bin",
+                    "bytes": 1,
+                    "sha256": validSHA256,
+                ]]
+            ),
+            (
+                "invalid checksum",
+                [[
+                    "relativePath": "model.bin",
+                    "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                    "bytes": 1,
+                    "sha256": "not-a-sha256",
+                ]]
+            ),
+            (
+                "duplicate path",
+                [
+                    [
+                        "relativePath": "model.bin",
+                        "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                        "bytes": 1,
+                        "sha256": validSHA256,
+                    ],
+                    [
+                        "relativePath": "model.bin",
+                        "objectKey": "models/acme/asr/mirror-v1/files/second.bin",
+                        "bytes": 1,
+                        "sha256": validSHA256,
+                    ],
+                ]
+            ),
+        ]
+
+        for testCase in cases {
+            let manifestData = try JSONSerialization.data(withJSONObject: [
+                "format": "muesli-r2-model-manifest-v1",
+                "modelID": "acme/asr",
+                "version": "mirror-v1",
+                "files": testCase.files,
+            ])
+            ModelDownloadTestURLProtocol.install { _ in
+                ModelDownloadTestURLProtocol.Response(data: manifestData)
+            }
+            let resolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+            await #expect(throws: MuesliModelMirrorManifestError.self) {
+                try await resolver.resolve(
+                    modelID: "acme/asr",
+                    mirror: MuesliModelMirror(manifestURL: manifestURL)
+                )
+            }
+            ModelDownloadTestURLProtocol.uninstall()
+        }
+    }
+
     @Test("managed downloads prefer the Muesli mirror without contacting Hugging Face")
     func managedDownloadPrefersMuesliMirror() async throws {
         let root = try makeTemporaryDirectory()
@@ -1135,6 +1219,47 @@ struct ModelDownloadCoordinatorTests {
         }
         try await first.value
         #expect(tracker.requestCount == 1)
+    }
+
+    @Test("removal fails while a download owns the destination")
+    func removalFailsWhileDownloadIsActive() async throws {
+        let tracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { _ in
+            ModelDownloadTestURLProtocol.Response(
+                data: Data(repeating: 0x42, count: 512 * 1024),
+                chunkSize: 4 * 1024,
+                delay: 0.002,
+                tracker: tracker
+            )
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let coordinator = makeCoordinator()
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let manifest = ModelDownloadManifest(
+            id: "active-removal",
+            version: "1",
+            files: [ModelDownloadFile(
+                relativePath: "model.bin",
+                remoteURL: try #require(URL(string: "https://example.com/model")),
+                expectedByteCount: 512 * 1024
+            )],
+            maximumConcurrency: 1
+        )
+        let task = Task { try await coordinator.download(manifest, to: directory) }
+        #expect(tracker.waitUntilRequestStarts())
+
+        await #expect(throws: ModelDownloadError.self) {
+            try await coordinator.removeDownload(manifest, at: directory)
+        }
+        await coordinator.cancelAndWait(modelID: manifest.id)
+        do {
+            try await task.value
+            Issue.record("Cancellation unexpectedly completed")
+        } catch is CancellationError {
+            // Expected.
+        }
     }
 
     @Test("cancelling one duplicate caller does not cancel the shared transfer")

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -787,6 +787,77 @@ struct ModelDownloadCoordinatorTests {
         ))
     }
 
+    @Test("interrupted fallback restores its mirror cache before retrying")
+    func interruptedFallbackRestoresMirrorCacheBeforeRetry() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mirrorData = Data("mirror model".utf8)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "acme/asr",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": mirrorData.count,
+                "sha256": sha256(mirrorData),
+            ]],
+        ])
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            // A restored, verified mirror file needs no second transfer. If
+            // the interrupted Hugging Face cache were used instead, both
+            // origins are deliberately unavailable and this retry would fail.
+            if url.host == "assets.muesli.works" || url.path.contains("/tree/") {
+                return ModelDownloadTestURLProtocol.Response(statusCode: 503)
+            }
+            Issue.record("Unexpected interrupted-fallback request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let interruptedFallback = root.appendingPathComponent(
+            ".model.muesli-mirror-fallback-interrupted",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: interruptedFallback, withIntermediateDirectories: true)
+        try mirrorData.write(to: interruptedFallback.appendingPathComponent("model.bin"))
+
+        try FileManager.default.createDirectory(at: plan.cacheDirectory, withIntermediateDirectories: true)
+        try Data("partial Hugging Face bytes".utf8).write(
+            to: plan.cacheDirectory.appendingPathComponent("model.bin.part")
+        )
+        try Data("{}".utf8).write(
+            to: plan.cacheDirectory.appendingPathComponent(".muesli-download-state.json")
+        )
+
+        let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+            mirrorResolver: MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration()),
+            coordinator: makeCoordinator()
+        )
+
+        #expect(directory == plan.cacheDirectory)
+        #expect(try Data(contentsOf: directory.appendingPathComponent("model.bin")) == mirrorData)
+        #expect(plan.isComplete())
+        #expect(!FileManager.default.fileExists(atPath: interruptedFallback.path))
+        #expect(!FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("model.bin.part").path
+        ))
+    }
+
     @Test("same-model callers share one mirror and fallback operation")
     func sameModelCallersShareOneDownloadOperation() async throws {
         let root = try makeTemporaryDirectory()
@@ -944,14 +1015,14 @@ struct ModelDownloadCoordinatorTests {
         #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
     }
 
-    @Test("cancelling and waiting permits an immediate fresh model retry")
-    func cancellingAndWaitingPermitsImmediateFreshModelRetry() async throws {
+    @Test("cancelling a model permits an immediate fresh retry")
+    func cancellingModelPermitsImmediateFreshRetry() async throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let data = Data(repeating: 0x7F, count: 512 * 1024)
         let mirrorManifest = try JSONSerialization.data(withJSONObject: [
             "format": "muesli-r2-model-manifest-v1",
-            "modelID": "cancel-and-retry",
+            "modelID": "cancel-and-immediate-retry",
             "version": "mirror-v1",
             "files": [[
                 "relativePath": "model.bin",
@@ -974,13 +1045,91 @@ struct ModelDownloadCoordinatorTests {
                     tracker: modelTracker
                 )
             }
-            Issue.record("Unexpected cancellation-retry request \(url.absoluteString)")
+            Issue.record("Unexpected immediate-cancellation-retry request \(url.absoluteString)")
             return ModelDownloadTestURLProtocol.Response(statusCode: 500)
         }
         defer { ModelDownloadTestURLProtocol.uninstall() }
 
         let plan = ManagedASRModelPlan(
-            modelID: "cancel-and-retry",
+            modelID: "cancel-and-immediate-retry",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let mirrorResolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+        let coordinator = makeCoordinator()
+        let first = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                mirrorResolver: mirrorResolver,
+                coordinator: coordinator
+            )
+        }
+        #expect(modelTracker.waitUntilRequestStarts())
+
+        await ManagedASRModelDownloader.cancel(
+            modelID: plan.modelID,
+            coordinator: coordinator
+        )
+
+        let retry = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                mirrorResolver: mirrorResolver,
+                coordinator: coordinator
+            )
+        }
+        await #expect(throws: CancellationError.self) {
+            _ = try await first.value
+        }
+        let directory = try await retry.value
+        #expect(directory == plan.cacheDirectory)
+        #expect(modelTracker.requestCount == 2)
+        #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
+    }
+
+    @Test("cancelling and waiting permits an immediate fresh model retry")
+    func cancellingAndWaitingPermitsImmediateFreshModelRetry() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = Data(repeating: 0x7F, count: 512 * 1024)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "cancel-and-wait-retry",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": data.count,
+                "sha256": sha256(data),
+            ]],
+        ])
+        let modelTracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(
+                    data: data,
+                    chunkSize: 4 * 1024,
+                    delay: 0.002,
+                    tracker: modelTracker
+                )
+            }
+            Issue.record("Unexpected cancellation-wait-retry request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "cancel-and-wait-retry",
             repository: "acme/asr",
             cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
             selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -1127,7 +1127,10 @@ struct ModelDownloadCoordinatorTests {
 
         #expect(value == "good")
         #expect(attempts.current == 2)
-        #expect(tracker.requestCount == 2)
+        // The repair must list the model and transfer its artifact. Transport
+        // retries are permitted by both stages, so they are not part of this
+        // legacy-cache repair contract.
+        #expect(tracker.requestCount >= 2)
         #expect(plan.isComplete())
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -859,6 +859,91 @@ struct ModelDownloadCoordinatorTests {
         #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
     }
 
+    @Test("cancelling the owner caller preserves a shared model operation")
+    func cancellingOwnerCallerPreservesSharedModelOperation() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = Data(repeating: 0x42, count: 512 * 1024)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "owner-cancellation",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": data.count,
+                "sha256": sha256(data),
+            ]],
+        ])
+        let modelTracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(
+                    data: data,
+                    chunkSize: 4 * 1024,
+                    delay: 0.002,
+                    tracker: modelTracker
+                )
+            }
+            Issue.record("Unexpected owner-cancellation request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "owner-cancellation",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let mirrorResolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+        let coordinator = makeCoordinator()
+        let firstReturned = DownloadCompletionFlag()
+        let first = Task {
+            do {
+                let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+                    plan,
+                    resolver: resolver,
+                    mirrorResolver: mirrorResolver,
+                    coordinator: coordinator
+                )
+                firstReturned.markCompleted()
+                return directory
+            } catch {
+                firstReturned.markCompleted()
+                throw error
+            }
+        }
+        #expect(modelTracker.waitUntilRequestStarts())
+        let second = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                mirrorResolver: mirrorResolver,
+                coordinator: coordinator
+            )
+        }
+        try await Task.sleep(for: .milliseconds(20))
+        first.cancel()
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(firstReturned.isCompleted)
+        let secondDirectory = try await second.value
+        await #expect(throws: CancellationError.self) {
+            try await first.value
+        }
+        #expect(secondDirectory == plan.cacheDirectory)
+        #expect(modelTracker.requestCount == 1)
+        #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
+    }
+
     @Test("cancelling mirror manifest resolution does not fall back to Hugging Face")
     func cancellingMirrorManifestResolutionDoesNotFallBack() async throws {
         let mirrorTracker = DownloadTestTracker()

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -787,6 +787,78 @@ struct ModelDownloadCoordinatorTests {
         ))
     }
 
+    @Test("same-model callers share one mirror and fallback operation")
+    func sameModelCallersShareOneDownloadOperation() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = Data("shared model".utf8)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "acme/asr",
+            "version": "mirror-v1",
+            "files": [[
+                "relativePath": "model.bin",
+                "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                "bytes": data.count,
+                "sha256": sha256(data),
+            ]],
+        ])
+        let mirrorManifestTracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(
+                    data: mirrorManifest,
+                    chunkSize: 1,
+                    delay: 0.001,
+                    tracker: mirrorManifestTracker
+                )
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(data: data)
+            }
+            Issue.record("Unexpected shared-operation request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let mirrorResolver = MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration())
+        let coordinator = makeCoordinator()
+        let first = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                mirrorResolver: mirrorResolver,
+                coordinator: coordinator
+            )
+        }
+        #expect(mirrorManifestTracker.waitUntilRequestStarts())
+        let second = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                mirrorResolver: mirrorResolver,
+                coordinator: coordinator
+            )
+        }
+
+        let firstDirectory = try await first.value
+        let secondDirectory = try await second.value
+        #expect(firstDirectory == plan.cacheDirectory)
+        #expect(secondDirectory == plan.cacheDirectory)
+        #expect(mirrorManifestTracker.requestCount == 1)
+        #expect(try Data(contentsOf: plan.cacheDirectory.appendingPathComponent("model.bin")) == data)
+    }
+
     @Test("cancelling mirror manifest resolution does not fall back to Hugging Face")
     func cancellingMirrorManifestResolutionDoesNotFallBack() async throws {
         let mirrorTracker = DownloadTestTracker()

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -719,6 +719,74 @@ struct ModelDownloadCoordinatorTests {
         #expect(plan.isComplete())
     }
 
+    @Test("failed fallback restores reused files from a mirror cache")
+    func failedFallbackRestoresReusedMirrorCache() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let reusedData = Data("reused mirror artifact".utf8)
+        let mirrorData = Data("mirror model".utf8)
+        let mirrorManifest = try JSONSerialization.data(withJSONObject: [
+            "format": "muesli-r2-model-manifest-v1",
+            "modelID": "acme/asr",
+            "version": "mirror-v1",
+            "files": [
+                [
+                    "relativePath": "a-reused.bin",
+                    "objectKey": "models/acme/asr/mirror-v1/files/a-reused.bin",
+                    "bytes": reusedData.count,
+                    "sha256": sha256(reusedData),
+                ],
+                [
+                    "relativePath": "model.bin",
+                    "objectKey": "models/acme/asr/mirror-v1/files/model.bin",
+                    "bytes": mirrorData.count,
+                    "sha256": sha256(mirrorData),
+                ],
+            ],
+        ])
+        ModelDownloadTestURLProtocol.install { request in
+            guard let url = request.url else { fatalError("Expected request URL") }
+            if url.host == "assets.muesli.works", url.lastPathComponent == "manifest.json" {
+                return ModelDownloadTestURLProtocol.Response(data: mirrorManifest)
+            }
+            if url.host == "assets.muesli.works", url.path.hasSuffix("/files/model.bin") {
+                return ModelDownloadTestURLProtocol.Response(statusCode: 503)
+            }
+            if url.path.contains("/tree/") {
+                return ModelDownloadTestURLProtocol.Response(statusCode: 503)
+            }
+            Issue.record("Unexpected failed fallback request \(url.absoluteString)")
+            return ModelDownloadTestURLProtocol.Response(statusCode: 500)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let plan = ManagedASRModelPlan(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]],
+            mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
+        )
+        let reusedURL = plan.cacheDirectory.appendingPathComponent("a-reused.bin")
+        try FileManager.default.createDirectory(at: plan.cacheDirectory, withIntermediateDirectories: true)
+        try reusedData.write(to: reusedURL)
+
+        await #expect(throws: Error.self) {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+                mirrorResolver: MuesliModelMirrorManifestResolver(configuration: makeSessionConfiguration()),
+                coordinator: makeCoordinator()
+            )
+        }
+
+        #expect(try Data(contentsOf: reusedURL) == reusedData)
+        #expect(!FileManager.default.fileExists(
+            atPath: plan.cacheDirectory.appendingPathComponent("model.bin").path
+        ))
+    }
+
     @Test("cancelling mirror manifest resolution does not fall back to Hugging Face")
     func cancellingMirrorManifestResolutionDoesNotFallBack() async throws {
         let mirrorTracker = DownloadTestTracker()

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -633,6 +633,7 @@ struct ModelDownloadCoordinatorTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let mirroredData = Data("mirror".utf8)
         let fallbackData = Data("fallback".utf8)
+        let fallbackOnlyData = Data("fallback-only".utf8)
         let mirrorOnlyData = Data("mirror-only".utf8)
         let mirrorManifest = try JSONSerialization.data(withJSONObject: [
             "format": "muesli-r2-model-manifest-v1",
@@ -655,6 +656,11 @@ struct ModelDownloadCoordinatorTests {
         ])
         let tree = try JSONSerialization.data(withJSONObject: [[
             "type": "file",
+            "path": "fallback-only.bin",
+            "size": fallbackOnlyData.count,
+            "oid": "fallback-only-oid",
+        ], [
+            "type": "file",
             "path": "model.bin",
             "size": fallbackData.count,
             "oid": "fallback-oid",
@@ -674,6 +680,10 @@ struct ModelDownloadCoordinatorTests {
                 return ModelDownloadTestURLProtocol.Response(data: tree)
             }
             if url.path.contains("/resolve/") {
+                if url.lastPathComponent == "fallback-only.bin" {
+                    #expect(request.value(forHTTPHeaderField: "Range") == nil)
+                    return ModelDownloadTestURLProtocol.Response(data: fallbackOnlyData)
+                }
                 return ModelDownloadTestURLProtocol.Response(data: fallbackData)
             }
             Issue.record("Unexpected transfer fallback request \(url.absoluteString)")
@@ -685,10 +695,14 @@ struct ModelDownloadCoordinatorTests {
             modelID: "acme/asr",
             repository: "acme/asr",
             cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
-            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin", "fallback-only.bin"])],
             requiredArtifactAlternatives: [["model.bin"]],
             mirror: MuesliModelMirror(manifestURL: try #require(URL(string: "https://assets.muesli.works/models/acme/asr/mirror-v1/manifest.json")))
         )
+        let staleFallbackPartialURL = plan.cacheDirectory.appendingPathComponent("fallback-only.bin.part")
+        try FileManager.default.createDirectory(at: plan.cacheDirectory, withIntermediateDirectories: true)
+        try Data("stale fallback bytes".utf8).write(to: staleFallbackPartialURL)
+
         let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
             plan,
             resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
@@ -697,6 +711,8 @@ struct ModelDownloadCoordinatorTests {
         )
 
         #expect(try Data(contentsOf: directory.appendingPathComponent("model.bin")) == fallbackData)
+        #expect(try Data(contentsOf: directory.appendingPathComponent("fallback-only.bin")) == fallbackOnlyData)
+        #expect(!FileManager.default.fileExists(atPath: staleFallbackPartialURL.path))
         #expect(!FileManager.default.fileExists(
             atPath: directory.appendingPathComponent("a-mirror-only.bin").path
         ))

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -492,7 +492,7 @@ struct PostProcessorOptionTests {
     @Test("resolveDownloaded prefers selected downloaded option")
     func resolveDownloadedPrefersSelected() {
         let downloadedIDs: Set<String> = [
-            PostProcessorOption.finetunedV2.id,
+            PostProcessorOption.s1Mini.id,
             PostProcessorOption.qwen35_0_8b.id,
         ]
         #expect(PostProcessorOption.resolveDownloaded(
@@ -503,17 +503,17 @@ struct PostProcessorOptionTests {
 
     @Test("resolveDownloaded falls back to first downloaded option")
     func resolveDownloadedFallsBack() {
-        let downloadedIDs: Set<String> = [PostProcessorOption.finetunedV2.id]
+        let downloadedIDs: Set<String> = [PostProcessorOption.s1Mini.id]
         #expect(PostProcessorOption.resolveDownloaded(
             id: PostProcessorOption.finetunedV3.id,
             downloadedIDs: downloadedIDs
-        ) == PostProcessorOption.finetunedV2)
+        ) == PostProcessorOption.s1Mini)
     }
 
     @Test("runtimeOption prefers selected downloaded option")
     func runtimeOptionPrefersSelectedDownloadedOption() {
         let downloadedIDs: Set<String> = [
-            PostProcessorOption.finetunedV2.id,
+            PostProcessorOption.s1Mini.id,
             PostProcessorOption.qwen35_0_8b.id,
         ]
         #expect(PostProcessorOption.runtimeOption(
@@ -525,12 +525,12 @@ struct PostProcessorOptionTests {
 
     @Test("runtimeOption falls back to first downloaded option")
     func runtimeOptionFallsBackToFirstDownloadedOption() {
-        let downloadedIDs: Set<String> = [PostProcessorOption.finetunedV2.id]
+        let downloadedIDs: Set<String> = [PostProcessorOption.s1Mini.id]
         #expect(PostProcessorOption.runtimeOption(
             id: PostProcessorOption.finetunedV3.id,
             downloadedIDs: downloadedIDs,
             hasDevOverride: false
-        ) == PostProcessorOption.finetunedV2)
+        ) == PostProcessorOption.s1Mini)
     }
 
     @Test("runtimeOption accepts configured option with dev override")
@@ -555,12 +555,12 @@ struct PostProcessorOptionTests {
     func firstDownloadedExcludingDeleted() {
         let downloadedIDs: Set<String> = [
             PostProcessorOption.finetunedV3.id,
-            PostProcessorOption.finetunedV2.id,
+            PostProcessorOption.s1Mini.id,
         ]
         #expect(PostProcessorOption.firstDownloaded(
             excluding: PostProcessorOption.finetunedV3.id,
             downloadedIDs: downloadedIDs
-        ) == PostProcessorOption.finetunedV2)
+        ) == PostProcessorOption.s1Mini)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -489,6 +489,18 @@ struct PostProcessorOptionTests {
         #expect(PostProcessorOption.resolve(id: "missing") == PostProcessorOption.defaultOption)
     }
 
+    @Test("cached legacy v2 remains runnable but is not downloadable")
+    func cachedLegacyV2RemainsRunnable() {
+        #expect(!PostProcessorOption.all.contains(PostProcessorOption.legacyV2))
+        #expect(!PostProcessorOption.legacyV2.isDownloadable)
+        #expect(PostProcessorOption.resolve(id: PostProcessorOption.legacyV2.id) == PostProcessorOption.legacyV2)
+        #expect(PostProcessorOption.runtimeOption(
+            id: PostProcessorOption.legacyV2.id,
+            downloadedIDs: [PostProcessorOption.legacyV2.id],
+            hasDevOverride: false
+        ) == PostProcessorOption.legacyV2)
+    }
+
     @Test("resolveDownloaded prefers selected downloaded option")
     func resolveDownloadedPrefersSelected() {
         let downloadedIDs: Set<String> = [

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -147,11 +147,11 @@ struct FloatingIndicatorVisibilityTests {
     func postProcessorRoundTrip() throws {
         var config = AppConfig()
         config.enablePostProcessor = true
-        config.activePostProcessorId = PostProcessorOption.finetunedV2.id
+        config.activePostProcessorId = PostProcessorOption.finetunedV3.id
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.enablePostProcessor == true)
-        #expect(decoded.activePostProcessorId == PostProcessorOption.finetunedV2.id)
+        #expect(decoded.activePostProcessorId == PostProcessorOption.finetunedV3.id)
     }
 
     @Test("post processor decodes from snake_case JSON")

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -147,11 +147,11 @@ struct FloatingIndicatorVisibilityTests {
     func postProcessorRoundTrip() throws {
         var config = AppConfig()
         config.enablePostProcessor = true
-        config.activePostProcessorId = PostProcessorOption.finetunedV3.id
+        config.activePostProcessorId = PostProcessorOption.qwen35_0_8b.id
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.enablePostProcessor == true)
-        #expect(decoded.activePostProcessorId == PostProcessorOption.finetunedV3.id)
+        #expect(decoded.activePostProcessorId == PostProcessorOption.qwen35_0_8b.id)
     }
 
     @Test("post processor decodes from snake_case JSON")

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -154,6 +154,22 @@ struct FloatingIndicatorVisibilityTests {
         #expect(decoded.activePostProcessorId == PostProcessorOption.qwen35_0_8b.id)
     }
 
+    @Test("cached legacy post processor persists through JSON round-trip")
+    func cachedLegacyPostProcessorRoundTrip() throws {
+        let json = #"{"active_post_processor_id":"qwen3-postproc-v2"}"#
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json.data(using: .utf8)!)
+        #expect(decoded.activePostProcessorId == PostProcessorOption.legacyV2.id)
+
+        let data = try JSONEncoder().encode(decoded)
+        let reloaded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(reloaded.activePostProcessorId == PostProcessorOption.legacyV2.id)
+        #expect(PostProcessorOption.runtimeOption(
+            id: reloaded.activePostProcessorId,
+            downloadedIDs: [PostProcessorOption.legacyV2.id],
+            hasDevOverride: false
+        ) == .legacyV2)
+    }
+
     @Test("post processor decodes from snake_case JSON")
     func postProcessorSnakeCaseDecode() throws {
         let json = #"{"enable_post_processor": true}"#

--- a/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
@@ -159,7 +159,6 @@ struct QuilTransformationTests {
     func localModelCapability() {
         for model in [
             PostProcessorOption.s1Mini,
-            PostProcessorOption.finetunedV2,
             PostProcessorOption.finetunedV3,
         ] {
             #expect(throws: QuilTransformationError.unsupportedModel) {


### PR DESCRIPTION
## Summary

- Prefer checksum-pinned, immutable R2 manifests at `assets.muesli.works` for Parakeet v2, Parakeet v3, Parakeet Unified, and the six mirrored WhisperKit variants.
- Validate the HTTPS origin, manifest schema, model ID, release-local object prefix, safe paths, byte counts, and SHA-256 checksums before any model file is downloaded.
- Fall back to Hugging Face when mirror resolution or transfer fails. A mirror-touched cache is moved aside first, so the fallback starts clean; it is restored if the fallback also fails, preventing both byte mixing and loss of checksum-valid reused files.
- Retire the v2 cleanup-model download while keeping a v2 cache usable until its owner deletes it. The deletion UI now makes that permanence explicit.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/worktrees/a986-r2-mirror/merge-ready-focused --filter 'ModelDownloadCoordinatorTests|FloatingIndicatorVisibilityTests|PostProcessorOptionTests'` — 64 tests passed.
- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/worktrees/a986-r2-mirror/merge-ready-focused --filter 'ModelDownloadCoordinatorTests/(managedDownloadFallsBackWhenMuesliMirrorTransferFails|failedFallbackRestoresReusedMirrorCache|sameModelCallersShareOneDownloadOperation)'` — source-isolation, cache-restoration, and same-model concurrency regressions passed.
- `MUESLI_SWIFTPM_SCRATCH_PATH=/Users/pranavhari/Library/Caches/muesli-spm/worktrees/a986-r2-mirror/merge-ready-core ./scripts/run_ci_test_shard.sh core` — passed.
- Confirmed the deployed Parakeet v2 manifest schema at `https://assets.muesli.works/models/fluidaudio/parakeet-tdt-0.6b-v2/legacy-local-v1/manifest.json`.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

- Model artifacts served by the new mirrors remain the unmodified upstream artifacts from [FluidInference](https://huggingface.co/FluidInference) (Parakeet v2, v3, and Unified) and [argmaxinc/whisperkit-coreml](https://huggingface.co/argmaxinc/whisperkit-coreml) (the listed WhisperKit variants). They are not committed to this repository; their original upstream licenses and terms continue to apply.

### AI assistance

- OpenAI Codex was used for implementation, test authoring, and PR maintenance. The resulting changes and test outcomes were reviewed.
