### PR TITLE
Modernize ChatGPT and OpenRouter authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,32 +27,25 @@ Local build scripts resolve a shared SwiftPM scratch path through `scripts/muesl
 
 - If `MUESLI_SWIFTPM_SCRATCH_PATH` is set, that explicit path wins.
 - If `MUESLI_SWIFTPM_SCRATCH_CHANNEL` is set, scripts use that channel under the resolved cache root.
-- If `MUESLI_EXTERNAL_SPM_CACHE_ROOT` is set, it replaces the default `/Volumes/MuesliBuildCache/muesli-spm` external cache root.
-- Otherwise, if `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
-- Otherwise, scripts fall back to `$HOME/Library/Caches/muesli-spm`.
+- If `MUESLI_EXTERNAL_SPM_CACHE_ROOT` is set, it opts into that explicitly provided cache root when the directory exists.
+- Otherwise, use `$HOME/Library/Caches/muesli-spm`; older resolver versions may still recognize a pre-existing legacy volume, but agents must not attach or create one.
 - Set `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` to intentionally use SwiftPM's package-local `.build`; this takes precedence over all scratch path settings.
 
-The external cache lives in an APFS sparse bundle at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`; attach it before build-heavy work:
-
-```bash
-hdiutil attach /Volumes/eSSD/MuesliBuildCache.sparsebundle
-```
-
-`/Volumes/eSSD/MuesliBuildCache.sparsebundle` is the maintainer's local SSD path. Contributors can substitute their own volume path or skip the attach step; scripts fall back to `~/Library/Caches/muesli-spm` when the external cache is not mounted.
+`$HOME/Library/Caches/muesli-spm` is the canonical maintainer cache. The retired eSSD sparse bundle and `/Volumes/MuesliBuildCache` are no longer part of the local workflow. Use `MUESLI_EXTERNAL_SPM_CACHE_ROOT` only when the user explicitly provides another cache root; do not discover or attach external volumes during ordinary builds.
 
 Default channels:
 
 ```bash
-./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/worktrees/<worktree>/dev when mounted
-./scripts/build_native_app.sh release # /Volumes/MuesliBuildCache/muesli-spm/release when mounted
-./scripts/release-preprod.sh          # /Volumes/MuesliBuildCache/muesli-spm/preprod when mounted
+./scripts/dev-test.sh                 # ~/Library/Caches/muesli-spm/worktrees/<worktree>/dev
+./scripts/build_native_app.sh release # ~/Library/Caches/muesli-spm/release
+./scripts/release-preprod.sh          # ~/Library/Caches/muesli-spm/preprod
 ```
 
 For direct or concurrent worktree builds, pass a specific path:
 
 ```bash
-MUESLI_SWIFTPM_SCRATCH_PATH="/Volumes/MuesliBuildCache/muesli-spm/worktrees/pr182/dev" ./scripts/dev-test.sh
-swift test --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/worktrees/pr182/test"
+MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/worktrees/pr182/dev" ./scripts/dev-test.sh
+swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/pr182/test"
 ```
 
 Caveat: do not run concurrent builds from different worktrees into the same scratch path. Use separate paths per channel, agent, or simultaneous build, such as `worktrees/pr182/dev`, `worktrees/pr188/dev`, or `agent-1`.
@@ -84,5 +77,30 @@ Deleting a scratch path only removes rebuildable SwiftPM artifacts. It does not 
 For direct SwiftPM test runs, pass the scratch path yourself:
 
 ```bash
-swift test --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/test"
+swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"
 ```
+
+## LocalVQE Runtime
+
+Every signed Muesli package, including `MuesliDev`, fixed dev lanes, preproduction, and stable builds, must include a complete LocalVQE runtime. The committed `.gguf` model is not sufficient by itself; packaging also requires `liblocalvqe`, the `libggml` umbrella library, `libggml-base`, and every referenced ggml backend library.
+
+The generated runtime under `native/MuesliNative/LocalVQE/lib/` is gitignored and is not part of the SwiftPM or Xcode cache. A fresh worktree can therefore have a warm build cache while still lacking LocalVQE. Before a signed build:
+
+```bash
+source scripts/localvqe_runtime.sh
+if ! muesli_localvqe_runtime_is_complete native/MuesliNative/LocalVQE/lib; then
+  ./scripts/build_localvqe.sh
+fi
+./scripts/dev-test.sh --lane B
+```
+
+`scripts/build_native_app.sh` fails closed when a signed package lacks the complete runtime. Do not use `MUESLI_ALLOW_MISSING_LOCALVQE=1` for normal dev, preproduction, or release builds; that override is only for explicitly requested unsigned diagnostic packaging.
+
+After packaging, verify the installed bundle rather than assuming the source directory was copied correctly:
+
+```bash
+source scripts/localvqe_runtime.sh
+muesli_localvqe_runtime_is_complete /Applications/MuesliDevB.app/Contents/MacOS
+```
+
+For cross-worktree reuse, prefer a pinned-ref- and architecture-specific runtime under `$HOME/Library/Caches/muesli-localvqe/` and pass it through `MUESLI_LOCALVQE_LIB_DIR`. Until the repository resolves that layout automatically, never copy an unvalidated partial dylib set between worktrees, and do not treat `/tmp/LocalVQE` as durable storage.

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -1139,8 +1139,22 @@ struct CLISummaryConfig: Decodable {
     static func load(from supportDirectory: URL) -> CLISummaryConfig {
         let url = supportDirectory.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: url),
-              let config = try? JSONDecoder().decode(CLISummaryConfig.self, from: data) else {
+              var config = try? JSONDecoder().decode(CLISummaryConfig.self, from: data) else {
             return CLISummaryConfig()
+        }
+        if config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            struct StoredOpenRouterCredential: Decodable {
+                let apiKey: String
+
+                enum CodingKeys: String, CodingKey {
+                    case apiKey = "api_key"
+                }
+            }
+            let credentialURL = supportDirectory.appendingPathComponent("openrouter-auth.json")
+            if let credentialData = try? Data(contentsOf: credentialURL),
+               let credential = try? JSONDecoder().decode(StoredOpenRouterCredential.self, from: credentialData) {
+                config.openRouterAPIKey = credential.apiKey
+            }
         }
         return config
     }

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -1102,19 +1102,19 @@ struct CLISummaryConfig: Decodable {
     var customLLMFormat = "openai"
 
     enum CodingKeys: String, CodingKey {
-        case meetingSummaryBackend
-        case openAIAPIKey
-        case openRouterAPIKey
-        case openAIModel
-        case openRouterModel
-        case ollamaURL
-        case ollamaModel
-        case lmStudioURL
-        case lmStudioModel
-        case customLLMURL
-        case customLLMAPIKey
-        case customLLMModel
-        case customLLMFormat
+        case meetingSummaryBackend = "meeting_summary_backend"
+        case openAIAPIKey = "openai_api_key"
+        case openRouterAPIKey = "openrouter_api_key"
+        case openAIModel = "openai_model"
+        case openRouterModel = "openrouter_model"
+        case ollamaURL = "ollama_url"
+        case ollamaModel = "ollama_model"
+        case lmStudioURL = "lmstudio_url"
+        case lmStudioModel = "lmstudio_model"
+        case customLLMURL = "custom_llm_url"
+        case customLLMAPIKey = "custom_llm_api_key"
+        case customLLMModel = "custom_llm_model"
+        case customLLMFormat = "custom_llm_format"
     }
 
     init() {}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -200,6 +200,8 @@ final class AppState {
     var isVoiceNoteRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false
     var isOpenRouterAuthenticated: Bool = false
+    var isOpenRouterEnvironmentManaged: Bool = false
+    var hasStoredOpenRouterCredential: Bool = false
     var isGoogleCalendarAvailable: Bool = false
     var isGoogleCalendarVerified: Bool = false
     var isGoogleCalendarAuthenticated: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -199,6 +199,7 @@ final class AppState {
     var dictationState: DictationState = .idle
     var isVoiceNoteRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false
+    var isOpenRouterAuthenticated: Bool = false
     var isGoogleCalendarAvailable: Bool = false
     var isGoogleCalendarVerified: Bool = false
     var isGoogleCalendarAuthenticated: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -45,7 +45,7 @@ struct AudioOutputDeviceDescription: Equatable {
     }
 }
 
-struct AudioInputDeviceInfo: Equatable, Identifiable {
+struct AudioInputDeviceInfo: Equatable, Identifiable, Sendable {
     let uid: String
     let name: String
     let deviceID: AudioObjectID
@@ -120,6 +120,10 @@ protocol DictationAudioRouting: AnyObject {
     func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID?
     func meetingInputRouteSnapshot() -> MeetingMicRouteDiagnosticsSnapshot
     func availableInputDevices() -> [AudioInputDeviceInfo]
+    func cachedAvailableInputDevices() -> [AudioInputDeviceInfo]
+    func refreshAvailableInputDevices(
+        completion: @escaping @Sendable ([AudioInputDeviceInfo]) -> Void
+    )
     func isDefaultOutputHeadphoneLike() -> Bool
     func currentOutputRouteKindForDebug() -> AudioOutputRouteKind
     func currentRouteDebugDescription() -> String
@@ -156,6 +160,16 @@ extension DictationAudioRouting {
             systemDefaultInputIsBuiltIn: systemDefaultInputIsBuiltInForDictation()
         )
     }
+
+    func cachedAvailableInputDevices() -> [AudioInputDeviceInfo] {
+        availableInputDevices()
+    }
+
+    func refreshAvailableInputDevices(
+        completion: @escaping @Sendable ([AudioInputDeviceInfo]) -> Void
+    ) {
+        completion(availableInputDevices())
+    }
 }
 
 final class DictationAudioRouteController: DictationAudioRouting {
@@ -166,6 +180,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         var defaultInputDeviceID: AudioObjectID?
         var selectedInputDeviceID: AudioObjectID?
         var selectedMeetingInputDeviceID: AudioObjectID?
+        var availableInputDevices: [AudioInputDeviceInfo] = []
         var inputDeviceNamesByID: [AudioObjectID: String] = [:]
         var inputDeviceIDsByUID: [String: AudioObjectID] = [:]
 
@@ -374,6 +389,24 @@ final class DictationAudioRouteController: DictationAudioRouting {
         inspector.availableInputDevices()
     }
 
+    func cachedAvailableInputDevices() -> [AudioInputDeviceInfo] {
+        lock.withLock { snapshot.availableInputDevices }
+    }
+
+    func refreshAvailableInputDevices(
+        completion: @escaping @Sendable ([AudioInputDeviceInfo]) -> Void
+    ) {
+        queue.async { [weak self] in
+            guard let self else {
+                completion([])
+                return
+            }
+            let next = self.makeRouteSnapshot(refreshingDeviceNames: true)
+            self.replaceRouteSnapshot(next)
+            completion(next.availableInputDevices)
+        }
+    }
+
     func isDefaultOutputHeadphoneLike() -> Bool {
         // Unknown outputs are treated as non-speaker for lifecycle sounds so we
         // avoid playing cues into headphones during CoreAudio route transitions.
@@ -445,25 +478,27 @@ final class DictationAudioRouteController: DictationAudioRouting {
             (
                 selectedInputDeviceUID: selectedInputDeviceUIDStorage,
                 selectedMeetingInputDeviceUID: selectedMeetingInputDeviceUIDStorage,
+                availableInputDevices: snapshot.availableInputDevices,
                 inputDeviceNamesByID: snapshot.inputDeviceNamesByID,
                 inputDeviceIDsByUID: snapshot.inputDeviceIDsByUID
             )
         }
-        let inputDevices = refreshingDeviceNames ? inspector.availableInputDevices() : nil
-        let inputDeviceNamesByID = inputDevices.map { devices in
+        let refreshedInputDevices = refreshingDeviceNames ? inspector.availableInputDevices() : nil
+        let availableInputDevices = refreshedInputDevices ?? cachedRoute.availableInputDevices
+        let inputDeviceNamesByID = refreshedInputDevices.map { devices in
             Dictionary(
                 devices.map { ($0.deviceID, $0.name) },
                 uniquingKeysWith: { first, _ in first }
             )
         } ?? cachedRoute.inputDeviceNamesByID
-        var inputDeviceIDsByUID = inputDevices.map { devices in
+        var inputDeviceIDsByUID = refreshedInputDevices.map { devices in
             Dictionary(
                 devices.map { ($0.uid, $0.deviceID) },
                 uniquingKeysWith: { first, _ in first }
             )
         } ?? cachedRoute.inputDeviceIDsByUID
         let selectedInputDeviceID = cachedRoute.selectedInputDeviceUID.flatMap { uid -> AudioObjectID? in
-            if inputDevices != nil {
+            if refreshedInputDevices != nil {
                 return inputDeviceIDsByUID[uid]
             }
             let deviceID = inspector.inputDeviceID(matchingUID: uid)
@@ -484,6 +519,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
             defaultInputDeviceID: inspector.defaultInputDeviceID(),
             selectedInputDeviceID: selectedInputDeviceID,
             selectedMeetingInputDeviceID: selectedMeetingInputDeviceID,
+            availableInputDevices: availableInputDevices,
             inputDeviceNamesByID: inputDeviceNamesByID,
             inputDeviceIDsByUID: inputDeviceIDsByUID
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -59,7 +59,7 @@ struct UpcomingMeetingEvent {
 /// A calendar exposed by EventKit (iCloud, On-My-Mac, Exchange, an Internet
 /// Account–linked Google calendar, etc.). Used by Settings to show which
 /// calendars Muesli is reading from and to drive per-calendar enable/disable.
-struct AvailableCalendar: Identifiable, Equatable {
+struct AvailableCalendar: Identifiable, Equatable, Sendable {
     let id: String           // EKCalendar.calendarIdentifier
     let title: String
     let sourceTitle: String  // e.g. "iCloud", "spencer@dockstreet.com"
@@ -313,7 +313,9 @@ final class CalendarMonitor {
     /// Exchange, and any Google account linked via System Settings > Internet
     /// Accounts. Used by Settings to surface which calendars Muesli is reading
     /// from and to power per-calendar enable/disable.
-    func availableCalendars() -> [AvailableCalendar] {
+    /// Produces a value-only snapshot so EventKit objects never cross the
+    /// background boundary used by Settings and calendar-monitor refreshes.
+    static func availableCalendars() -> [AvailableCalendar] {
         let freshStore = EKEventStore()
         return freshStore.calendars(for: .event)
             .map { cal in

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTAuthManager.swift
@@ -127,7 +127,7 @@ final class ChatGPTAuthManager {
             URLQueryItem(name: "code_challenge_method", value: "S256"),
             URLQueryItem(name: "id_token_add_organizations", value: "true"),
             URLQueryItem(name: "codex_cli_simplified_flow", value: "true"),
-            URLQueryItem(name: "originator", value: "opencode"),
+            URLQueryItem(name: "originator", value: "muesli"),
         ]
         return components.url
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -66,7 +66,6 @@ enum ChatGPTResponsesTransport {
         if backend == .codex {
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
             request.setValue(originator, forHTTPHeaderField: "originator")
-            request.setValue(appVersion, forHTTPHeaderField: "version")
             request.setValue("Muesli/\(appVersion)", forHTTPHeaderField: "User-Agent")
             request.setValue(sessionID.uuidString.lowercased(), forHTTPHeaderField: "session_id")
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -11,10 +11,71 @@ enum ChatGPTResponsesError: LocalizedError {
     }
 }
 
-enum ChatGPTResponsesClient {
-    private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
-    private static let requestTimeout: TimeInterval = 120
+/// Shared request construction for ChatGPT-authenticated Responses calls.
+///
+/// Muesli routes its existing ChatGPT OAuth credentials to the Codex inference
+/// lane. That direct third-party contract is compatibility-sensitive, so keep
+/// request metadata centralized and the client identity honest: these headers
+/// describe Muesli and never impersonate an official Codex client. WHAM remains
+/// available only as an explicit, process-level emergency rollback.
+enum ChatGPTResponsesTransport {
+    enum Backend: Equatable {
+        case codex
+        case wham
 
+        var responsesURL: URL {
+            switch self {
+            case .codex:
+                return URL(string: "https://chatgpt.com/backend-api/codex/responses")!
+            case .wham:
+                return URL(string: "https://chatgpt.com/backend-api/wham/responses")!
+            }
+        }
+    }
+
+    static let environmentKey = "MUESLI_CHATGPT_TRANSPORT"
+    static let requestTimeout: TimeInterval = 120
+    static let originator = "muesli"
+
+    static func selectedBackend(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Backend {
+        let requested = environment[environmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return requested == "wham" ? .wham : .codex
+    }
+
+    static func makeRequest(
+        body: [String: Any],
+        token: String,
+        accountId: String,
+        appVersion: String = AppIdentity.marketingVersion,
+        sessionID: UUID = UUID(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> URLRequest {
+        let backend = selectedBackend(environment: environment)
+        var request = URLRequest(url: backend.responsesURL)
+        request.timeoutInterval = requestTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        if backend == .codex {
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            request.setValue(originator, forHTTPHeaderField: "originator")
+            request.setValue(appVersion, forHTTPHeaderField: "version")
+            request.setValue("Muesli/\(appVersion)", forHTTPHeaderField: "User-Agent")
+            request.setValue(sessionID.uuidString.lowercased(), forHTTPHeaderField: "session_id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+}
+
+enum ChatGPTResponsesClient {
     static func respond(
         systemPrompt: String,
         userPrompt: String,
@@ -30,15 +91,11 @@ enum ChatGPTResponsesClient {
             maxOutputTokens: maxOutputTokens
         )
 
-        var request = URLRequest(url: whamURL)
-        request.timeoutInterval = requestTimeout
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        if !accountId.isEmpty {
-            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
-        }
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let request = try ChatGPTResponsesTransport.makeRequest(
+            body: body,
+            token: token,
+            accountId: accountId
+        )
 
         let (bytes, response) = try await URLSession.shared.bytes(for: request)
         let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
@@ -48,7 +105,7 @@ enum ChatGPTResponsesClient {
             let message = extractErrorMessage(from: errorData)
                 ?? String(data: errorData, encoding: .utf8)
                 ?? "(unknown)"
-            fputs("[\(logCategory)] ChatGPT WHAM: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
+            fputs("[\(logCategory)] ChatGPT Responses: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
             throw ChatGPTResponsesError.backendFailed(statusCode: httpStatus, message: message)
         }
 
@@ -65,7 +122,7 @@ enum ChatGPTResponsesClient {
 
         let fullText = accumulatedOutputText(deltaText: deltaText, finalText: finalText)
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-        fputs("[\(logCategory)] ChatGPT WHAM: collected \(trimmed.count) chars\n", stderr)
+        fputs("[\(logCategory)] ChatGPT Responses: collected \(trimmed.count) chars\n", stderr)
         return trimmed
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
@@ -24,7 +24,6 @@ enum ComputerUsePlannerError: LocalizedError, Equatable {
 }
 
 enum ComputerUsePlannerClient {
-    private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     static let defaultModel = "gpt-5.6-sol"
 
     static var instructions: String {
@@ -64,7 +63,7 @@ enum ComputerUsePlannerClient {
         config: AppConfig
     ) async throws -> ComputerUsePlannerResponse {
         do {
-            return try await callWHAM(
+            return try await callChatGPTResponses(
                 systemPrompt: instructions,
                 userPrompt: requestPrompt(for: request),
                 imageDataURL: request.latestWindowState.screenshot?.imageDataURL,
@@ -93,7 +92,7 @@ enum ComputerUsePlannerClient {
         return String(data: data, encoding: .utf8) ?? "{}"
     }
 
-    private static func callWHAM(
+    private static func callChatGPTResponses(
         systemPrompt: String,
         userPrompt: String,
         imageDataURL: String?,
@@ -107,14 +106,11 @@ enum ComputerUsePlannerClient {
             model: model
         )
 
-        var urlRequest = URLRequest(url: whamURL)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        if !accountId.isEmpty {
-            urlRequest.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
-        }
-        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let urlRequest = try ChatGPTResponsesTransport.makeRequest(
+            body: body,
+            token: token,
+            accountId: accountId
+        )
 
         let (bytes, response) = try await URLSession.shared.bytes(for: urlRequest)
         let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0

--- a/native/MuesliNative/Sources/MuesliNativeApp/ConfigStore.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ConfigStore.swift
@@ -3,11 +3,13 @@ import MuesliCore
 
 final class ConfigStore {
     private let configURL: URL
+    private let openRouterCredentialStore: OpenRouterCredentialStore
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
     init(supportDirectory: URL = AppIdentity.supportDirectoryURL) {
         self.configURL = supportDirectory.appendingPathComponent("config.json")
+        self.openRouterCredentialStore = OpenRouterCredentialStore(supportDirectory: supportDirectory)
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     }
 
@@ -16,11 +18,25 @@ final class ConfigStore {
         guard let data = try? Data(contentsOf: configURL) else {
             return AppConfig()
         }
-        return (try? decoder.decode(AppConfig.self, from: data)) ?? AppConfig()
+        var config = (try? decoder.decode(AppConfig.self, from: data)) ?? AppConfig()
+        let hadLegacyOpenRouterKey = !config.openRouterAPIKey
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+        migrateLegacyOpenRouterCredential(in: &config)
+        if hadLegacyOpenRouterKey, config.openRouterAPIKey.isEmpty {
+            write(config)
+        }
+        return config
     }
 
     func save(_ config: AppConfig) {
         ensureDirectory()
+        var persistedConfig = config
+        migrateLegacyOpenRouterCredential(in: &persistedConfig)
+        write(persistedConfig)
+    }
+
+    private func write(_ config: AppConfig) {
         guard let data = try? encoder.encode(config) else { return }
         do {
             try data.write(to: configURL, options: .atomic)
@@ -30,6 +46,30 @@ final class ConfigStore {
             )
         } catch {
             fputs("[config-store] failed to save config: \(error)\n", stderr)
+        }
+    }
+
+    /// Moves the legacy config.json key into the dedicated owner-only
+    /// credential file. If that write fails, keep the old value in config so
+    /// migration can retry without losing the user's credential.
+    private func migrateLegacyOpenRouterCredential(in config: inout AppConfig) {
+        let legacyKey = config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !legacyKey.isEmpty else { return }
+        do {
+            if let existingCredential = try openRouterCredentialStore.load(),
+               !existingCredential.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                // A dedicated credential may have been created after this stale
+                // config value was written. Keep the newer destination value and
+                // only remove the legacy duplicate from config.json.
+                config.openRouterAPIKey = ""
+                return
+            }
+            try openRouterCredentialStore.save(
+                OpenRouterCredential(apiKey: legacyKey, userID: nil)
+            )
+            config.openRouterAPIKey = ""
+        } catch {
+            fputs("[config-store] failed to migrate OpenRouter credential\n", stderr)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -1346,7 +1346,9 @@ struct MeetingDetailView: View {
         } else if appState.selectedMeetingSummaryBackend == .customLLM {
             return MeetingSummaryClient.customLLMHasRequiredSettings(config: config)
         } else {
-            return !config.openRouterAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
+            return !OpenRouterCredentialResolver.resolvedAPIKey(
+                legacyAPIKey: config.openRouterAPIKey
+            ).isEmpty
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -160,7 +160,8 @@ enum MeetingSummaryClient {
         existingNotes: String? = nil,
         manualNotesToRetain: String? = nil,
         visualContext: String? = nil,
-        previousMeetingNotes: String? = nil
+        previousMeetingNotes: String? = nil,
+        openRouterAPIKeyOverride: String? = nil
     ) async throws -> String {
         try await withSummaryRetries(maxRetries: config.meetingSummaryRetryCount) {
             try await summarizeOnce(
@@ -171,7 +172,8 @@ enum MeetingSummaryClient {
                 existingNotes: existingNotes,
                 manualNotesToRetain: manualNotesToRetain,
                 visualContext: visualContext,
-                previousMeetingNotes: previousMeetingNotes
+                previousMeetingNotes: previousMeetingNotes,
+                openRouterAPIKeyOverride: openRouterAPIKeyOverride
             )
         }
     }
@@ -211,7 +213,8 @@ enum MeetingSummaryClient {
         existingNotes: String?,
         manualNotesToRetain: String?,
         visualContext: String?,
-        previousMeetingNotes: String?
+        previousMeetingNotes: String?,
+        openRouterAPIKeyOverride: String?
     ) async throws -> String {
         let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.chatGPT.backend : config.meetingSummaryBackend).lowercased()
         let generatedNotes: String
@@ -237,7 +240,8 @@ enum MeetingSummaryClient {
                 config: config,
                 template: template,
                 visualContext: visualContext,
-                previousMeetingNotes: previousMeetingNotes
+                previousMeetingNotes: previousMeetingNotes,
+                apiKeyOverride: openRouterAPIKeyOverride
             )
             return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
         }
@@ -532,9 +536,12 @@ enum MeetingSummaryClient {
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil,
-        previousMeetingNotes: String? = nil
+        previousMeetingNotes: String? = nil,
+        apiKeyOverride: String? = nil
     ) async throws -> String {
-        let apiKey = ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] ?? config.openRouterAPIKey
+        let apiKey = apiKeyOverride ?? OpenRouterCredentialResolver.resolvedAPIKey(
+            legacyAPIKey: config.openRouterAPIKey
+        )
         guard !apiKey.isEmpty else {
             return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
         }
@@ -1097,11 +1104,25 @@ enum MeetingSummaryClient {
         return false
     }
 
-    static func generateTitle(transcript: String, config: AppConfig) async -> String? {
-        await generateTitle(transcript: transcript, manualNotes: nil, config: config)
+    static func generateTitle(
+        transcript: String,
+        config: AppConfig,
+        openRouterAPIKeyOverride: String? = nil
+    ) async -> String? {
+        await generateTitle(
+            transcript: transcript,
+            manualNotes: nil,
+            config: config,
+            openRouterAPIKeyOverride: openRouterAPIKeyOverride
+        )
     }
 
-    static func generateTitle(transcript: String, manualNotes: String?, config: AppConfig) async -> String? {
+    static func generateTitle(
+        transcript: String,
+        manualNotes: String?,
+        config: AppConfig,
+        openRouterAPIKeyOverride: String? = nil
+    ) async -> String? {
         let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.chatGPT.backend : config.meetingSummaryBackend).lowercased()
 
         let excerpt = titlePrompt(transcript: transcript, manualNotes: manualNotes)
@@ -1111,7 +1132,9 @@ enum MeetingSummaryClient {
         }
 
         if backend == MeetingSummaryBackendOption.openRouter.backend {
-            let apiKey = ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] ?? config.openRouterAPIKey
+            let apiKey = openRouterAPIKeyOverride ?? OpenRouterCredentialResolver.resolvedAPIKey(
+                legacyAPIKey: config.openRouterAPIKey
+            )
             guard !apiKey.isEmpty else { return nil }
             let configuredModel = config.openRouterModel.trimmingCharacters(in: .whitespacesAndNewlines)
             let model = configuredModel.isEmpty ? defaultOpenRouterModel : configuredModel

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -650,6 +650,12 @@ struct OpenRouterModelCatalog: Decodable {
     let data: [OpenRouterModel]
 }
 
+enum OpenRouterModelSelection {
+    static func persistedModelID(for selectedID: String) -> String {
+        selectedID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 struct OpenRouterModel: Decodable {
     let id: String
     let name: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3359,11 +3359,14 @@ public final class MuesliController: NSObject {
         syncAppState()
     }
 
-    /// Refresh the EventKit-available calendars list. Cheap (no network), safe
-    /// to call frequently — driven by Settings panel onAppear and by the
-    /// EKEventStoreChangedNotification handler.
-    func refreshAvailableEventKitCalendars() {
-        appState.availableEventKitCalendars = calendarMonitor.availableCalendars()
+    /// Refresh the EventKit-available calendars list without making the main
+    /// actor wait for EventKit's synchronous calendar-store enumeration.
+    func refreshAvailableEventKitCalendars() async {
+        let calendars = await Task.detached(priority: .utility) {
+            CalendarMonitor.availableCalendars()
+        }.value
+        guard !Task.isCancelled else { return }
+        appState.availableEventKitCalendars = calendars
     }
 
     /// Refresh the Google calendar list via the Calendar API. No-op when OAuth
@@ -3518,7 +3521,7 @@ public final class MuesliController: NSObject {
         calendarMonitor.onCalendarChanged = { [weak self] in
             guard let self else { return }
             Task { @MainActor in
-                self.refreshAvailableEventKitCalendars()
+                await self.refreshAvailableEventKitCalendars()
                 let refreshed = await self.refreshUpcomingCalendarEvents()
                 guard refreshed else { return }
                 await self.reconcilePendingEventKitCalendarAttendees(
@@ -3540,7 +3543,7 @@ public final class MuesliController: NSObject {
             guard let self else { return }
             Task { @MainActor in
                 self.calendarMonitor.start()
-                self.refreshAvailableEventKitCalendars()
+                await self.refreshAvailableEventKitCalendars()
                 let refreshed = await self.refreshUpcomingCalendarEvents()
                 guard refreshed else { return }
                 self.checkUpcomingCalendarNotifications()
@@ -3551,7 +3554,7 @@ public final class MuesliController: NSObject {
         // Run one initial reconciliation so changes made while Muesli was not
         // running are reflected without waiting for another EventKit change.
         Task { @MainActor in
-            self.refreshAvailableEventKitCalendars()
+            await self.refreshAvailableEventKitCalendars()
             let refreshed = await self.refreshUpcomingCalendarEvents()
             guard refreshed else { return }
             await self.reconcilePendingEventKitCalendarAttendees(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -399,6 +399,7 @@ public final class MuesliController: NSObject {
     private let meetingSourceWindowLocator = MeetingSourceWindowLocator()
 
     private let chatGPTAuth = ChatGPTAuthManager.shared
+    private let openRouterAuth: OpenRouterAuthManager
     private let googleCalAuth = GoogleCalendarAuthManager.shared
     private let googleCalClient = GoogleCalendarClient()
     private var calendarCheckTimer: Timer?
@@ -545,9 +546,11 @@ public final class MuesliController: NSObject {
         meetingMarkdownAutoExporter: MeetingMarkdownAutoExporting = MeetingMarkdownAutoExporter(),
         launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager(),
         audioDuckingController: AudioDuckingManaging = AudioDuckingController(),
-        dictationAudioRoutingController: DictationAudioRouting = DictationAudioRouteController()
+        dictationAudioRoutingController: DictationAudioRouting = DictationAudioRouteController(),
+        openRouterAuth: OpenRouterAuthManager? = nil
     ) {
         self.configStore = configStore
+        self.openRouterAuth = openRouterAuth ?? .shared
         var loadedConfig = configStore.load()
         let loadedBackend = BackendOption.all.first(where: {
             $0.backend == loadedConfig.sttBackend && $0.model == loadedConfig.sttModel
@@ -1343,6 +1346,7 @@ public final class MuesliController: NSObject {
         appState.activeMeetingAudioWarning = activeMeetingAudioWarning
         indicator.setMeetingRecordingPaused(appState.isMeetingRecordingPaused, config: config)
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
+        appState.isOpenRouterAuthenticated = openRouterAuth.isAuthenticated
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
         appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
@@ -1620,6 +1624,7 @@ public final class MuesliController: NSObject {
         appState.selectedPostProcessorBackend = selectedPostProcessorBackend
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
+        appState.isOpenRouterAuthenticated = openRouterAuth.isAuthenticated
         syncCalendarMonitor()
         syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
@@ -3255,6 +3260,67 @@ public final class MuesliController: NSObject {
         syncAppState()
     }
 
+    /// Returns nil on success, or an error message on failure.
+    func signInWithOpenRouter(
+        selectMeetingSummaryBackend shouldSelectMeetingSummaryBackend: Bool = true
+    ) async -> String? {
+        do {
+            try await openRouterAuth.signIn()
+            if shouldSelectMeetingSummaryBackend {
+                selectMeetingSummaryBackend(.openRouter)
+            }
+            syncAppState()
+            return nil
+        } catch {
+            fputs("[muesli-native] OpenRouter sign-in failed: \(error.localizedDescription)\n", stderr)
+            return error.localizedDescription
+        }
+    }
+
+    /// Stores a legacy/manual OpenRouter key in the same protected credential
+    /// file used by the browser sign-in flow.
+    func storeManualOpenRouterAPIKey(
+        _ apiKey: String,
+        selectMeetingSummaryBackend shouldSelectMeetingSummaryBackend: Bool = true
+    ) -> String? {
+        do {
+            try openRouterAuth.storeManualAPIKey(apiKey)
+            if shouldSelectMeetingSummaryBackend {
+                selectMeetingSummaryBackend(.openRouter)
+            }
+            syncAppState()
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    func signOutOpenRouter() {
+        openRouterAuth.signOut()
+
+        if selectedMeetingSummaryBackend == .openRouter {
+            // Match ChatGPT sign-out: move summaries to the existing API-key fallback.
+            selectMeetingSummaryBackend(.openAI)
+        }
+        if selectedPostProcessorBackend == .hosted(.openRouter) {
+            // Reuse the cleanup selector so local-model availability and the
+            // enabled state are normalized exactly as for a manual switch.
+            selectPostProcessorBackend(.local)
+        }
+        if TranscriptCleanupBackendOption.resolved(config.quilBackend) == .hosted(.openRouter) {
+            updateConfig {
+                $0.quilBackend = TranscriptCleanupBackendOption.local.backend
+                $0.quilModel = PostProcessorOption.defaultQuilOption.id
+            }
+        }
+        syncAppState()
+    }
+
+    func manageOpenRouterKey() {
+        guard let url = openRouterAuth.manageKeyURL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
     // MARK: - Google Calendar
 
     func signInWithGoogleCalendar() async -> String? {
@@ -4467,6 +4533,15 @@ public final class MuesliController: NSObject {
         summaryBackend: MeetingSummaryBackendOption?,
         apiKey: String?
     ) {
+        var shouldRetainLegacyOpenRouterKey = false
+        if summaryBackend == .openRouter,
+           let apiKey,
+           !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            shouldRetainLegacyOpenRouterKey = storeManualOpenRouterAPIKey(
+                apiKey,
+                selectMeetingSummaryBackend: false
+            ) != nil
+        }
         updateConfig { config in
             config.hasCompletedOnboarding = true
             config.userName = userName
@@ -4486,10 +4561,12 @@ public final class MuesliController: NSObject {
             if let apiKey, !apiKey.isEmpty {
                 if summaryBackend == .openAI {
                     config.openAIAPIKey = apiKey
-                } else if summaryBackend == .openRouter {
+                } else if summaryBackend == .openRouter,
+                          shouldRetainLegacyOpenRouterKey {
+                    // ConfigStore retries the migration and preserves this
+                    // fallback if protected credential storage remains unavailable.
                     config.openRouterAPIKey = apiKey
                 }
-                // ChatGPT backend uses OAuth tokens stored in app support dir, not an API key
             }
         }
         selectBackend(backend)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1347,6 +1347,8 @@ public final class MuesliController: NSObject {
         indicator.setMeetingRecordingPaused(appState.isMeetingRecordingPaused, config: config)
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isOpenRouterAuthenticated = openRouterAuth.isAuthenticated
+        appState.isOpenRouterEnvironmentManaged = openRouterAuth.hasEnvironmentCredential
+        appState.hasStoredOpenRouterCredential = openRouterAuth.hasStoredCredential
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
         appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
@@ -1625,6 +1627,8 @@ public final class MuesliController: NSObject {
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isOpenRouterAuthenticated = openRouterAuth.isAuthenticated
+        appState.isOpenRouterEnvironmentManaged = openRouterAuth.hasEnvironmentCredential
+        appState.hasStoredOpenRouterCredential = openRouterAuth.hasStoredCredential
         syncCalendarMonitor()
         syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
@@ -3303,8 +3307,18 @@ public final class MuesliController: NSObject {
         }
     }
 
-    func signOutOpenRouter() {
-        openRouterAuth.signOut()
+    func signOutOpenRouter() -> String? {
+        do {
+            try openRouterAuth.signOut()
+        } catch {
+            syncAppState()
+            return error.localizedDescription
+        }
+
+        guard !openRouterAuth.isAuthenticated else {
+            syncAppState()
+            return nil
+        }
 
         if selectedMeetingSummaryBackend == .openRouter {
             // Match ChatGPT sign-out: move summaries to the existing API-key fallback.
@@ -3322,6 +3336,7 @@ public final class MuesliController: NSObject {
             }
         }
         syncAppState()
+        return nil
     }
 
     func manageOpenRouterKey() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2680,8 +2680,16 @@ public final class MuesliController: NSObject {
         return "\(counts.total) (\(parts.joined(separator: ", ")))"
     }
 
-    func availableDictationInputDevices() -> [AudioInputDeviceInfo] {
-        dictationAudioRoutingController.availableInputDevices()
+    func cachedDictationInputDevices() -> [AudioInputDeviceInfo] {
+        dictationAudioRoutingController.cachedAvailableInputDevices()
+    }
+
+    func refreshDictationInputDevices() async -> [AudioInputDeviceInfo] {
+        await withCheckedContinuation { continuation in
+            dictationAudioRoutingController.refreshAvailableInputDevices { devices in
+                continuation.resume(returning: devices)
+            }
+        }
     }
 
     func selectDictationInputDeviceUID(_ uid: String?) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -17,6 +17,10 @@ struct OnboardingView: View {
     @State private var isSigningInChatGPT = false
     @State private var chatGPTSignInDone = false
     @State private var chatGPTSignInError: String?
+    @State private var isSigningInOpenRouter = false
+    @State private var openRouterSignInDone = false
+    @State private var openRouterSignInError: String?
+    @State private var isEnteringOpenRouterAPIKey = false
 
     // Permission states — polled from OS every second
     @State private var micGranted = false
@@ -1574,13 +1578,84 @@ struct OnboardingView: View {
                             .foregroundStyle(MuesliTheme.success)
                     }
                 }
-            } else {
-                if summaryBackend == .openRouter {
-                    Text("OpenRouter supports many model providers through one API key.")
-                        .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                }
+            } else if summaryBackend == .openRouter {
+                Text("Connect OpenRouter in your browser. Muesli receives a dedicated API key after you approve access.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .multilineTextAlignment(.center)
 
+                if appState.isOpenRouterAuthenticated || openRouterSignInDone {
+                    HStack(spacing: 6) {
+                        Image(systemName: "network")
+                            .font(.system(size: 13, weight: .semibold))
+                        Text("OpenRouter connected")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(MuesliTheme.success)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                } else if isSigningInOpenRouter {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Connecting...")
+                            .font(.system(size: 12))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+                } else {
+                    Button {
+                        isSigningInOpenRouter = true
+                        openRouterSignInError = nil
+                        apiKey = ""
+                        isEnteringOpenRouterAPIKey = false
+                        Task {
+                            let error = await controller.signInWithOpenRouter()
+                            isSigningInOpenRouter = false
+                            openRouterSignInDone = OpenRouterAuthManager.shared.isAuthenticated
+                            openRouterSignInError = error
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "network")
+                                .font(.system(size: 13, weight: .semibold))
+                            Text("Connect OpenRouter")
+                                .font(.system(size: 13, weight: .medium))
+                        }
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(MuesliTheme.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(isEnteringOpenRouterAPIKey ? "Cancel manual key" : "Enter API key manually") {
+                        isEnteringOpenRouterAPIKey.toggle()
+                        apiKey = ""
+                        openRouterSignInError = nil
+                    }
+                    .buttonStyle(.link)
+                    .font(.system(size: 11))
+
+                    if isEnteringOpenRouterAPIKey {
+                        PastableSecureField(
+                            text: apiKey,
+                            placeholder: "sk-or-...",
+                            onChange: { apiKey = $0 }
+                        )
+                        .frame(width: 320, height: 28)
+                    }
+
+                    if let openRouterSignInError {
+                        Text(openRouterSignInError)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+                }
+            } else {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                     Text("API Key")
                         .font(MuesliTheme.caption())
@@ -1588,7 +1663,7 @@ struct OnboardingView: View {
 
                     PastableSecureField(
                         text: apiKey,
-                        placeholder: summaryBackend == .openAI ? "sk-..." : "sk-or-...",
+                        placeholder: "sk-...",
                         onChange: { apiKey = $0 }
                     )
                     .frame(width: 320, height: 28)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterAuthManager.swift
@@ -1,0 +1,544 @@
+import AppKit
+import CryptoKit
+import Foundation
+import Network
+import Security
+
+enum OpenRouterAuthError: Error, LocalizedError, Equatable {
+    case notAuthenticated
+    case callbackServerFailed
+    case callbackTimeout
+    case callbackRejected(String)
+    case callbackMissingCode
+    case invalidCallback
+    case couldNotOpenBrowser
+    case keyExchangeFailed(statusCode: Int?)
+    case invalidKeyExchangeResponse
+    case credentialStorageFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "Not connected to OpenRouter"
+        case .callbackServerFailed:
+            return "Could not start the OpenRouter sign-in callback server"
+        case .callbackTimeout:
+            return "OpenRouter sign-in timed out — please try again"
+        case .callbackRejected(let reason):
+            return "OpenRouter sign-in was not completed: \(reason)"
+        case .callbackMissingCode:
+            return "OpenRouter callback did not include an authorization code"
+        case .invalidCallback:
+            return "Received an invalid OpenRouter sign-in callback"
+        case .couldNotOpenBrowser:
+            return "Could not open OpenRouter sign-in in the browser"
+        case .keyExchangeFailed(let statusCode):
+            if let statusCode {
+                return "OpenRouter key exchange failed (HTTP \(statusCode))"
+            }
+            return "OpenRouter key exchange failed"
+        case .invalidKeyExchangeResponse:
+            return "OpenRouter key exchange returned an invalid response"
+        case .credentialStorageFailed:
+            return "Could not store the OpenRouter credential"
+        }
+    }
+}
+
+/// An OpenRouter OAuth exchange creates a normal, user-controlled API key.
+/// It does not create refreshable OAuth access and refresh tokens.
+struct OpenRouterCredential: Codable, Equatable, Sendable {
+    let apiKey: String
+    let userID: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case apiKey = "api_key"
+        case userID = "user_id"
+    }
+}
+
+struct OpenRouterCredentialStore {
+    let fileURL: URL
+
+    init(supportDirectory: URL = AppIdentity.supportDirectoryURL) {
+        fileURL = supportDirectory.appendingPathComponent("openrouter-auth.json")
+    }
+
+    func load() throws -> OpenRouterCredential? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(OpenRouterCredential.self, from: data)
+    }
+
+    func save(_ credential: OpenRouterCredential) throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        let data = try JSONEncoder().encode(credential)
+        try data.write(to: fileURL, options: [.atomic])
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: fileURL.path
+        )
+
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var credentialURL = fileURL
+        try credentialURL.setResourceValues(resourceValues)
+    }
+
+    func delete() throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        try FileManager.default.removeItem(at: fileURL)
+    }
+}
+
+enum OpenRouterCredentialResolver {
+    /// Environment variables intentionally win for automation and local
+    /// development. The config value is a read-only compatibility fallback
+    /// until ConfigStore migrates it to the dedicated credential file.
+    static func resolvedAPIKey(
+        legacyAPIKey: String = "",
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        credentialStore: OpenRouterCredentialStore = OpenRouterCredentialStore()
+    ) -> String {
+        let environmentKey = environment["OPENROUTER_API_KEY"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !environmentKey.isEmpty { return environmentKey }
+
+        if let credential = try? credentialStore.load(),
+           !credential.apiKey.isEmpty {
+            return credential.apiKey
+        }
+
+        return legacyAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+@MainActor
+final class OpenRouterAuthManager {
+    static let shared = OpenRouterAuthManager()
+
+    static let callbackTimeoutSeconds: TimeInterval = 600
+
+    nonisolated private static let authorizationEndpoint = URL(string: "https://openrouter.ai/auth")!
+    nonisolated private static let keyExchangeEndpoint = URL(
+        string: "https://openrouter.ai/api/v1/auth/keys"
+    )!
+
+    private let credentialStore: OpenRouterCredentialStore
+    private let loadData: (URLRequest) async throws -> (Data, URLResponse)
+    private let openURL: (URL) -> Bool
+
+    init(
+        credentialStore: OpenRouterCredentialStore = OpenRouterCredentialStore(),
+        loadData: @escaping (URLRequest) async throws -> (Data, URLResponse) = {
+            try await URLSession.shared.data(for: $0)
+        },
+        openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) }
+    ) {
+        self.credentialStore = credentialStore
+        self.loadData = loadData
+        self.openURL = openURL
+    }
+
+    var isAuthenticated: Bool {
+        do {
+            guard let credential = try credentialStore.load() else { return false }
+            return !credential.apiKey.isEmpty
+        } catch {
+            return false
+        }
+    }
+
+    func credential() throws -> OpenRouterCredential {
+        guard let credential = try credentialStore.load(), !credential.apiKey.isEmpty else {
+            throw OpenRouterAuthError.notAuthenticated
+        }
+        return credential
+    }
+
+    func apiKey() throws -> String {
+        try credential().apiKey
+    }
+
+    func signIn() async throws {
+        let (verifier, challenge) = generatePKCE()
+        let authorizationCode = try await waitForAuthorizationCode(codeChallenge: challenge)
+        let credential = try await exchangeAuthorizationCode(
+            authorizationCode,
+            codeVerifier: verifier
+        )
+
+        do {
+            try credentialStore.save(credential)
+        } catch {
+            throw OpenRouterAuthError.credentialStorageFailed
+        }
+    }
+
+    /// Removes only Muesli's local credential. The user-controlled key remains
+    /// active at OpenRouter until the user deletes it from OpenRouter's key page.
+    func signOut() {
+        do {
+            try credentialStore.delete()
+        } catch {
+            // Sign-out has local-only semantics. Avoid reflecting file paths or
+            // credential material into logs; the next state sync will still
+            // accurately report whether a credential remains.
+        }
+    }
+
+    func storeManualAPIKey(_ apiKey: String) throws {
+        let normalizedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedKey.isEmpty else { throw OpenRouterAuthError.notAuthenticated }
+        do {
+            try credentialStore.save(OpenRouterCredential(apiKey: normalizedKey, userID: nil))
+        } catch {
+            throw OpenRouterAuthError.credentialStorageFailed
+        }
+    }
+
+    func resolvedAPIKey(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        OpenRouterCredentialResolver.resolvedAPIKey(
+            environment: environment,
+            credentialStore: credentialStore
+        )
+    }
+
+    var manageKeyURL: URL? {
+        guard let credential = try? credential() else { return nil }
+        return Self.manageKeyURL(for: credential.apiKey)
+    }
+
+    nonisolated static func manageKeyURL(for apiKey: String) -> URL {
+        let digest = SHA256.hash(data: Data(apiKey.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return URL(string: "https://openrouter.ai/keys/\(digest)")!
+    }
+
+    // MARK: - PKCE and authorization URL
+
+    func generatePKCE() -> (verifier: String, challenge: String) {
+        let verifier = randomBase64URL(byteCount: 32)
+        let challenge = Data(SHA256.hash(data: Data(verifier.utf8))).base64URLEncoded()
+        return (verifier, challenge)
+    }
+
+    func generateCallbackPath() -> String {
+        "/muesli/openrouter/oauth/\(randomBase64URL(byteCount: 32))"
+    }
+
+    nonisolated func buildAuthorizationURL(callbackURL: URL, codeChallenge: String) -> URL? {
+        var components = URLComponents(
+            url: Self.authorizationEndpoint,
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = [
+            URLQueryItem(name: "callback_url", value: callbackURL.absoluteString),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        return components?.url
+    }
+
+    private func randomBase64URL(byteCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        guard SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes) == errSecSuccess else {
+            preconditionFailure("Secure random number generation failed")
+        }
+        return Data(bytes).base64URLEncoded()
+    }
+
+    // MARK: - Loopback callback
+
+    enum CallbackRequest: Equatable {
+        case authorizationCode(String)
+        case providerError(String)
+        case missingCode
+        case invalid
+        case unrelated
+    }
+
+    nonisolated func parseCallbackRequest(
+        _ httpRequest: String,
+        expectedPath: String
+    ) -> CallbackRequest {
+        guard let requestLine = httpRequest.split(whereSeparator: { $0.isNewline }).first else {
+            return .invalid
+        }
+        let requestParts = requestLine.split(separator: " ", omittingEmptySubsequences: true)
+        guard requestParts.count >= 2 else { return .invalid }
+        guard let components = URLComponents(string: String(requestParts[1])) else { return .invalid }
+        guard components.path == expectedPath else { return .unrelated }
+        guard requestParts[0] == "GET" else { return .invalid }
+
+        let queryItems = components.queryItems ?? []
+        if let code = queryItems.first(where: { $0.name == "code" })?.value,
+           !code.isEmpty {
+            return .authorizationCode(code)
+        }
+        if let error = queryItems.first(where: { $0.name == "error" })?.value,
+           !error.isEmpty {
+            return .providerError(error)
+        }
+        return .missingCode
+    }
+
+    private func waitForAuthorizationCode(codeChallenge: String) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let parameters = NWParameters.tcp
+            parameters.requiredLocalEndpoint = .hostPort(host: .ipv4(.loopback), port: .any)
+
+            let listener: NWListener
+            do {
+                listener = try NWListener(using: parameters)
+            } catch {
+                continuation.resume(throwing: OpenRouterAuthError.callbackServerFailed)
+                return
+            }
+
+            let callbackPath = generateCallbackPath()
+            var completed = false
+            var browserOpened = false
+
+            func finish(_ result: Result<String, Error>) {
+                guard !completed else { return }
+                completed = true
+                listener.cancel()
+                switch result {
+                case .success(let code): continuation.resume(returning: code)
+                case .failure(let error): continuation.resume(throwing: error)
+                }
+            }
+
+            let timeout = DispatchWorkItem {
+                Task { @MainActor in
+                    finish(.failure(OpenRouterAuthError.callbackTimeout))
+                }
+            }
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Self.callbackTimeoutSeconds,
+                execute: timeout
+            )
+
+            listener.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor [weak self] in
+                    switch state {
+                    case .ready:
+                        guard !browserOpened, let self, let port = listener.port else { return }
+                        browserOpened = true
+                        guard let callbackURL = URL(
+                            string: "http://localhost:\(port.rawValue)\(callbackPath)"
+                        ),
+                        let authorizationURL = self.buildAuthorizationURL(
+                            callbackURL: callbackURL,
+                            codeChallenge: codeChallenge
+                        ) else {
+                            timeout.cancel()
+                            finish(.failure(OpenRouterAuthError.callbackServerFailed))
+                            return
+                        }
+                        guard self.openURL(authorizationURL) else {
+                            timeout.cancel()
+                            finish(.failure(OpenRouterAuthError.couldNotOpenBrowser))
+                            return
+                        }
+                    case .failed:
+                        timeout.cancel()
+                        finish(.failure(OpenRouterAuthError.callbackServerFailed))
+                    default:
+                        break
+                    }
+                }
+            }
+
+            listener.newConnectionHandler = { [weak self] connection in
+                Task { @MainActor [weak self] in
+                    guard let self, !completed else {
+                        connection.cancel()
+                        return
+                    }
+                    connection.start(queue: .main)
+                    Self.receiveHTTPRequest(on: connection) { request in
+                        Task { @MainActor in
+                            guard !completed else {
+                                connection.cancel()
+                                return
+                            }
+                            guard let request else {
+                                Self.sendHTTPResponse(
+                                    status: 400,
+                                    title: "Sign-in failed",
+                                    on: connection
+                                )
+                                return
+                            }
+
+                            switch self.parseCallbackRequest(request, expectedPath: callbackPath) {
+                            case .authorizationCode(let code):
+                                Self.sendHTTPResponse(
+                                    status: 200,
+                                    title: "OpenRouter connected to Muesli",
+                                    on: connection
+                                )
+                                timeout.cancel()
+                                finish(.success(code))
+                            case .providerError(let reason):
+                                Self.sendHTTPResponse(
+                                    status: 400,
+                                    title: "Sign-in cancelled",
+                                    on: connection
+                                )
+                                timeout.cancel()
+                                finish(.failure(OpenRouterAuthError.callbackRejected(reason)))
+                            case .missingCode:
+                                Self.sendHTTPResponse(
+                                    status: 400,
+                                    title: "Sign-in failed",
+                                    on: connection
+                                )
+                                timeout.cancel()
+                                finish(.failure(OpenRouterAuthError.callbackMissingCode))
+                            case .invalid:
+                                Self.sendHTTPResponse(
+                                    status: 400,
+                                    title: "Sign-in failed",
+                                    on: connection
+                                )
+                                timeout.cancel()
+                                finish(.failure(OpenRouterAuthError.invalidCallback))
+                            case .unrelated:
+                                // Port scanners and unrelated local requests do not consume the callback.
+                                Self.sendHTTPResponse(status: 404, title: "Not found", on: connection)
+                            }
+                        }
+                    }
+                }
+            }
+
+            listener.start(queue: .main)
+        }
+    }
+
+    nonisolated private static func receiveHTTPRequest(
+        on connection: NWConnection,
+        completion: @escaping (String?) -> Void
+    ) {
+        var received = Data()
+
+        func receiveNextChunk() {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) {
+                data, _, isComplete, error in
+                if let data { received.append(data) }
+
+                if received.count > 16_384 {
+                    completion(nil)
+                    return
+                }
+                if received.range(of: Data("\r\n\r\n".utf8)) != nil ||
+                    received.range(of: Data("\n\n".utf8)) != nil ||
+                    isComplete {
+                    completion(String(data: received, encoding: .utf8))
+                    return
+                }
+                if error != nil {
+                    completion(nil)
+                    return
+                }
+                receiveNextChunk()
+            }
+        }
+
+        receiveNextChunk()
+    }
+
+    nonisolated private static func sendHTTPResponse(
+        status: Int,
+        title: String,
+        on connection: NWConnection
+    ) {
+        let reason = status == 200 ? "OK" : status == 404 ? "Not Found" : "Bad Request"
+        let body = """
+        <!doctype html><html><head><meta charset="utf-8"><title>\(title)</title></head>
+        <body style="font-family:-apple-system,system-ui;text-align:center;padding:5rem">
+        <h2>\(title)</h2><p>You can close this window.</p></body></html>
+        """
+        let response = """
+        HTTP/1.1 \(status) \(reason)\r
+        Content-Type: text/html; charset=utf-8\r
+        Content-Length: \(body.utf8.count)\r
+        Cache-Control: no-store\r
+        Connection: close\r
+        \r
+        \(body)
+        """
+        connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    // MARK: - Key exchange
+
+    private struct KeyExchangeRequest: Encodable {
+        let code: String
+        let codeVerifier: String
+        let codeChallengeMethod = "S256"
+
+        enum CodingKeys: String, CodingKey {
+            case code
+            case codeVerifier = "code_verifier"
+            case codeChallengeMethod = "code_challenge_method"
+        }
+    }
+
+    private struct KeyExchangeResponse: Decodable {
+        let key: String
+        let userID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case key
+            case userID = "user_id"
+        }
+    }
+
+    func exchangeAuthorizationCode(
+        _ code: String,
+        codeVerifier: String
+    ) async throws -> OpenRouterCredential {
+        var request = URLRequest(url: Self.keyExchangeEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try JSONEncoder().encode(
+            KeyExchangeRequest(code: code, codeVerifier: codeVerifier)
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await loadData(request)
+        } catch {
+            throw OpenRouterAuthError.keyExchangeFailed(statusCode: nil)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw OpenRouterAuthError.keyExchangeFailed(
+                statusCode: (response as? HTTPURLResponse)?.statusCode
+            )
+        }
+        guard let exchange = try? JSONDecoder().decode(KeyExchangeResponse.self, from: data),
+              !exchange.key.isEmpty else {
+            throw OpenRouterAuthError.invalidKeyExchangeResponse
+        }
+        return OpenRouterCredential(apiKey: exchange.key, userID: exchange.userID)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterAuthManager.swift
@@ -15,6 +15,7 @@ enum OpenRouterAuthError: Error, LocalizedError, Equatable {
     case keyExchangeFailed(statusCode: Int?)
     case invalidKeyExchangeResponse
     case credentialStorageFailed
+    case credentialDeletionFailed
 
     var errorDescription: String? {
         switch self {
@@ -41,6 +42,8 @@ enum OpenRouterAuthError: Error, LocalizedError, Equatable {
             return "OpenRouter key exchange returned an invalid response"
         case .credentialStorageFailed:
             return "Could not store the OpenRouter credential"
+        case .credentialDeletionFailed:
+            return "Could not remove the local OpenRouter credential"
         }
     }
 }
@@ -133,26 +136,38 @@ final class OpenRouterAuthManager {
     private let credentialStore: OpenRouterCredentialStore
     private let loadData: (URLRequest) async throws -> (Data, URLResponse)
     private let openURL: (URL) -> Bool
+    private let environment: () -> [String: String]
+    private let deleteCredential: () throws -> Void
 
     init(
         credentialStore: OpenRouterCredentialStore = OpenRouterCredentialStore(),
         loadData: @escaping (URLRequest) async throws -> (Data, URLResponse) = {
             try await URLSession.shared.data(for: $0)
         },
-        openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) }
+        openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) },
+        environment: @escaping () -> [String: String] = { ProcessInfo.processInfo.environment },
+        deleteCredential: (() throws -> Void)? = nil
     ) {
         self.credentialStore = credentialStore
         self.loadData = loadData
         self.openURL = openURL
+        self.environment = environment
+        self.deleteCredential = deleteCredential ?? { try credentialStore.delete() }
+    }
+
+    var hasEnvironmentCredential: Bool {
+        let key = environment()["OPENROUTER_API_KEY"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return !key.isEmpty
+    }
+
+    var hasStoredCredential: Bool {
+        guard let credential = try? credentialStore.load() else { return false }
+        return !credential.apiKey.isEmpty
     }
 
     var isAuthenticated: Bool {
-        do {
-            guard let credential = try credentialStore.load() else { return false }
-            return !credential.apiKey.isEmpty
-        } catch {
-            return false
-        }
+        hasEnvironmentCredential || hasStoredCredential
     }
 
     func credential() throws -> OpenRouterCredential {
@@ -183,13 +198,11 @@ final class OpenRouterAuthManager {
 
     /// Removes only Muesli's local credential. The user-controlled key remains
     /// active at OpenRouter until the user deletes it from OpenRouter's key page.
-    func signOut() {
+    func signOut() throws {
         do {
-            try credentialStore.delete()
+            try deleteCredential()
         } catch {
-            // Sign-out has local-only semantics. Avoid reflecting file paths or
-            // credential material into logs; the next state sync will still
-            // accurately report whether a credential remains.
+            throw OpenRouterAuthError.credentialDeletionFailed
         }
     }
 
@@ -213,8 +226,12 @@ final class OpenRouterAuthManager {
     }
 
     var manageKeyURL: URL? {
-        guard let credential = try? credential() else { return nil }
-        return Self.manageKeyURL(for: credential.apiKey)
+        let apiKey = OpenRouterCredentialResolver.resolvedAPIKey(
+            environment: environment(),
+            credentialStore: credentialStore
+        )
+        guard !apiKey.isEmpty else { return nil }
+        return Self.manageKeyURL(for: apiKey)
     }
 
     nonisolated static func manageKeyURL(for apiKey: String) -> URL {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1566,8 +1566,15 @@ struct SettingsView: View {
                     openRouterAccountControl()
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Model", controlWidth: meetingControlWidth) {
+                settingsRow("Free model", controlWidth: meetingControlWidth) {
                     openRouterFreeModelMenu
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
+                    settingsModelTextField(
+                        currentModel: appState.config.openRouterModel,
+                        placeholder: "provider/model"
+                    ) { val in controller.updateConfig { $0.openRouterModel = val } }
                 }
             }
         }
@@ -2164,38 +2171,40 @@ struct SettingsView: View {
         selectMeetingSummaryBackend: Bool = true
     ) -> some View {
         if appState.isOpenRouterAuthenticated {
-            VStack(alignment: .center, spacing: 4) {
-                Button {
-                    controller.signOutOpenRouter()
-                } label: {
-                    HStack(spacing: 5) {
-                        Image(systemName: "network")
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(.white)
-                        Text("Connected · Disconnect")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.white)
-                            .lineLimit(1)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
-                    .background(MuesliTheme.success)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            HStack(spacing: 6) {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text("Connected")
+                        .font(.system(size: 10, weight: .medium))
+                        .lineLimit(1)
                 }
-                .buttonStyle(.plain)
-                .help("Disconnect removes Muesli's local copy. Revoke the key from OpenRouter's key page.")
+                .foregroundStyle(MuesliTheme.success)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button {
                     controller.manageOpenRouterKey()
                 } label: {
-                    Text("Manage key at OpenRouter")
+                    Text("Manage key")
                         .font(.system(size: 10))
                         .foregroundStyle(.blue)
                         .underline()
                 }
                 .buttonStyle(.plain)
                 .frame(maxWidth: .infinity, alignment: .center)
+                .help("Manage this key at OpenRouter")
+
+                Button {
+                    controller.signOutOpenRouter()
+                } label: {
+                    Text("Disconnect")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.red)
+                        .underline()
+                }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .help("Remove Muesli's local copy of this OpenRouter key")
             }
         } else if isSigningInOpenRouter {
             HStack(spacing: 6) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -185,6 +185,7 @@ struct SettingsView: View {
     @State private var openRouterFreeModels: [SummaryModelPreset] = []
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
+    @State private var isUsingCustomOpenRouterModel = false
     @State private var hasRefreshedMeetingCalendarSources = false
     @State private var isShowingICloudSyncReconnectConfirmation = false
     @State private var isShowingICloudSyncResetConfirmation = false
@@ -1566,14 +1567,15 @@ struct SettingsView: View {
                     openRouterAccountControl()
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Free model", controlWidth: meetingControlWidth) {
+                settingsRow("Model", controlWidth: meetingControlWidth) {
                     openRouterFreeModelMenu
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
                     settingsModelTextField(
                         currentModel: appState.config.openRouterModel,
-                        placeholder: "provider/model"
+                        placeholder: "provider/model",
+                        onBeginEditing: { isUsingCustomOpenRouterModel = true }
                     ) { val in controller.updateConfig { $0.openRouterModel = val } }
                 }
             }
@@ -2171,41 +2173,59 @@ struct SettingsView: View {
         selectMeetingSummaryBackend: Bool = true
     ) -> some View {
         if appState.isOpenRouterAuthenticated {
-            HStack(spacing: 6) {
+            HStack(spacing: 0) {
                 HStack(spacing: 4) {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.success)
                     Text("Connected")
                         .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(MuesliTheme.textSecondary)
                         .lineLimit(1)
                 }
-                .foregroundStyle(MuesliTheme.success)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                Divider()
+                    .background(MuesliTheme.surfaceBorder)
+                    .padding(.vertical, 5)
 
                 Button {
                     controller.manageOpenRouterKey()
                 } label: {
                     Text("Manage key")
                         .font(.system(size: 10))
-                        .foregroundStyle(.blue)
-                        .underline()
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .help("Manage this key at OpenRouter")
+
+                Divider()
+                    .background(MuesliTheme.surfaceBorder)
+                    .padding(.vertical, 5)
 
                 Button {
                     controller.signOutOpenRouter()
                 } label: {
                     Text("Disconnect")
                         .font(.system(size: 10))
-                        .foregroundStyle(.red)
-                        .underline()
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .frame(maxWidth: .infinity, alignment: .trailing)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .help("Remove Muesli's local copy of this OpenRouter key")
             }
+            .frame(height: 24)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
         } else if isSigningInOpenRouter {
             HStack(spacing: 6) {
                 ProgressView()
@@ -3446,10 +3466,16 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func settingsModelTextField(currentModel: String, placeholder: String, onChange: @escaping (String) -> Void) -> some View {
+    private func settingsModelTextField(
+        currentModel: String,
+        placeholder: String,
+        onBeginEditing: (() -> Void)? = nil,
+        onChange: @escaping (String) -> Void
+    ) -> some View {
         PastableTextField(
             text: currentModel,
             placeholder: placeholder,
+            onBeginEditing: onBeginEditing,
             onChange: { value in
                 onChange(value.trimmingCharacters(in: .whitespacesAndNewlines))
             }
@@ -3469,10 +3495,37 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
         } else if !openRouterFreeModels.isEmpty {
-            settingsModelMenu(
-                currentModel: appState.config.openRouterModel,
-                presets: openRouterFreeModels
-            ) { val in controller.updateConfig { $0.openRouterModel = val } }
+            let configuredModel = appState.config.openRouterModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            let configuredPreset = openRouterFreeModels.first { $0.id == configuredModel }
+            let showsCustomSelection = isUsingCustomOpenRouterModel
+                || (!configuredModel.isEmpty && configuredPreset == nil)
+            let customLabel = configuredModel.isEmpty
+                ? "Custom model ID"
+                : "Custom: \(configuredModel)"
+            let menuPresets = showsCustomSelection
+                ? openRouterFreeModels + [SummaryModelPreset(id: configuredModel, label: customLabel)]
+                : openRouterFreeModels
+            let selectedLabel = showsCustomSelection
+                ? customLabel
+                : (configuredPreset?.label ?? openRouterFreeModels[0].label)
+
+            FixedWidthPopUp(
+                selection: selectedLabel,
+                options: menuPresets.map(\.label),
+                onSelectIndex: { index in
+                    guard index >= 0 && index < menuPresets.count else { return }
+                    if showsCustomSelection && index == openRouterFreeModels.count {
+                        isUsingCustomOpenRouterModel = true
+                        return
+                    }
+                    isUsingCustomOpenRouterModel = false
+                    let selectedID = openRouterFreeModels[index].id
+                    controller.updateConfig {
+                        $0.openRouterModel = selectedID == openRouterFreeModels.first?.id ? "" : selectedID
+                    }
+                }
+            )
+            .frame(height: 24)
         } else {
             HStack(spacing: 8) {
                 if let openRouterFreeModelsError {
@@ -3793,7 +3846,20 @@ struct PastableSecureField: NSViewRepresentable {
 struct PastableTextField: NSViewRepresentable {
     let text: String
     let placeholder: String
+    let onBeginEditing: (() -> Void)?
     let onChange: (String) -> Void
+
+    init(
+        text: String,
+        placeholder: String,
+        onBeginEditing: (() -> Void)? = nil,
+        onChange: @escaping (String) -> Void
+    ) {
+        self.text = text
+        self.placeholder = placeholder
+        self.onBeginEditing = onBeginEditing
+        self.onChange = onChange
+    }
 
     func makeNSView(context: Context) -> EditableNSTextField {
         let field = EditableNSTextField()
@@ -3811,17 +3877,25 @@ struct PastableTextField: NSViewRepresentable {
         if nsView.stringValue != text {
             nsView.stringValue = text
         }
+        context.coordinator.onBeginEditing = onBeginEditing
+        context.coordinator.onChange = onChange
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onChange: onChange)
+        Coordinator(onBeginEditing: onBeginEditing, onChange: onChange)
     }
 
     class Coordinator: NSObject, NSTextFieldDelegate {
-        let onChange: (String) -> Void
+        var onBeginEditing: (() -> Void)?
+        var onChange: (String) -> Void
 
-        init(onChange: @escaping (String) -> Void) {
+        init(onBeginEditing: (() -> Void)?, onChange: @escaping (String) -> Void) {
+            self.onBeginEditing = onBeginEditing
             self.onChange = onChange
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) {
+            onBeginEditing?()
         }
 
         func controlTextDidChange(_ obj: Notification) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -158,6 +158,10 @@ struct SettingsView: View {
 
     @State private var chatGPTSignInError: String?
     @State private var isSigningInChatGPT = false
+    @State private var openRouterSignInError: String?
+    @State private var isSigningInOpenRouter = false
+    @State private var isEnteringOpenRouterAPIKey = false
+    @State private var manualOpenRouterAPIKey = ""
     @State private var googleCalSignInError: String?
     @State private var isSigningInGoogleCal = false
     @State private var pendingDataDestruction: PendingDataDestruction?
@@ -1256,12 +1260,8 @@ struct SettingsView: View {
             }
         } else if backend == .hosted(.openRouter) {
             Divider().background(MuesliTheme.surfaceBorder)
-            settingsRow("API Key", controlWidth: meetingControlWidth) {
-                PastableSecureField(
-                    text: appState.config.openRouterAPIKey,
-                    placeholder: "sk-or-...",
-                    onChange: { value in controller.updateConfig { $0.openRouterAPIKey = value } }
-                ).frame(height: 22)
+            settingsRow("Account", controlWidth: meetingControlWidth) {
+                openRouterAccountControl(selectMeetingSummaryBackend: false)
             }
         } else if backend == .hosted(.ollama) {
             Divider().background(MuesliTheme.surfaceBorder)
@@ -1374,13 +1374,8 @@ struct SettingsView: View {
             keyStatusRow(key: appState.config.openAIAPIKey)
         case .some(.openRouter):
             Divider().background(MuesliTheme.surfaceBorder)
-            settingsRow("API Key", controlWidth: meetingControlWidth) {
-                PastableSecureField(
-                    text: appState.config.openRouterAPIKey,
-                    placeholder: "sk-or-...",
-                    onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
-                )
-                .frame(height: 22)
+            settingsRow("Account", controlWidth: meetingControlWidth) {
+                openRouterAccountControl(selectMeetingSummaryBackend: false)
             }
             Divider().background(MuesliTheme.surfaceBorder)
             settingsRow("Model preset", controlWidth: meetingControlWidth) {
@@ -1396,7 +1391,6 @@ struct SettingsView: View {
                     placeholder: "provider/model"
                 ) { controller.updatePostProcessorModel($0, for: backend) }
             }
-            keyStatusRow(key: appState.config.openRouterAPIKey)
         case .some(.ollama):
             Divider().background(MuesliTheme.surfaceBorder)
             settingsRow("Ollama URL", controlWidth: meetingControlWidth) {
@@ -1568,19 +1562,13 @@ struct SettingsView: View {
                     val in controller.updateConfig { $0.customLLMModel = val }
                 }
             } else {
-                settingsRow("API Key", controlWidth: meetingControlWidth) {
-                    PastableSecureField(
-                        text: appState.config.openRouterAPIKey,
-                        placeholder: "sk-or-...",
-                        onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
-                    )
-                    .frame(height: 22)
+                settingsRow("Account", controlWidth: meetingControlWidth) {
+                    openRouterAccountControl()
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Model", controlWidth: meetingControlWidth) {
                     openRouterFreeModelMenu
                 }
-                keyStatusRow(key: appState.config.openRouterAPIKey)
             }
         }
     }
@@ -2163,6 +2151,118 @@ struct SettingsView: View {
 
                 if let chatGPTSignInError {
                     Text(chatGPTSignInError)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func openRouterAccountControl(
+        selectMeetingSummaryBackend: Bool = true
+    ) -> some View {
+        if appState.isOpenRouterAuthenticated {
+            VStack(alignment: .trailing, spacing: 4) {
+                Button {
+                    controller.signOutOpenRouter()
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "network")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.white)
+                        Text("Connected · Disconnect")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.success)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+                .help("Disconnect removes Muesli's local copy. Revoke the key from OpenRouter's key page.")
+
+                Button("Manage key at OpenRouter") {
+                    controller.manageOpenRouterKey()
+                }
+                .buttonStyle(.link)
+                .font(.system(size: 10))
+            }
+        } else if isSigningInOpenRouter {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Connecting...")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 5) {
+                Button {
+                    isSigningInOpenRouter = true
+                    openRouterSignInError = nil
+                    Task {
+                        let error = await controller.signInWithOpenRouter(
+                            selectMeetingSummaryBackend: selectMeetingSummaryBackend
+                        )
+                        isSigningInOpenRouter = false
+                        openRouterSignInError = error
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "network")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.white)
+                        Text("Connect OpenRouter")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.accent)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+
+                Button(isEnteringOpenRouterAPIKey ? "Cancel manual key" : "Enter API key manually") {
+                    isEnteringOpenRouterAPIKey.toggle()
+                    manualOpenRouterAPIKey = ""
+                    openRouterSignInError = nil
+                }
+                .buttonStyle(.link)
+                .font(.system(size: 10))
+
+                if isEnteringOpenRouterAPIKey {
+                    HStack(spacing: 6) {
+                        PastableSecureField(
+                            text: manualOpenRouterAPIKey,
+                            placeholder: "sk-or-...",
+                            onChange: { manualOpenRouterAPIKey = $0 }
+                        )
+                        .frame(height: 22)
+
+                        Button("Save") {
+                            openRouterSignInError = controller.storeManualOpenRouterAPIKey(
+                                manualOpenRouterAPIKey,
+                                selectMeetingSummaryBackend: selectMeetingSummaryBackend
+                            )
+                            if openRouterSignInError == nil {
+                                manualOpenRouterAPIKey = ""
+                                isEnteringOpenRouterAPIKey = false
+                            }
+                        }
+                        .disabled(manualOpenRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if let openRouterSignInError {
+                    Text(openRouterSignInError)
                         .font(.system(size: 10))
                         .foregroundStyle(.red)
                         .lineLimit(2)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -2164,7 +2164,7 @@ struct SettingsView: View {
         selectMeetingSummaryBackend: Bool = true
     ) -> some View {
         if appState.isOpenRouterAuthenticated {
-            VStack(alignment: .trailing, spacing: 4) {
+            VStack(alignment: .center, spacing: 4) {
                 Button {
                     controller.signOutOpenRouter()
                 } label: {
@@ -2186,11 +2186,16 @@ struct SettingsView: View {
                 .buttonStyle(.plain)
                 .help("Disconnect removes Muesli's local copy. Revoke the key from OpenRouter's key page.")
 
-                Button("Manage key at OpenRouter") {
+                Button {
                     controller.manageOpenRouterKey()
+                } label: {
+                    Text("Manage key at OpenRouter")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.blue)
+                        .underline()
                 }
-                .buttonStyle(.link)
-                .font(.system(size: 10))
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, alignment: .center)
             }
         } else if isSigningInOpenRouter {
             HStack(spacing: 6) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -19,6 +19,27 @@ private struct MicrophoneOption: Identifiable {
     var id: String { uid ?? "__automatic__" }
 }
 
+enum SettingsPermissionRefreshReason {
+    case initialDisplay
+    case periodicPoll
+    case permissionRequested
+    case settingsSelected
+    case appActivated
+
+    var refreshesLaunchAtLogin: Bool {
+        self == .appActivated
+    }
+
+    var refreshesSystemAudio: Bool {
+        switch self {
+        case .initialDisplay, .settingsSelected, .appActivated:
+            true
+        case .periodicPoll, .permissionRequested:
+            false
+        }
+    }
+}
+
 struct ICloudLinkedDevicePresentation: Equatable {
     let name: String
     let platformLabel: String
@@ -435,7 +456,7 @@ struct SettingsView: View {
                     selectedPane = appState.selectedSettingsPane
                     refreshDownloadedModelOptions()
                     refreshAudioInputDevices()
-                    refreshPermissionStatuses()
+                    refreshPermissionStatuses(for: .settingsSelected)
                 }
             }
             .onChange(of: appState.selectedSettingsPane) { _, pane in
@@ -454,7 +475,7 @@ struct SettingsView: View {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 guard appState.selectedTab == .settings else { return }
                 refreshAudioInputDevices()
-                refreshPermissionStatuses(refreshLaunchAtLogin: true)
+                refreshPermissionStatuses(for: .appActivated)
             }
             .onChange(of: appState.selectedBackend) { _, _ in
                 refreshDownloadedModelOptions()
@@ -2581,7 +2602,9 @@ struct SettingsView: View {
                     "System Audio",
                     granted: systemAudioGranted,
                     action: {
-                        Task { await CoreAudioSystemRecorder.requestSystemAudioAccess() }
+                        Task { @MainActor in
+                            systemAudioGranted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
+                        }
                     },
                     pane: "Privacy_ScreenCapture"
                 )
@@ -2673,7 +2696,7 @@ struct SettingsView: View {
         } else {
             Button {
                 _ = CGRequestScreenCaptureAccess()
-                refreshPermissionStatuses()
+                refreshPermissionStatuses(for: .permissionRequested)
             } label: {
                 Text("Grant")
                     .font(.system(size: 13, weight: .semibold))
@@ -2720,12 +2743,13 @@ struct SettingsView: View {
     }
 
     private func startPermissionPolling() {
-        // Startup already synchronizes this state. Querying SMAppService here can
-        // block the main thread long enough to make Settings appear unresponsive.
-        refreshPermissionStatuses()
+        // Keep the 1 Hz poll limited to cheap TCC snapshots. SMAppService can block
+        // the main thread, while probing system audio creates a CoreAudio process
+        // tap and can perturb the HAL. Refresh those only at lifecycle boundaries.
+        refreshPermissionStatuses(for: .initialDisplay)
         permissionPollTimer?.invalidate()
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            refreshPermissionStatuses()
+            refreshPermissionStatuses(for: .periodicPoll)
         }
         RunLoop.main.add(timer, forMode: .common)
         permissionPollTimer = timer
@@ -2736,13 +2760,13 @@ struct SettingsView: View {
         permissionPollTimer = nil
     }
 
-    private func refreshPermissionStatuses(refreshLaunchAtLogin: Bool = false) {
+    private func refreshPermissionStatuses(for reason: SettingsPermissionRefreshReason) {
         micGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         accessibilityGranted = AXIsProcessTrusted()
         controller.reconcilePendingDictionaryCorrectionAccessibilityEnable()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
-        if refreshLaunchAtLogin {
+        if reason.refreshesLaunchAtLogin {
             controller.refreshLaunchAtLoginState()
         }
         if accessibilityGranted && pendingScreenContextEnable {
@@ -2768,7 +2792,9 @@ struct SettingsView: View {
             accessibilityGranted: accessibilityGranted,
             inputMonitoringGranted: inputMonitoringGranted
         )
-        refreshSystemAudioPermissionIfNeeded()
+        if reason.refreshesSystemAudio {
+            refreshSystemAudioPermissionIfNeeded()
+        }
     }
 
     private var isPendingScreenContextGrantExpired: Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -193,6 +193,7 @@ struct SettingsView: View {
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
     @State private var downloadedMeetingLiveCaptionBackends: [MeetingLiveCaptionBackend] = []
     @State private var audioInputDevices: [AudioInputDeviceInfo] = []
+    @State private var audioInputDeviceRefreshTask: Task<Void, Never>?
     @State private var permissionPollTimer: Timer?
     @State private var isCleanupPromptManagerPresented = false
     @State private var micGranted = false
@@ -449,6 +450,8 @@ struct SettingsView: View {
             .onDisappear {
                 SoundController.stopMaraudersMapClip()
                 isPreviewingClip = false
+                audioInputDeviceRefreshTask?.cancel()
+                audioInputDeviceRefreshTask = nil
                 stopPermissionPolling()
             }
             .onChange(of: appState.selectedTab) { _, tab in
@@ -465,7 +468,7 @@ struct SettingsView: View {
             .onChange(of: selectedPane) { _, pane in
                 appState.selectedSettingsPane = pane
                 if pane == .dictation || pane == .meetings {
-                    refreshAudioInputDevices()
+                    loadCachedAudioInputDevices()
                 }
                 scrollToFeatureTourTarget(activeFeatureTourTarget, using: scrollProxy)
             }
@@ -583,7 +586,17 @@ struct SettingsView: View {
     }
 
     private func refreshAudioInputDevices() {
-        audioInputDevices = controller.availableDictationInputDevices()
+        loadCachedAudioInputDevices()
+        audioInputDeviceRefreshTask?.cancel()
+        audioInputDeviceRefreshTask = Task { @MainActor in
+            let devices = await controller.refreshDictationInputDevices()
+            guard !Task.isCancelled else { return }
+            audioInputDevices = devices
+        }
+    }
+
+    private func loadCachedAudioInputDevices() {
+        audioInputDevices = controller.cachedDictationInputDevices()
     }
 
     private func backendOptions(including selection: BackendOption) -> [BackendOption] {
@@ -1024,7 +1037,7 @@ struct SettingsView: View {
                     onSelectIndex: { index in
                         guard options.indices.contains(index) else { return }
                         controller.selectMeetingInputDeviceUID(options[index].uid)
-                        refreshAudioInputDevices()
+                        loadCachedAudioInputDevices()
                     }
                 )
                 .frame(height: 24)
@@ -1664,7 +1677,7 @@ struct SettingsView: View {
                         onSelectIndex: { index in
                             guard index >= 0, index < options.count else { return }
                             controller.selectDictationInputDeviceUID(options[index].uid)
-                            refreshAudioInputDevices()
+                            loadCachedAudioInputDevices()
                         }
                     )
                     .frame(height: 24)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -3134,19 +3134,20 @@ struct SettingsView: View {
     }
 
     private var calendarSourcesControl: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+        let sourceGroups = calendarSourceGroups
+        return VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
             Text("Calendar sources are listed first, with their calendars underneath. Disabled calendars are hidden from Muesli — no notifications, no Coming Up, no meeting detection.")
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textTertiary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            if calendarSourceGroups.isEmpty {
+            if sourceGroups.isEmpty {
                 Text("No calendars detected. Make sure Calendar permission is granted in System Settings > Privacy & Security > Calendars.")
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
-                ForEach(calendarSourceGroups) { group in
+                ForEach(sourceGroups) { group in
                     calendarSourceGroupView(group)
                 }
             }
@@ -3285,8 +3286,11 @@ struct SettingsView: View {
     private func refreshMeetingCalendarSourcesIfNeeded() {
         guard !hasRefreshedMeetingCalendarSources else { return }
         hasRefreshedMeetingCalendarSources = true
-        controller.refreshAvailableEventKitCalendars()
-        Task { await controller.refreshGoogleCalendarList() }
+        Task {
+            async let eventKitRefresh: Void = controller.refreshAvailableEventKitCalendars()
+            async let googleRefresh: Void = controller.refreshGoogleCalendarList()
+            _ = await (eventKitRefresh, googleRefresh)
+        }
     }
 
     private func updateDisabledCalendar(_ calendarID: String, isDisabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1739,20 +1739,18 @@ struct SettingsView: View {
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Timeout", controlWidth: meetingControlWidth) {
-                    Stepper(
+                    integerInput(
+                        label: "Computer use timeout",
                         value: Binding(
                             get: { max(appState.config.computerUseTimeoutSeconds, 1) },
                             set: { newValue in
                                 controller.updateConfig { $0.computerUseTimeoutSeconds = max(newValue, 1) }
                             }
                         ),
-                        in: 1...600,
-                        step: 15
-                    ) {
-                        Text("\(max(appState.config.computerUseTimeoutSeconds, 1)) seconds")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                    }
+                        range: 1...600,
+                        step: 15,
+                        unit: { $0 == 1 ? "second" : "seconds" }
+                    )
                 }
             }
         }
@@ -1776,7 +1774,8 @@ struct SettingsView: View {
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Summary retries", controlWidth: meetingControlWidth) {
-                    Stepper(
+                    integerInput(
+                        label: "Summary retries",
                         value: Binding(
                             get: {
                                 MeetingSummaryRetryPolicy.clampedRetryCount(appState.config.meetingSummaryRetryCount)
@@ -1787,12 +1786,9 @@ struct SettingsView: View {
                                 }
                             }
                         ),
-                        in: 0...MeetingSummaryRetryPolicy.maximumRetryCount
-                    ) {
-                        Text(summaryRetryLabel(appState.config.meetingSummaryRetryCount))
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                    }
+                        range: 0...MeetingSummaryRetryPolicy.maximumRetryCount,
+                        unit: { $0 == 1 ? "retry" : "retries" }
+                    )
                 }
                 settingsDescription("Retry transient AI summary failures before saving failed notes.")
                 Divider().background(MuesliTheme.surfaceBorder)
@@ -2962,18 +2958,6 @@ struct SettingsView: View {
             .padding(.bottom, MuesliTheme.spacing8)
     }
 
-    private func summaryRetryLabel(_ retryCount: Int) -> String {
-        let clamped = MeetingSummaryRetryPolicy.clampedRetryCount(retryCount)
-        switch clamped {
-        case 0:
-            return "No retries"
-        case 1:
-            return "1 retry"
-        default:
-            return "\(clamped) retries"
-        }
-    }
-
     // MARK: - Controls
 
     @ViewBuilder
@@ -3484,20 +3468,48 @@ struct SettingsView: View {
     }
 
     private var meetingHookTimeoutControl: some View {
-        Stepper(
+        integerInput(
+            label: "Meeting hook timeout",
             value: Binding(
                 get: { max(appState.config.meetingHookTimeoutSeconds, 1) },
                 set: { newValue in
                     controller.updateConfig { $0.meetingHookTimeoutSeconds = max(newValue, 1) }
                 }
             ),
-            in: 1...600
-        ) {
-            Text("\(max(appState.config.meetingHookTimeoutSeconds, 1)) seconds")
-                .font(MuesliTheme.body())
-                .foregroundStyle(MuesliTheme.textPrimary)
+            range: 1...600,
+            unit: { $0 == 1 ? "second" : "seconds" }
+        )
+    }
+
+    private func integerInput(
+        label: String,
+        value: Binding<Int>,
+        range: ClosedRange<Int>,
+        step: Int = 1,
+        unit: @escaping (Int) -> String
+    ) -> some View {
+        let clampedValue = min(max(value.wrappedValue, range.lowerBound), range.upperBound)
+        let clampedBinding = Binding(
+            get: { min(max(value.wrappedValue, range.lowerBound), range.upperBound) },
+            set: { value.wrappedValue = min(max($0, range.lowerBound), range.upperBound) }
+        )
+
+        return HStack(spacing: MuesliTheme.spacing8) {
+            TextField(label, value: clampedBinding, format: .number)
+                .textFieldStyle(.roundedBorder)
+                .multilineTextAlignment(.trailing)
                 .monospacedDigit()
-                .frame(minWidth: 92, alignment: .trailing)
+                .frame(width: 72)
+                .accessibilityLabel(label)
+
+            Text(unit(clampedValue))
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 58, alignment: .leading)
+
+            Stepper(label, value: clampedBinding, in: range, step: step)
+                .labelsHidden()
+                .fixedSize()
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -2207,59 +2207,79 @@ struct SettingsView: View {
         selectMeetingSummaryBackend: Bool = true
     ) -> some View {
         if appState.isOpenRouterAuthenticated {
-            HStack(spacing: 0) {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.success)
-                    Text("Connected")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(MuesliTheme.textSecondary)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 0) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.success)
+                        Text(appState.isOpenRouterEnvironmentManaged ? "Environment key" : "Connected")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-                Divider()
-                    .background(MuesliTheme.surfaceBorder)
-                    .padding(.vertical, 5)
+                    Divider()
+                        .background(MuesliTheme.surfaceBorder)
+                        .padding(.vertical, 5)
 
-                Button {
-                    controller.manageOpenRouterKey()
-                } label: {
-                    Text("Manage key")
-                        .font(.system(size: 10))
-                        .foregroundStyle(MuesliTheme.textSecondary)
+                    Button {
+                        controller.manageOpenRouterKey()
+                    } label: {
+                        Text("Manage key")
+                            .font(.system(size: 10))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .help("Manage this key at OpenRouter")
+
+                    Divider()
+                        .background(MuesliTheme.surfaceBorder)
+                        .padding(.vertical, 5)
+
+                    if appState.hasStoredOpenRouterCredential {
+                        Button {
+                            openRouterSignInError = controller.signOutOpenRouter()
+                            if openRouterSignInError == nil && !appState.isOpenRouterAuthenticated {
+                                isUsingCustomOpenRouterModel = false
+                            }
+                        } label: {
+                            Text(appState.isOpenRouterEnvironmentManaged ? "Forget local" : "Disconnect")
+                                .font(.system(size: 10))
+                                .foregroundStyle(MuesliTheme.textSecondary)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .contentShape(Rectangle())
+                        .help("Remove Muesli's local copy of this OpenRouter key")
+                    } else {
+                        Text("Managed externally")
+                            .font(.system(size: 10))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .lineLimit(1)
+                    }
                 }
-                .buttonStyle(.plain)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .help("Manage this key at OpenRouter")
+                .frame(height: 24)
+                .background(MuesliTheme.surfacePrimary)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
 
-                Divider()
-                    .background(MuesliTheme.surfaceBorder)
-                    .padding(.vertical, 5)
-
-                Button {
-                    controller.signOutOpenRouter()
-                } label: {
-                    Text("Disconnect")
+                if let openRouterSignInError {
+                    Text(openRouterSignInError)
                         .font(.system(size: 10))
-                        .foregroundStyle(MuesliTheme.textSecondary)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .contentShape(Rectangle())
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
                 }
-                .buttonStyle(.plain)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .help("Remove Muesli's local copy of this OpenRouter key")
             }
-            .frame(height: 24)
-            .background(MuesliTheme.surfacePrimary)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-            )
         } else if isSigningInOpenRouter {
             HStack(spacing: 6) {
                 ProgressView()
@@ -2615,18 +2635,28 @@ struct SettingsView: View {
                     "System Audio",
                     granted: systemAudioGranted,
                     action: {
+                        guard !isCheckingSystemAudioPermission else { return }
+                        isCheckingSystemAudioPermission = true
                         Task { @MainActor in
+                            defer { isCheckingSystemAudioPermission = false }
                             systemAudioGranted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
                         }
                     },
-                    pane: "Privacy_ScreenCapture"
+                    pane: "Privacy_ScreenCapture",
+                    isBusy: isCheckingSystemAudioPermission
                 )
             }
         }
     }
 
     @ViewBuilder
-    private func permissionStatusRow(_ name: String, granted: Bool, action: @escaping () -> Void, pane: String) -> some View {
+    private func permissionStatusRow(
+        _ name: String,
+        granted: Bool,
+        action: @escaping () -> Void,
+        pane: String,
+        isBusy: Bool = false
+    ) -> some View {
         HStack {
             HStack(spacing: 8) {
                 Circle()
@@ -2642,9 +2672,10 @@ struct SettingsView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(MuesliTheme.success)
             } else {
-                Button("Grant") {
+                Button(isBusy ? "Checking…" : "Grant") {
                     action()
                 }
+                .disabled(isBusy)
                 .buttonStyle(.plain)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(MuesliTheme.accent)
@@ -3564,7 +3595,7 @@ struct SettingsView: View {
                     isUsingCustomOpenRouterModel = false
                     let selectedID = openRouterFreeModels[index].id
                     controller.updateConfig {
-                        $0.openRouterModel = selectedID == openRouterFreeModels.first?.id ? "" : selectedID
+                        $0.openRouterModel = OpenRouterModelSelection.persistedModelID(for: selectedID)
                     }
                 }
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -95,8 +95,7 @@ enum TranscriptCleanupClient {
             return !config.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || ProcessInfo.processInfo.environment["OPENAI_API_KEY"] != nil
         case .some(.openRouter):
-            return !config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
+            return !resolvedOpenRouterAPIKey(config: config).isEmpty
         case .some(.ollama):
             return resolveConfiguredOllamaURL(config: config) != nil
         case .some(.lmStudio):
@@ -255,10 +254,14 @@ enum TranscriptCleanupClient {
 
     static func resolvedOpenRouterAPIKey(
         config: AppConfig,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        credentialStore: OpenRouterCredentialStore = OpenRouterCredentialStore()
     ) -> String {
-        let key = config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        return key.isEmpty ? (environment["OPENROUTER_API_KEY"] ?? "") : key
+        OpenRouterCredentialResolver.resolvedAPIKey(
+            legacyAPIKey: config.openRouterAPIKey,
+            environment: environment,
+            credentialStore: credentialStore
+        )
     }
 
     private static func cleanupConfig(_ config: AppConfig, model: String) -> AppConfig {

--- a/native/MuesliNative/Tests/MuesliTests/ChatGPTAuthTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ChatGPTAuthTests.swift
@@ -71,7 +71,7 @@ struct ChatGPTAuthTests {
         #expect(params["code_challenge_method"] == "S256")
         #expect(params["id_token_add_organizations"] == "true")
         #expect(params["codex_cli_simplified_flow"] == "true")
-        #expect(params["originator"] == "opencode")
+        #expect(params["originator"] == "muesli")
     }
 
     @Test("authorization URL points to auth.openai.com")

--- a/native/MuesliNative/Tests/MuesliTests/ChatGPTCodexTransportTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ChatGPTCodexTransportTests.swift
@@ -24,7 +24,7 @@ struct ChatGPTResponsesTransportTests {
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
         #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "account-123")
         #expect(request.value(forHTTPHeaderField: "originator") == "muesli")
-        #expect(request.value(forHTTPHeaderField: "version") == "1.2.3")
+        #expect(request.value(forHTTPHeaderField: "version") == nil)
         #expect(request.value(forHTTPHeaderField: "User-Agent") == "Muesli/1.2.3")
         #expect(request.value(forHTTPHeaderField: "session_id") == sessionID.uuidString.lowercased())
         #expect(request.value(forHTTPHeaderField: "OpenAI-Beta") == nil)
@@ -48,7 +48,7 @@ struct ChatGPTResponsesTransportTests {
 
         #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == nil)
         #expect(request.value(forHTTPHeaderField: "originator") == "muesli")
-        #expect(request.value(forHTTPHeaderField: "version") == "2.0.0")
+        #expect(request.value(forHTTPHeaderField: "version") == nil)
     }
 
     @Test("creates a fresh session ID for every request")

--- a/native/MuesliNative/Tests/MuesliTests/ChatGPTCodexTransportTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ChatGPTCodexTransportTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("ChatGPT Responses transport")
+struct ChatGPTResponsesTransportTests {
+    @Test("builds Codex Responses requests with honest Muesli identity")
+    func buildsCodexRequest() throws {
+        let sessionID = UUID(uuidString: "8AF070D8-956D-4706-9FF8-8140CE7F6B2D")!
+        let request = try ChatGPTResponsesTransport.makeRequest(
+            body: ["model": "gpt-5.6-sol", "stream": true],
+            token: "access-token",
+            accountId: "account-123",
+            appVersion: "1.2.3",
+            sessionID: sessionID,
+            environment: [:]
+        )
+
+        #expect(request.url == URL(string: "https://chatgpt.com/backend-api/codex/responses"))
+        #expect(request.httpMethod == "POST")
+        #expect(request.timeoutInterval == 120)
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "text/event-stream")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
+        #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "account-123")
+        #expect(request.value(forHTTPHeaderField: "originator") == "muesli")
+        #expect(request.value(forHTTPHeaderField: "version") == "1.2.3")
+        #expect(request.value(forHTTPHeaderField: "User-Agent") == "Muesli/1.2.3")
+        #expect(request.value(forHTTPHeaderField: "session_id") == sessionID.uuidString.lowercased())
+        #expect(request.value(forHTTPHeaderField: "OpenAI-Beta") == nil)
+
+        let body = try #require(request.httpBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-5.6-sol")
+        #expect(json["stream"] as? Bool == true)
+    }
+
+    @Test("omits empty account IDs without dropping Codex identity headers")
+    func omitsEmptyAccountID() throws {
+        let request = try ChatGPTResponsesTransport.makeRequest(
+            body: ["stream": true],
+            token: "access-token",
+            accountId: "",
+            appVersion: "2.0.0",
+            sessionID: UUID(uuidString: "194AC4DC-E234-4153-BA13-A1D48323303F")!,
+            environment: [:]
+        )
+
+        #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == nil)
+        #expect(request.value(forHTTPHeaderField: "originator") == "muesli")
+        #expect(request.value(forHTTPHeaderField: "version") == "2.0.0")
+    }
+
+    @Test("creates a fresh session ID for every request")
+    func createsFreshSessionIDs() throws {
+        let first = try ChatGPTResponsesTransport.makeRequest(
+            body: ["stream": true],
+            token: "access-token",
+            accountId: "account-123",
+            appVersion: "1.0.0",
+            environment: [:]
+        )
+        let second = try ChatGPTResponsesTransport.makeRequest(
+            body: ["stream": true],
+            token: "access-token",
+            accountId: "account-123",
+            appVersion: "1.0.0",
+            environment: [:]
+        )
+
+        let firstSessionID = try #require(first.value(forHTTPHeaderField: "session_id"))
+        let secondSessionID = try #require(second.value(forHTTPHeaderField: "session_id"))
+        #expect(UUID(uuidString: firstSessionID) != nil)
+        #expect(UUID(uuidString: secondSessionID) != nil)
+        #expect(firstSessionID != secondSessionID)
+    }
+
+    @Test("uses Codex by default and only selects WHAM for the explicit override")
+    func selectsBackendFromEnvironment() {
+        #expect(ChatGPTResponsesTransport.selectedBackend(environment: [:]) == .codex)
+        #expect(ChatGPTResponsesTransport.selectedBackend(environment: [
+            ChatGPTResponsesTransport.environmentKey: "codex",
+        ]) == .codex)
+        #expect(ChatGPTResponsesTransport.selectedBackend(environment: [
+            ChatGPTResponsesTransport.environmentKey: "unknown",
+        ]) == .codex)
+        #expect(ChatGPTResponsesTransport.selectedBackend(environment: [
+            ChatGPTResponsesTransport.environmentKey: " WHAM ",
+        ]) == .wham)
+    }
+
+    @Test("builds the legacy WHAM request only for the emergency override")
+    func buildsWhamOverrideRequest() throws {
+        let request = try ChatGPTResponsesTransport.makeRequest(
+            body: ["model": "gpt-5.4", "stream": true],
+            token: "access-token",
+            accountId: "account-123",
+            appVersion: "1.2.3",
+            sessionID: UUID(uuidString: "6482D44E-BE26-4B98-B0B7-B5D5281C713B")!,
+            environment: [ChatGPTResponsesTransport.environmentKey: "wham"]
+        )
+
+        #expect(request.url == URL(string: "https://chatgpt.com/backend-api/wham/responses"))
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
+        #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "account-123")
+        #expect(request.value(forHTTPHeaderField: "originator") == nil)
+        #expect(request.value(forHTTPHeaderField: "version") == nil)
+        #expect(request.value(forHTTPHeaderField: "User-Agent") == nil)
+        #expect(request.value(forHTTPHeaderField: "session_id") == nil)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ConfigStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ConfigStoreTests.swift
@@ -8,19 +8,21 @@ struct ConfigStoreTests {
 
     @Test("load returns a valid config")
     func loadReturnsConfig() {
-        let store = ConfigStore()
+        let supportDirectory = makeSupportDirectory(label: "load")
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+        let store = ConfigStore(supportDirectory: supportDirectory)
         let config = store.load()
-        // Hotkey may have been customized by user — just verify it loaded
         #expect(HotkeyConfig.label(for: config.dictationHotkey.keyCode) != nil)
         #expect(!config.sttBackend.isEmpty)
     }
 
     @Test("save and load round-trip")
-    func saveLoadRoundTrip() {
-        let store = ConfigStore()
-        let original = store.load()
+    func saveLoadRoundTrip() throws {
+        let supportDirectory = makeSupportDirectory(label: "roundtrip")
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+        let store = ConfigStore(supportDirectory: supportDirectory)
 
-        var config = original
+        var config = AppConfig()
         config.openAIAPIKey = "sk-test-roundtrip"
         config.openAIModel = "gpt-5.4-pro"
         config.openRouterAPIKey = "sk-or-test-roundtrip"
@@ -34,35 +36,78 @@ struct ConfigStoreTests {
         let loaded = store.load()
         #expect(loaded.openAIAPIKey == "sk-test-roundtrip")
         #expect(loaded.openAIModel == "gpt-5.4-pro")
-        #expect(loaded.openRouterAPIKey == "sk-or-test-roundtrip")
+        #expect(loaded.openRouterAPIKey.isEmpty)
+        #expect(
+            try OpenRouterCredentialStore(supportDirectory: supportDirectory).load()?.apiKey ==
+                "sk-or-test-roundtrip"
+        )
         #expect(loaded.openRouterModel == "nvidia/nemotron-3-super-120b-a12b:free")
         #expect(loaded.cohereLanguage == CohereTranscribeLanguage.german.rawValue)
         #expect(loaded.whisperLanguage == WhisperKitLanguage.german.rawValue)
         #expect(loaded.appleSpeechLanguage == "en-US")
         #expect(loaded.meetingSummaryBackend == "openrouter")
-
-        // Restore original
-        store.save(original)
     }
 
-    @Test("config path is in Application Support")
+    @Test("config path honors the isolated support directory")
     func configPath() {
-        let store = ConfigStore()
+        let supportDirectory = makeSupportDirectory(label: "path")
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+        let store = ConfigStore(supportDirectory: supportDirectory)
         let path = store.configPath().path
-        #expect(path.contains("Application Support"))
+        #expect(path.hasPrefix(supportDirectory.path))
         #expect(path.hasSuffix("config.json"))
     }
 
     @Test("saved config uses owner-only file permissions")
     func configPermissions() throws {
-        let store = ConfigStore()
-        let original = store.load()
+        let supportDirectory = makeSupportDirectory(label: "permissions")
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+        let store = ConfigStore(supportDirectory: supportDirectory)
 
-        store.save(original)
+        store.save(AppConfig())
 
         let attributes = try FileManager.default.attributesOfItem(atPath: store.configPath().path)
         let permissions = attributes[.posixPermissions] as? NSNumber
 
         #expect(permissions?.intValue == 0o600)
+    }
+
+    @Test("legacy migration preserves an existing dedicated credential")
+    func legacyMigrationPreservesExistingCredential() throws {
+        let supportDirectory = makeSupportDirectory(label: "migration-existing")
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+        try FileManager.default.createDirectory(
+            at: supportDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let credentialStore = OpenRouterCredentialStore(supportDirectory: supportDirectory)
+        let existingCredential = OpenRouterCredential(
+            apiKey: "sk-or-new-oauth",
+            userID: "user-new"
+        )
+        try credentialStore.save(existingCredential)
+
+        var staleConfig = AppConfig()
+        staleConfig.openRouterAPIKey = "sk-or-stale-legacy"
+        let configURL = supportDirectory.appendingPathComponent("config.json")
+        try JSONEncoder().encode(staleConfig).write(to: configURL, options: .atomic)
+
+        let loaded = ConfigStore(supportDirectory: supportDirectory).load()
+
+        #expect(loaded.openRouterAPIKey.isEmpty)
+        #expect(try credentialStore.load() == existingCredential)
+        let persistedConfig = try JSONDecoder().decode(
+            AppConfig.self,
+            from: Data(contentsOf: configURL)
+        )
+        #expect(persistedConfig.openRouterAPIKey.isEmpty)
+    }
+
+    private func makeSupportDirectory(label: String) -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(
+            "muesli-config-\(label)-\(UUID().uuidString)",
+            isDirectory: true
+        )
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -438,6 +438,37 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.preferredInputDeviceIDForDictation() == nil)
     }
 
+    @Test("settings device inventory reads use the route cache")
+    func settingsDeviceInventoryReadsUseRouteCache() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.cached-device-inventory")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        routeQueue.sync {}
+        let inspectionCountBeforeRead = inspector.inspectionCallCount
+
+        #expect(controller.cachedAvailableInputDevices().map(\.uid) == ["built-in-mic"])
+        #expect(inspector.inspectionCallCount == inspectionCountBeforeRead)
+
+        inspector.inputDevices.append(
+            AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false)
+        )
+        controller.refreshAvailableInputDevices { _ in }
+        routeQueue.sync {}
+
+        #expect(controller.cachedAvailableInputDevices().map(\.uid) == ["built-in-mic", "external-mic"])
+    }
+
     @Test("default input refresh can notify even when preferred route is unchanged")
     func defaultInputRefreshCanNotifyEvenWhenPreferredRouteIsUnchanged() {
         let inspector = FakeCoreAudioDeviceInspector(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -119,8 +119,8 @@ struct MeetingSummaryClientTests {
         #expect(prompt.count <= 6_000)
     }
 
-    @Test("ChatGPT WHAM requests fix GPT-5.6 reasoning to High")
-    func chatGPTWHAMRequestUsesHighReasoningForGPT56() {
+    @Test("ChatGPT Codex requests fix GPT-5.6 reasoning to High")
+    func chatGPTCodexRequestUsesHighReasoningForGPT56() {
         for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
             let body = ChatGPTResponsesClient.requestBody(
                 systemPrompt: "System",
@@ -133,8 +133,8 @@ struct MeetingSummaryClientTests {
         }
     }
 
-    @Test("ChatGPT WHAM requests preserve GPT-5.4 Mini reasoning behavior")
-    func chatGPTWHAMRequestPreservesGPT54MiniReasoning() {
+    @Test("ChatGPT Codex requests preserve GPT-5.4 Mini reasoning behavior")
+    func chatGPTCodexRequestPreservesGPT54MiniReasoning() {
         let body = ChatGPTResponsesClient.requestBody(
             systemPrompt: "System",
             userPrompt: "User",
@@ -144,8 +144,8 @@ struct MeetingSummaryClientTests {
         #expect(body["reasoning"] == nil)
     }
 
-    @Test("ChatGPT WHAM requests forward explicit output budgets")
-    func chatGPTWHAMRequestForwardsOutputBudget() {
+    @Test("ChatGPT Codex requests forward explicit output budgets")
+    func chatGPTCodexRequestForwardsOutputBudget() {
         let body = ChatGPTResponsesClient.requestBody(
             systemPrompt: "System",
             userPrompt: "User",
@@ -156,8 +156,8 @@ struct MeetingSummaryClientTests {
         #expect(body["max_output_tokens"] as? Int == QuilModelPolicy.remoteMaximumOutputTokens)
     }
 
-    @Test("ChatGPT WHAM parser reads top-level output text")
-    func chatGPTWHAMParserReadsTopLevelOutputText() {
+    @Test("ChatGPT Codex parser reads top-level output text")
+    func chatGPTCodexParserReadsTopLevelOutputText() {
         let payload: [String: Any] = [
             "output_text": "Cleaned dictation text",
         ]
@@ -165,8 +165,8 @@ struct MeetingSummaryClientTests {
         #expect(ChatGPTResponsesClient.extractOutputText(from: payload) == "Cleaned dictation text")
     }
 
-    @Test("ChatGPT WHAM parser reads streaming deltas")
-    func chatGPTWHAMParserReadsStreamingDeltas() {
+    @Test("ChatGPT Codex parser reads streaming deltas")
+    func chatGPTCodexParserReadsStreamingDeltas() {
         let payload: [String: Any] = [
             "type": "response.output_text.delta",
             "delta": "streamed text",
@@ -175,25 +175,25 @@ struct MeetingSummaryClientTests {
         #expect(ChatGPTResponsesClient.extractOutputTextDelta(from: payload) == "streamed text")
     }
 
-    @Test("ChatGPT WHAM parser rejects malformed stream payloads")
-    func chatGPTWHAMParserRejectsMalformedStreamPayloads() {
+    @Test("ChatGPT Codex parser rejects malformed stream payloads")
+    func chatGPTCodexParserRejectsMalformedStreamPayloads() {
         #expect(throws: ChatGPTResponsesError.self) {
             _ = try ChatGPTResponsesClient.decodeStreamPayload("{", httpStatus: 200)
         }
     }
 
-    @Test("ChatGPT WHAM parser ignores heartbeat stream payloads")
-    func chatGPTWHAMParserIgnoresHeartbeatPayloads() throws {
+    @Test("ChatGPT Codex parser ignores heartbeat stream payloads")
+    func chatGPTCodexParserIgnoresHeartbeatPayloads() throws {
         #expect(try ChatGPTResponsesClient.decodeStreamPayload("ping", httpStatus: 200) == nil)
     }
 
-    @Test("ChatGPT WHAM parser ignores blank stream payloads")
-    func chatGPTWHAMParserIgnoresBlankStreamPayloads() throws {
+    @Test("ChatGPT Codex parser ignores blank stream payloads")
+    func chatGPTCodexParserIgnoresBlankStreamPayloads() throws {
         #expect(try ChatGPTResponsesClient.decodeStreamPayload("   ", httpStatus: 200) == nil)
     }
 
-    @Test("ChatGPT WHAM parser ignores valid unknown stream events")
-    func chatGPTWHAMParserIgnoresValidUnknownStreamEvents() throws {
+    @Test("ChatGPT Codex parser ignores valid unknown stream events")
+    func chatGPTCodexParserIgnoresValidUnknownStreamEvents() throws {
         var deltaText = "partial"
         var finalText = ""
         let decoded = try ChatGPTResponsesClient.decodeStreamPayload(
@@ -212,8 +212,8 @@ struct MeetingSummaryClientTests {
         #expect(finalText.isEmpty)
     }
 
-    @Test("ChatGPT WHAM parser prefers final output over streamed deltas")
-    func chatGPTWHAMParserPrefersFinalOutputOverDeltas() {
+    @Test("ChatGPT Codex parser prefers final output over streamed deltas")
+    func chatGPTCodexParserPrefersFinalOutputOverDeltas() {
         var deltaText = ""
         var finalText = ""
 
@@ -241,8 +241,8 @@ struct MeetingSummaryClientTests {
         #expect(ChatGPTResponsesClient.accumulatedOutputText(deltaText: deltaText, finalText: finalText) == "final cleaned text")
     }
 
-    @Test("ChatGPT WHAM parser reads nested final response payload")
-    func chatGPTWHAMParserReadsNestedFinalResponsePayload() {
+    @Test("ChatGPT Codex parser reads nested final response payload")
+    func chatGPTCodexParserReadsNestedFinalResponsePayload() {
         let payload: [String: Any] = [
             "type": "response.completed",
             "response": [
@@ -264,8 +264,8 @@ struct MeetingSummaryClientTests {
         #expect(ChatGPTResponsesClient.extractOutputText(from: payload) == "Nested final response text")
     }
 
-    @Test("ChatGPT WHAM parser reads output content text")
-    func chatGPTWHAMParserReadsOutputContentText() {
+    @Test("ChatGPT Codex parser reads output content text")
+    func chatGPTCodexParserReadsOutputContentText() {
         let payload: [String: Any] = [
             "output": [
                 [
@@ -398,7 +398,8 @@ struct MeetingSummaryClientTests {
         let result = try await MeetingSummaryClient.summarize(
             transcript: "Test transcript",
             meetingTitle: "My Meeting",
-            config: config
+            config: config,
+            openRouterAPIKeyOverride: ""
         )
 
         // No key → falls back to raw transcript
@@ -639,7 +640,8 @@ struct MeetingSummaryClientTests {
 
         let title = await MeetingSummaryClient.generateTitle(
             transcript: "Sprint planning discussion",
-            config: config
+            config: config,
+            openRouterAPIKeyOverride: ""
         )
 
         #expect(title == nil)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1275,6 +1275,50 @@ struct MeetingsNavigationTests {
         #expect(!controller.appState.config.enablePostProcessor)
     }
 
+    @Test("disconnecting OpenRouter replaces every active OpenRouter provider")
+    func disconnectingOpenRouterFallsBackSafely() throws {
+        let supportDirectory = makeSupportDirectory()
+        let configStore = ConfigStore(supportDirectory: supportDirectory)
+        let credentialStore = OpenRouterCredentialStore(supportDirectory: supportDirectory)
+        let openRouterAuth = OpenRouterAuthManager(
+            credentialStore: credentialStore,
+            loadData: { _ in throw URLError(.unsupportedURL) },
+            openURL: { _ in false }
+        )
+        try openRouterAuth.storeManualAPIKey("sk-or-v1-test")
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            configStore: configStore,
+            openRouterAuth: openRouterAuth
+        )
+        controller.updateConfig {
+            $0.meetingSummaryBackend = MeetingSummaryBackendOption.openRouter.backend
+            $0.postProcessorBackend = LLMBackendOption.openRouter.backend
+            $0.quilBackend = LLMBackendOption.openRouter.backend
+            $0.quilModel = "openai/gpt-5.4"
+        }
+
+        controller.signOutOpenRouter()
+
+        #expect(!openRouterAuth.isAuthenticated)
+        #expect(controller.selectedMeetingSummaryBackend == .openAI)
+        #expect(controller.config.meetingSummaryBackend == MeetingSummaryBackendOption.openAI.backend)
+        #expect(controller.selectedPostProcessorBackend == .local)
+        #expect(controller.config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(controller.config.quilBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(controller.config.quilModel == PostProcessorOption.defaultQuilOption.id)
+
+        let persisted = configStore.load()
+        #expect(persisted.meetingSummaryBackend == MeetingSummaryBackendOption.openAI.backend)
+        #expect(persisted.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(persisted.quilBackend == TranscriptCleanupBackendOption.local.backend)
+    }
+
     @Test("startup repairs a persisted Gemma dictation and cleanup conflict")
     func startupRepairsPersistedGemmaConflict() {
         let configStore = ConfigStore(supportDirectory: makeSupportDirectory())

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -4,6 +4,10 @@ import Foundation
 import MuesliCore
 @testable import MuesliNativeApp
 
+private enum OpenRouterDisconnectTestError: Error {
+    case expected
+}
+
 @MainActor
 @Suite("Meetings navigation")
 struct MeetingsNavigationTests {
@@ -1283,7 +1287,8 @@ struct MeetingsNavigationTests {
         let openRouterAuth = OpenRouterAuthManager(
             credentialStore: credentialStore,
             loadData: { _ in throw URLError(.unsupportedURL) },
-            openURL: { _ in false }
+            openURL: { _ in false },
+            environment: { [:] }
         )
         try openRouterAuth.storeManualAPIKey("sk-or-v1-test")
         let controller = MuesliController(
@@ -1303,7 +1308,7 @@ struct MeetingsNavigationTests {
             $0.quilModel = "openai/gpt-5.4"
         }
 
-        controller.signOutOpenRouter()
+        #expect(controller.signOutOpenRouter() == nil)
 
         #expect(!openRouterAuth.isAuthenticated)
         #expect(controller.selectedMeetingSummaryBackend == .openAI)
@@ -1317,6 +1322,83 @@ struct MeetingsNavigationTests {
         #expect(persisted.meetingSummaryBackend == MeetingSummaryBackendOption.openAI.backend)
         #expect(persisted.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
         #expect(persisted.quilBackend == TranscriptCleanupBackendOption.local.backend)
+    }
+
+    @Test("failed OpenRouter credential deletion preserves provider selections")
+    func failedOpenRouterDisconnectPreservesSelections() throws {
+        let supportDirectory = makeSupportDirectory()
+        let configStore = ConfigStore(supportDirectory: supportDirectory)
+        let credentialStore = OpenRouterCredentialStore(supportDirectory: supportDirectory)
+        try credentialStore.save(OpenRouterCredential(apiKey: "sk-or-v1-retained", userID: nil))
+        let openRouterAuth = OpenRouterAuthManager(
+            credentialStore: credentialStore,
+            loadData: { _ in throw URLError(.unsupportedURL) },
+            openURL: { _ in false },
+            environment: { [:] },
+            deleteCredential: { throw OpenRouterDisconnectTestError.expected }
+        )
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            configStore: configStore,
+            openRouterAuth: openRouterAuth
+        )
+        controller.updateConfig {
+            $0.meetingSummaryBackend = MeetingSummaryBackendOption.openRouter.backend
+            $0.postProcessorBackend = LLMBackendOption.openRouter.backend
+            $0.quilBackend = LLMBackendOption.openRouter.backend
+        }
+
+        let error = controller.signOutOpenRouter()
+
+        #expect(error == OpenRouterAuthError.credentialDeletionFailed.errorDescription)
+        #expect(openRouterAuth.isAuthenticated)
+        #expect(controller.selectedMeetingSummaryBackend == .openRouter)
+        #expect(controller.selectedPostProcessorBackend == .hosted(.openRouter))
+        #expect(controller.config.quilBackend == LLMBackendOption.openRouter.backend)
+    }
+
+    @Test("environment OpenRouter credential survives local disconnect without resetting providers")
+    func environmentOpenRouterCredentialPreservesSelections() throws {
+        let supportDirectory = makeSupportDirectory()
+        let configStore = ConfigStore(supportDirectory: supportDirectory)
+        let credentialStore = OpenRouterCredentialStore(supportDirectory: supportDirectory)
+        let openRouterAuth = OpenRouterAuthManager(
+            credentialStore: credentialStore,
+            loadData: { _ in throw URLError(.unsupportedURL) },
+            openURL: { _ in false },
+            environment: { ["OPENROUTER_API_KEY": "sk-or-v1-environment"] }
+        )
+        try openRouterAuth.storeManualAPIKey("sk-or-v1-local")
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            configStore: configStore,
+            openRouterAuth: openRouterAuth
+        )
+        controller.updateConfig {
+            $0.meetingSummaryBackend = MeetingSummaryBackendOption.openRouter.backend
+            $0.postProcessorBackend = LLMBackendOption.openRouter.backend
+            $0.quilBackend = LLMBackendOption.openRouter.backend
+        }
+
+        #expect(controller.signOutOpenRouter() == nil)
+
+        #expect(openRouterAuth.isAuthenticated)
+        #expect(openRouterAuth.hasEnvironmentCredential)
+        #expect(!openRouterAuth.hasStoredCredential)
+        #expect(controller.appState.isOpenRouterEnvironmentManaged)
+        #expect(controller.selectedMeetingSummaryBackend == .openRouter)
+        #expect(controller.selectedPostProcessorBackend == .hosted(.openRouter))
+        #expect(controller.config.quilBackend == LLMBackendOption.openRouter.backend)
     }
 
     @Test("startup repairs a persisted Gemma dictation and cleanup conflict")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -714,6 +714,18 @@ struct SummaryModelPresetTests {
         #expect(menuPresets.count == SummaryModelPreset.openRouterModels.count)
     }
 
+    @Test("OpenRouter catalog selections always persist their exact model ID")
+    func openRouterCatalogSelectionPersistsModelID() {
+        let dynamicFirstModel = "provider/dynamic-first-model:free"
+
+        #expect(
+            OpenRouterModelSelection.persistedModelID(for: dynamicFirstModel) == dynamicFirstModel
+        )
+        #expect(
+            OpenRouterModelSelection.persistedModelID(for: "  \(dynamicFirstModel)  ") == dynamicFirstModel
+        )
+    }
+
     @Test("OpenRouter catalog filters free text generation models")
     func openRouterCatalogFiltersFreeTextModels() throws {
         let payload = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1000,21 +1000,35 @@ struct AppConfigTests {
         ))
     }
 
-    @Test("OpenRouter cleanup key falls back to environment")
-    func openRouterCleanupKeyFallsBackToEnvironment() {
+    @Test("OpenRouter cleanup key uses environment, stored credential, then legacy config")
+    func openRouterCleanupKeyPrecedence() throws {
+        let supportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-openrouter-resolution-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+        let credentialStore = OpenRouterCredentialStore(supportDirectory: supportDirectory)
         var config = AppConfig()
         config.openRouterAPIKey = ""
 
         #expect(TranscriptCleanupClient.resolvedOpenRouterAPIKey(
             config: config,
-            environment: ["OPENROUTER_API_KEY": "sk-or-env"]
+            environment: ["OPENROUTER_API_KEY": "sk-or-env"],
+            credentialStore: credentialStore
         ) == "sk-or-env")
 
+        try credentialStore.save(OpenRouterCredential(apiKey: "sk-or-stored", userID: nil))
         config.openRouterAPIKey = " sk-or-config "
 
         #expect(TranscriptCleanupClient.resolvedOpenRouterAPIKey(
             config: config,
-            environment: ["OPENROUTER_API_KEY": "sk-or-env"]
+            environment: [:],
+            credentialStore: credentialStore
+        ) == "sk-or-stored")
+
+        try credentialStore.delete()
+        #expect(TranscriptCleanupClient.resolvedOpenRouterAPIKey(
+            config: config,
+            environment: [:],
+            credentialStore: credentialStore
         ) == "sk-or-config")
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
@@ -53,19 +53,23 @@ struct MuesliCLITests {
         #expect(context.databaseURL.path == "/tmp/muesli-support/muesli.db")
     }
 
-    @Test("summary config reads the app's protected OpenRouter credential")
-    func summaryConfigReadsOpenRouterCredential() throws {
+    @Test("summary config reads the app's persisted OpenRouter selection and protected credential")
+    func summaryConfigReadsAppOpenRouterSettings() throws {
         let supportDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-cli-openrouter-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: supportDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: supportDirectory) }
 
-        try Data(#"{"meetingSummaryBackend":"openrouter"}"#.utf8)
+        try Data(
+            #"{"meeting_summary_backend":"openrouter","openrouter_model":"openai/gpt-oss-120b:free"}"#.utf8
+        )
             .write(to: supportDirectory.appendingPathComponent("config.json"))
         try Data(#"{"api_key":"sk-or-cli-test","user_id":"user_test"}"#.utf8)
             .write(to: supportDirectory.appendingPathComponent("openrouter-auth.json"))
 
         let config = CLISummaryConfig.load(from: supportDirectory)
+        #expect(config.meetingSummaryBackend == "openrouter")
+        #expect(config.openRouterModel == "openai/gpt-oss-120b:free")
         #expect(config.openRouterAPIKey == "sk-or-cli-test")
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
@@ -53,6 +53,22 @@ struct MuesliCLITests {
         #expect(context.databaseURL.path == "/tmp/muesli-support/muesli.db")
     }
 
+    @Test("summary config reads the app's protected OpenRouter credential")
+    func summaryConfigReadsOpenRouterCredential() throws {
+        let supportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-cli-openrouter-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: supportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+
+        try Data(#"{"meetingSummaryBackend":"openrouter"}"#.utf8)
+            .write(to: supportDirectory.appendingPathComponent("config.json"))
+        try Data(#"{"api_key":"sk-or-cli-test","user_id":"user_test"}"#.utf8)
+            .write(to: supportDirectory.appendingPathComponent("openrouter-auth.json"))
+
+        let config = CLISummaryConfig.load(from: supportDirectory)
+        #expect(config.openRouterAPIKey == "sk-or-cli-test")
+    }
+
     @Test("migration runs before a read so a legacy database gains new columns")
     func migrationWarningsUpgradesLegacyDatabase() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/native/MuesliNative/Tests/MuesliTests/OpenRouterAuthTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OpenRouterAuthTests.swift
@@ -1,0 +1,233 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("OpenRouter OAuth")
+struct OpenRouterAuthTests {
+    @Test("PKCE uses a unique, unpadded base64url verifier and S256 challenge")
+    @MainActor
+    func pkce() {
+        let auth = makeAuth()
+        let first = auth.generatePKCE()
+        let second = auth.generatePKCE()
+
+        #expect(first.verifier.count >= 43)
+        #expect(!first.verifier.contains("+"))
+        #expect(!first.verifier.contains("/"))
+        #expect(!first.verifier.contains("="))
+        #expect(first.verifier != second.verifier)
+        #expect(
+            first.challenge == Data(SHA256.hash(data: Data(first.verifier.utf8))).base64URLEncoded()
+        )
+    }
+
+    @Test("callback paths are high entropy and unique")
+    @MainActor
+    func callbackPath() {
+        let auth = makeAuth()
+        let first = auth.generateCallbackPath()
+        let second = auth.generateCallbackPath()
+
+        #expect(first.hasPrefix("/muesli/openrouter/oauth/"))
+        #expect(first.count >= 68)
+        #expect(first != second)
+    }
+
+    @Test("authorization URL uses OpenRouter callback and PKCE S256 parameters")
+    @MainActor
+    func authorizationURL() throws {
+        let auth = makeAuth()
+        let callbackURL = URL(string: "http://localhost:54321/muesli/openrouter/oauth/secret")!
+        let url = try #require(
+            auth.buildAuthorizationURL(callbackURL: callbackURL, codeChallenge: "challenge")
+        )
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let parameters = Dictionary(
+            uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+                item.value.map { (item.name, $0) }
+            }
+        )
+
+        #expect(components.scheme == "https")
+        #expect(components.host == "openrouter.ai")
+        #expect(components.path == "/auth")
+        #expect(parameters["callback_url"] == callbackURL.absoluteString)
+        #expect(parameters["code_challenge"] == "challenge")
+        #expect(parameters["code_challenge_method"] == "S256")
+        #expect(OpenRouterAuthManager.callbackTimeoutSeconds == 600)
+    }
+
+    @Test("callback parser accepts only the exact one-shot callback path")
+    @MainActor
+    func callbackValidation() {
+        let auth = makeAuth()
+        let path = "/muesli/openrouter/oauth/secret"
+
+        #expect(
+            auth.parseCallbackRequest(
+                "GET \(path)?code=abc%3D123 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                expectedPath: path
+            ) == .authorizationCode("abc=123")
+        )
+        #expect(
+            auth.parseCallbackRequest(
+                "GET /muesli/openrouter/oauth/wrong?code=stolen HTTP/1.1\r\n\r\n",
+                expectedPath: path
+            ) == .unrelated
+        )
+        #expect(
+            auth.parseCallbackRequest(
+                "POST \(path)?code=abc HTTP/1.1\r\n\r\n",
+                expectedPath: path
+            ) == .invalid
+        )
+        #expect(
+            auth.parseCallbackRequest(
+                "GET \(path)?error=access_denied HTTP/1.1\r\n\r\n",
+                expectedPath: path
+            ) == .providerError("access_denied")
+        )
+        #expect(
+            auth.parseCallbackRequest(
+                "GET \(path) HTTP/1.1\r\n\r\n",
+                expectedPath: path
+            ) == .missingCode
+        )
+    }
+
+    @Test("key exchange sends the documented JSON and returns key plus user id")
+    @MainActor
+    func keyExchange() async throws {
+        let recorder = RequestRecorder()
+        let responseData = Data(#"{"key":"sk-or-v1-secret","user_id":"user_123"}"#.utf8)
+        let auth = makeAuth { request in
+            await recorder.record(request)
+            return (
+                responseData,
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+            )
+        }
+
+        let credential = try await auth.exchangeAuthorizationCode("one-shot-code", codeVerifier: "verifier")
+        #expect(credential == OpenRouterCredential(apiKey: "sk-or-v1-secret", userID: "user_123"))
+
+        let recordedRequest = await recorder.request
+        let request = try #require(recordedRequest)
+        #expect(request.url?.absoluteString == "https://openrouter.ai/api/v1/auth/keys")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+        let body = try #require(request.httpBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+        #expect(json["code"] == "one-shot-code")
+        #expect(json["code_verifier"] == "verifier")
+        #expect(json["code_challenge_method"] == "S256")
+    }
+
+    @Test("key exchange reports status without reflecting response secrets")
+    @MainActor
+    func keyExchangeErrorIsSanitized() async {
+        let auth = makeAuth { request in
+            (
+                Data(#"{"error":"do not echo this secret"}"#.utf8),
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 403,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+            )
+        }
+
+        await #expect(throws: OpenRouterAuthError.keyExchangeFailed(statusCode: 403)) {
+            try await auth.exchangeAuthorizationCode("code", codeVerifier: "verifier")
+        }
+    }
+
+    @Test("credential store uses owner-only permissions and sign-out is local")
+    @MainActor
+    func credentialStorageAndLocalSignOut() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-openrouter-auth-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = OpenRouterCredentialStore(supportDirectory: root)
+        let credential = OpenRouterCredential(apiKey: "sk-or-v1-local", userID: "user_local")
+        try store.save(credential)
+
+        #expect(try store.load() == credential)
+        let attributes = try FileManager.default.attributesOfItem(atPath: store.fileURL.path)
+        let permissions = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(permissions.intValue == 0o600)
+
+        let auth = OpenRouterAuthManager(
+            credentialStore: store,
+            loadData: openRouterUnusedLoader,
+            openURL: { _ in false }
+        )
+        let manageURL = auth.manageKeyURL
+        auth.signOut()
+
+        #expect(manageURL == OpenRouterAuthManager.manageKeyURL(for: credential.apiKey))
+        #expect(!auth.isAuthenticated)
+        #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    @Test("manage-key URL is the lowercase SHA256 key hash")
+    func manageKeyURL() {
+        #expect(
+            OpenRouterAuthManager.manageKeyURL(for: "abc").absoluteString ==
+                "https://openrouter.ai/keys/ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        )
+    }
+
+    @Test("manual keys are normalized and stored, with environment fallback")
+    @MainActor
+    func manualKeyAndEnvironmentFallback() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-openrouter-manual-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let auth = OpenRouterAuthManager(
+            credentialStore: OpenRouterCredentialStore(supportDirectory: root),
+            loadData: openRouterUnusedLoader,
+            openURL: { _ in false }
+        )
+
+        #expect(auth.resolvedAPIKey(environment: ["OPENROUTER_API_KEY": " env-key "]) == "env-key")
+        try auth.storeManualAPIKey("  manual-key\n")
+        #expect(auth.resolvedAPIKey(environment: ["OPENROUTER_API_KEY": "env-key"]) == "env-key")
+        #expect(auth.resolvedAPIKey(environment: [:]) == "manual-key")
+        #expect(auth.isAuthenticated)
+    }
+
+    @MainActor
+    private func makeAuth(
+        loadData: @escaping (URLRequest) async throws -> (Data, URLResponse) = openRouterUnusedLoader
+    ) -> OpenRouterAuthManager {
+        let supportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("unused-openrouter-auth-\(UUID().uuidString)", isDirectory: true)
+        return OpenRouterAuthManager(
+            credentialStore: OpenRouterCredentialStore(supportDirectory: supportDirectory),
+            loadData: loadData,
+            openURL: { _ in false }
+        )
+    }
+
+}
+
+private func openRouterUnusedLoader(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    throw URLError(.unsupportedURL)
+}
+
+private actor RequestRecorder {
+    private(set) var request: URLRequest?
+
+    func record(_ request: URLRequest) {
+        self.request = request
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/OpenRouterAuthTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OpenRouterAuthTests.swift
@@ -168,14 +168,51 @@ struct OpenRouterAuthTests {
         let auth = OpenRouterAuthManager(
             credentialStore: store,
             loadData: openRouterUnusedLoader,
-            openURL: { _ in false }
+            openURL: { _ in false },
+            environment: { [:] }
         )
         let manageURL = auth.manageKeyURL
-        auth.signOut()
+        try auth.signOut()
 
         #expect(manageURL == OpenRouterAuthManager.manageKeyURL(for: credential.apiKey))
         #expect(!auth.isAuthenticated)
         #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    @Test("sign-out reports deletion failure and preserves authentication")
+    @MainActor
+    func signOutDeletionFailure() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-openrouter-delete-failure-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = OpenRouterCredentialStore(supportDirectory: root)
+        try store.save(OpenRouterCredential(apiKey: "sk-or-v1-retained", userID: nil))
+        let auth = OpenRouterAuthManager(
+            credentialStore: store,
+            loadData: openRouterUnusedLoader,
+            openURL: { _ in false },
+            environment: { [:] },
+            deleteCredential: { throw OpenRouterDeletionTestError.expected }
+        )
+
+        #expect(throws: OpenRouterAuthError.credentialDeletionFailed) {
+            try auth.signOut()
+        }
+        #expect(auth.isAuthenticated)
+        #expect(try store.load()?.apiKey == "sk-or-v1-retained")
+    }
+
+    @Test("environment credentials are authenticated and managed explicitly")
+    @MainActor
+    func environmentCredentialState() {
+        let auth = makeAuth(environment: { ["OPENROUTER_API_KEY": "  sk-or-v1-environment  "] })
+
+        #expect(auth.hasEnvironmentCredential)
+        #expect(!auth.hasStoredCredential)
+        #expect(auth.isAuthenticated)
+        #expect(
+            auth.manageKeyURL == OpenRouterAuthManager.manageKeyURL(for: "sk-or-v1-environment")
+        )
     }
 
     @Test("manage-key URL is the lowercase SHA256 key hash")
@@ -195,7 +232,8 @@ struct OpenRouterAuthTests {
         let auth = OpenRouterAuthManager(
             credentialStore: OpenRouterCredentialStore(supportDirectory: root),
             loadData: openRouterUnusedLoader,
-            openURL: { _ in false }
+            openURL: { _ in false },
+            environment: { [:] }
         )
 
         #expect(auth.resolvedAPIKey(environment: ["OPENROUTER_API_KEY": " env-key "]) == "env-key")
@@ -207,17 +245,23 @@ struct OpenRouterAuthTests {
 
     @MainActor
     private func makeAuth(
-        loadData: @escaping (URLRequest) async throws -> (Data, URLResponse) = openRouterUnusedLoader
+        loadData: @escaping (URLRequest) async throws -> (Data, URLResponse) = openRouterUnusedLoader,
+        environment: @escaping () -> [String: String] = { [:] }
     ) -> OpenRouterAuthManager {
         let supportDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("unused-openrouter-auth-\(UUID().uuidString)", isDirectory: true)
         return OpenRouterAuthManager(
             credentialStore: OpenRouterCredentialStore(supportDirectory: supportDirectory),
             loadData: loadData,
-            openURL: { _ in false }
+            openURL: { _ in false },
+            environment: environment
         )
     }
 
+}
+
+private enum OpenRouterDeletionTestError: Error {
+    case expected
 }
 
 private func openRouterUnusedLoader(_ request: URLRequest) async throws -> (Data, URLResponse) {

--- a/native/MuesliNative/Tests/MuesliTests/SettingsPermissionRefreshReasonTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SettingsPermissionRefreshReasonTests.swift
@@ -8,6 +8,7 @@ struct SettingsPermissionRefreshReasonTests {
         #expect(SettingsPermissionRefreshReason.periodicPoll.refreshesSystemAudio == false)
         #expect(SettingsPermissionRefreshReason.periodicPoll.refreshesLaunchAtLogin == false)
         #expect(SettingsPermissionRefreshReason.permissionRequested.refreshesSystemAudio == false)
+        #expect(SettingsPermissionRefreshReason.permissionRequested.refreshesLaunchAtLogin == false)
     }
 
     @Test("settings lifecycle boundaries refresh system-audio permission")

--- a/native/MuesliNative/Tests/MuesliTests/SettingsPermissionRefreshReasonTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SettingsPermissionRefreshReasonTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Settings permission refresh reasons")
+struct SettingsPermissionRefreshReasonTests {
+    @Test("periodic polling reuses the cached system-audio permission")
+    func periodicPollingReusesSystemAudioCache() {
+        #expect(SettingsPermissionRefreshReason.periodicPoll.refreshesSystemAudio == false)
+        #expect(SettingsPermissionRefreshReason.periodicPoll.refreshesLaunchAtLogin == false)
+        #expect(SettingsPermissionRefreshReason.permissionRequested.refreshesSystemAudio == false)
+    }
+
+    @Test("settings lifecycle boundaries refresh system-audio permission")
+    func lifecycleBoundariesRefreshSystemAudioPermission() {
+        #expect(SettingsPermissionRefreshReason.initialDisplay.refreshesSystemAudio)
+        #expect(SettingsPermissionRefreshReason.settingsSelected.refreshesSystemAudio)
+        #expect(SettingsPermissionRefreshReason.appActivated.refreshesSystemAudio)
+    }
+
+    @Test("only app activation refreshes launch-at-login state")
+    func onlyAppActivationRefreshesLaunchAtLogin() {
+        #expect(SettingsPermissionRefreshReason.initialDisplay.refreshesLaunchAtLogin == false)
+        #expect(SettingsPermissionRefreshReason.settingsSelected.refreshesLaunchAtLogin == false)
+        #expect(SettingsPermissionRefreshReason.appActivated.refreshesLaunchAtLogin)
+    }
+}

--- a/scripts/muesli_spm_cache.sh
+++ b/scripts/muesli_spm_cache.sh
@@ -18,8 +18,8 @@ muesli_spm_scratch_disabled() {
 }
 
 muesli_default_spm_cache_root() {
-  local external_root="${MUESLI_EXTERNAL_SPM_CACHE_ROOT:-/Volumes/MuesliBuildCache/muesli-spm}"
-  if [[ -d "$external_root" ]]; then
+  local external_root="${MUESLI_EXTERNAL_SPM_CACHE_ROOT:-}"
+  if [[ -n "$external_root" && -d "$external_root" ]]; then
     printf '%s\n' "$external_root"
   else
     printf '%s\n' "$HOME/Library/Caches/muesli-spm"

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -22,7 +22,9 @@ case "${shard}" in
       MuesliCKSyncEngineTests
       MuesliCLITests
       ChatGPTAuthTests
+      ChatGPTResponsesTransportTests
       ChatGPTTokenStorageTests
+      OpenRouterAuthTests
       FloatingIndicatorVisibilityTests
       IndicatorFrameSizeTests
       WindowAppearanceTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -25,6 +25,7 @@ case "${shard}" in
       ChatGPTResponsesTransportTests
       ChatGPTTokenStorageTests
       OpenRouterAuthTests
+      SettingsPermissionRefreshReasonTests
       FloatingIndicatorVisibilityTests
       IndicatorFrameSizeTests
       WindowAppearanceTests


### PR DESCRIPTION
## Summary

This PR began as a provider-authentication overhaul and now also includes the Settings responsiveness and local build/runtime hardening uncovered while validating those flows in Dev B. The combined change has been tested and reviewed as one integration.

### ChatGPT and OpenRouter

- Route ChatGPT OAuth inference through one shared Responses transport for meeting summaries, transcript cleanup, and computer-use planning. Codex is the default lane and Muesli identifies itself truthfully through `originator` and `User-Agent` metadata.
- Do not send Muesli's application version as Codex's `version` header. A live request demonstrated that `version: 0.8.4` was interpreted as an obsolete Codex client version; omitting the optional header restored access to the default `gpt-5.6-sol` planner model.
- Keep an explicit emergency rollback to the legacy WHAM transport through `MUESLI_CHATGPT_TRANSPORT=wham`. There is no automatic POST retry or silent fallback between lanes.
- Add OpenRouter browser authorization with PKCE S256, an ephemeral IPv4 loopback callback, a high-entropy callback path, exact callback validation, protected API-key storage, legacy-key migration, and environment-key awareness.
- Make browser connection the primary OpenRouter setup flow in onboarding and Settings while retaining manual-key and `OPENROUTER_API_KEY` compatibility for existing users and automation.
- Provide consistent Connected, Manage key, and Disconnect controls. Local credential deletion failures are visible and preserve provider selections; selections reset only when no usable OpenRouter credential remains.
- Keep dynamic free-model discovery while restoring persistent custom `provider/model` IDs. The dropdown and custom-model field remain synchronized and persist the exact selected model ID.
- Share OpenRouter credential resolution with the CLI. The CLI now decodes the app's persisted snake_case summary-provider keys, including `meeting_summary_backend` and `openrouter_model`, instead of silently falling back to ChatGPT.

### Settings responsiveness and controls

- Stop periodic Settings permission polling from creating CoreAudio process taps. System-audio permission work is limited to lifecycle boundaries and explicit requests, and overlapping grant requests are serialized.
- Render cached audio-input inventory immediately and refresh HAL device information asynchronously so opening Dictation or Meetings settings does not synchronously enumerate CoreAudio devices on the main actor.
- Move calendar inventory refreshes off the main actor to remove the remaining perceptible Meetings-tab navigation delay.
- Use native numeric text fields with standard increment/decrement steppers for computer-use timeout, meeting-summary retries, and meeting-hook timeout.

### Local build and runtime workflow

- Make the complete LocalVQE runtime mandatory for every signed dev, preproduction, and release bundle; a committed GGUF model alone is not treated as a complete runtime.
- Document source-runtime and installed-bundle validation, including all required LocalVQE/ggml companion libraries.
- Retire automatic discovery of the old eSSD `/Volumes/MuesliBuildCache` cache path. The canonical cache is `~/Library/Caches/muesli-spm`; external roots are used only when explicitly provided through `MUESLI_EXTERNAL_SPM_CACHE_ROOT`.

## Research and compatibility

Official Codex clients currently use `https://chatgpt.com/backend-api/codex`, while Muesli historically targeted WHAM:

- https://github.com/openai/codex/blob/main/codex-rs/model-provider-info/src/lib.rs
- https://developers.openai.com/codex/auth/
- https://github.com/openai/codex/issues/36886
- https://github.com/openai/codex/issues/31967

The direct third-party Codex backend remains undocumented and compatibility-sensitive. This change centralizes the seam, identifies as Muesli rather than impersonating `codex_cli_rs`, and keeps a narrow explicit rollback path.

OpenRouter OAuth provisions a normal user-controlled API key through its documented PKCE flow:

- https://openrouter.ai/docs/guides/overview/auth/oauth
- https://openrouter.ai/docs/api/api-reference/oauth/exchange-authorization-code-for-api-key
- https://openrouter.ai/docs/guides/overview/auth/management-api-keys

## Validation

- Exact PR head `777ed00a` passed the GitHub release build, core, dictation/transcription, meetings, Apple Speech macOS 26, CLI smoke, update-flow, classifier, CodeQL, DCO, and aggregate CI gate checks.
- Greptile reviewed exact head `777ed00a` at 5/5 confidence with zero unresolved comments and no blocking failure.
- The focused MuesliCLI suite passed all 28 tests, including an app-shaped OpenRouter configuration fixture that verifies the backend, model, and protected credential.
- The focused ChatGPT transport suite passed all 5 tests after removing the Codex `version` header.
- Earlier final focused validation passed 81 tests across OpenRouter OAuth, model selection, Settings permission refresh, summary presets, and Meetings navigation.
- A live Dev B computer-use request using ChatGPT OAuth and the default `gpt-5.6-sol` model reached the Codex lane and returned seven native tool calls. Its later executor failure was caused by a missing Chrome profile, not provider transport.
- `./scripts/test_classify_changed_files.sh`
- `./scripts/test_ci_test_shards.sh`
- `./scripts/verify_update_flow.sh --skip-dmg`
- `./scripts/test_localvqe_runtime_validation.sh`
- `git diff --check`
- Dev B was rebuilt and launched from the canonical local cache. The installed app contains all 13 LocalVQE runtime files and passes deep-signature and installed-runtime verification.

The unfiltered Swift suite was started during local validation but manually stopped in its long audio-test tail; it is not represented as a completed pass.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` certification, directly or through the DCO remediation commit.
- [x] I have the right to submit these changes under the repository license.
- [x] The contribution does not knowingly include confidential or improperly licensed material.
- [x] Third-party materials and their licensing or service terms are disclosed below.
- [x] Material AI assistance is disclosed below.

### Third-party materials

No third-party source code, models, datasets, media, or assets were added. This integration uses OpenRouter and OpenAI web APIs under their service terms; official documentation is linked above.

### AI assistance

OpenAI Codex was used materially for research, implementation, tests, and review remediation. The resulting changes were reviewed and tested by the contributor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenRouter account connection during onboarding and Settings, including browser sign-in, manual API-key entry, sign-out, and key management.
  - Added custom OpenRouter model IDs alongside available model presets.
  - OpenRouter credentials are securely recognized across summaries, title generation, transcript cleanup, and the CLI.
  - ChatGPT Responses now uses Codex by default, with optional WHAM compatibility.

- **Bug Fixes**
  - Signing out of OpenRouter switches affected features to safe alternatives only when no usable credential remains.
  - CLI configuration preserves the provider and model written by the native app.
  - Settings loads audio devices immediately, refreshes hardware and calendar inventory asynchronously, and avoids process-tap creation during periodic permission polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
