### PR TITLE
Add Apple Speech live and final meeting transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ By default, dictation uses an on-device model. You can instead opt into OpenAI S
 ### Meeting Transcription
 Start a meeting recording → Muesli captures your mic (You) and system audio (Others) simultaneously → VAD-driven chunked transcription happens during the meeting at natural speech boundaries → speaker diarization identifies individual remote speakers (Speaker 1, Speaker 2, etc.) → when you stop, the transcript is ready in seconds, not minutes. Generate structured meeting notes via OpenAI, free OpenRouter models, your ChatGPT Plus/Pro subscription, or local Ollama models.
 
-Live meeting transcripts have two explicit modes. **Nemotron 3.5** is a unified multilingual option: its continuous transcript is the normal final raw transcript before diarization and note generation, with the configured meeting model retained only for gap recovery. **Parakeet Realtime EOU** is a low-latency English preview: it powers the live floating transcript while a separately selected meeting model creates the final transcript. Settings always shows which model owns the final transcript.
+Live meeting transcripts have two explicit modes. **Nemotron 3.5** is a unified multilingual option: its continuous transcript is the normal final raw transcript before diarization and note generation, with the configured meeting model retained only for gap recovery. **Apple Speech** and **Parakeet Realtime EOU** provide provisional live previews while a separately selected meeting model creates the final transcript. Apple Speech adds system-supported languages on macOS 26+, while Parakeet Realtime EOU remains the low-latency English option. Settings always shows which model owns the final transcript.
 
-Live transcription is off by default. Download Parakeet Realtime EOU or Nemotron 3.5 from Models, then select one under **Settings → Meetings → Transcription**. The waveform-hover preview can be enabled separately from the same section. Downloading a streaming model does not activate it automatically.
+Live transcription is off by default. Choose Apple Speech, or download Parakeet Realtime EOU or Nemotron 3.5, from Models and then select one under **Settings → Meetings → Transcription**. The waveform-hover preview can be enabled separately from the same section. Making a live model available does not activate it automatically.
 
 ---
 
@@ -52,7 +52,7 @@ Live transcription is off by default. Download Parakeet Realtime EOU or Nemotron
 - **Quill voice rewriting** — Highlight text to rewrite it from a spoken instruction, or generate new text at the cursor with no selection. Quill supports local and hosted models, hands-free activation, and an independent toggle for its activation and release sounds.
 - **Apple Shortcuts & Siri** — Six preconfigured actions out of the box: Start/Stop Dictation (latched hands-free mode, same as double-tapping the hotkey), Start/Stop Meeting Recording, Get Last Dictation, and Get Last Meeting Notes. Trigger them from Spotlight, Siri ("Start a meeting recording in Muesli"), keyboard shortcuts, or Shortcuts automations — e.g. auto-record when a calendar event starts, or pipe your last dictation into Notes, Messages, or Files.
 - **Meeting recording** — Captures mic + system audio (including Bluetooth/AirPods) with a CoreAudio process tap by default and ScreenCaptureKit fallback. System audio from Zoom, Teams, and other call clients stays on the Others side of the transcript.
-- **Live meeting transcript** — Choose Nemotron 3.5 for one multilingual live-and-final transcript, or Parakeet Realtime EOU for an English live preview paired with a separate final meeting model.
+- **Live meeting transcript** — Choose Nemotron 3.5 for one multilingual live-and-final transcript, Apple Speech for a system-managed multilingual live preview on macOS 26+, or Parakeet Realtime EOU for an English live preview. Preview-only choices remain paired with a separate final meeting model.
 - **VAD-driven chunk rotation** — Silero VAD detects natural speech boundaries in real-time, splitting mic audio at pauses instead of fixed intervals. No mid-sentence cuts.
 - **Speaker diarization** — Identifies individual speakers in system audio (Speaker 1, Speaker 2, etc.) using FluidAudio's pyannote-based CoreML diarization model.
 - **Camera-based meeting detection** — Detects when your webcam + mic activate in a recognized meeting app (Zoom, Chrome, Teams, FaceTime, Slack, WhatsApp). Camera alone (e.g. Photo Booth) won't trigger false positives.
@@ -330,7 +330,7 @@ Important meeting fields:
 
 | Model | Backend | Runtime | Size | Languages | Latency |
 |-------|---------|---------|------|-----------|---------|
-| **Apple Speech** | SpeechAnalyzer / SpeechTranscriber | System-managed | No Muesli model download | System-supported locales | macOS 26+, system dependent |
+| **Apple Speech** | SpeechAnalyzer / SpeechTranscriber | System-managed | No Muesli model download | System-supported locales | Dictation, meetings, live preview on macOS 26+ |
 | **Parakeet v3** (recommended) | FluidAudio | CoreML / Neural Engine | ~450 MB | 25 languages | ~0.13s |
 | Parakeet v2 | FluidAudio | CoreML / Neural Engine | ~450 MB | English only | ~0.13s |
 | Parakeet Realtime EOU | FluidAudio | CoreML / Neural Engine | ~430 MB | English only | Live preview |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ By default, dictation uses an on-device model. You can instead opt into OpenAI S
 ### Meeting Transcription
 Start a meeting recording → Muesli captures your mic (You) and system audio (Others) simultaneously → VAD-driven chunked transcription happens during the meeting at natural speech boundaries → speaker diarization identifies individual remote speakers (Speaker 1, Speaker 2, etc.) → when you stop, the transcript is ready in seconds, not minutes. Generate structured meeting notes via OpenAI, free OpenRouter models, your ChatGPT Plus/Pro subscription, or local Ollama models.
 
-Live meeting transcripts have two explicit modes. **Nemotron 3.5** is a unified multilingual option: its continuous transcript is the normal final raw transcript before diarization and note generation, with the configured meeting model retained only for gap recovery. **Apple Speech** and **Parakeet Realtime EOU** provide provisional live previews while a separately selected meeting model creates the final transcript. Apple Speech adds system-supported languages on macOS 26+, while Parakeet Realtime EOU remains the low-latency English option. Settings always shows which model owns the final transcript.
+Live meeting transcripts have two explicit modes. **Nemotron 3.5** and **Apple Speech** supply live captions and the normal final raw transcript before diarization and note generation. The existing recorded-audio transcription pipeline remains available for missing or incomplete streaming results. **Parakeet Realtime EOU** provides provisional live previews while a separately selected meeting model creates the final transcript. Apple Speech adds system-supported languages on macOS 26+, while Parakeet Realtime EOU remains the low-latency English option. Settings always shows which model owns the final transcript.
 
 Live transcription is off by default. Choose Apple Speech, or download Parakeet Realtime EOU or Nemotron 3.5, from Models and then select one under **Settings → Meetings → Transcription**. The waveform-hover preview can be enabled separately from the same section. Making a live model available does not activate it automatically.
 
@@ -52,7 +52,7 @@ Live transcription is off by default. Choose Apple Speech, or download Parakeet 
 - **Quill voice rewriting** — Highlight text to rewrite it from a spoken instruction, or generate new text at the cursor with no selection. Quill supports local and hosted models, hands-free activation, and an independent toggle for its activation and release sounds.
 - **Apple Shortcuts & Siri** — Six preconfigured actions out of the box: Start/Stop Dictation (latched hands-free mode, same as double-tapping the hotkey), Start/Stop Meeting Recording, Get Last Dictation, and Get Last Meeting Notes. Trigger them from Spotlight, Siri ("Start a meeting recording in Muesli"), keyboard shortcuts, or Shortcuts automations — e.g. auto-record when a calendar event starts, or pipe your last dictation into Notes, Messages, or Files.
 - **Meeting recording** — Captures mic + system audio (including Bluetooth/AirPods) with a CoreAudio process tap by default and ScreenCaptureKit fallback. System audio from Zoom, Teams, and other call clients stays on the Others side of the transcript.
-- **Live meeting transcript** — Choose Nemotron 3.5 for one multilingual live-and-final transcript, Apple Speech for a system-managed multilingual live preview on macOS 26+, or Parakeet Realtime EOU for an English live preview. Preview-only choices remain paired with a separate final meeting model.
+- **Live meeting transcript** — Choose Nemotron 3.5 or system-managed Apple Speech (macOS 26+) for multilingual live-and-final transcripts, or Parakeet Realtime EOU for an English live preview paired with a separate final meeting model.
 - **VAD-driven chunk rotation** — Silero VAD detects natural speech boundaries in real-time, splitting mic audio at pauses instead of fixed intervals. No mid-sentence cuts.
 - **Speaker diarization** — Identifies individual speakers in system audio (Speaker 1, Speaker 2, etc.) using FluidAudio's pyannote-based CoreML diarization model.
 - **Camera-based meeting detection** — Detects when your webcam + mic activate in a recognized meeting app (Zoom, Chrome, Teams, FaceTime, Slack, WhatsApp). Camera alone (e.g. Photo Booth) won't trigger false positives.
@@ -330,7 +330,7 @@ Important meeting fields:
 
 | Model | Backend | Runtime | Size | Languages | Latency |
 |-------|---------|---------|------|-----------|---------|
-| **Apple Speech** | SpeechAnalyzer / SpeechTranscriber | System-managed | No Muesli model download | System-supported locales | Dictation, meetings, live preview on macOS 26+ |
+| **Apple Speech** | SpeechAnalyzer / SpeechTranscriber | System-managed | No Muesli model download | System-supported locales | Dictation, live + final meetings on macOS 26+ |
 | **Parakeet v3** (recommended) | FluidAudio | CoreML / Neural Engine | ~450 MB | 25 languages | ~0.13s |
 | Parakeet v2 | FluidAudio | CoreML / Neural Engine | ~450 MB | English only | ~0.13s |
 | Parakeet Realtime EOU | FluidAudio | CoreML / Neural Engine | ~430 MB | English only | Live preview |

--- a/docs/plans/plan-2026-07-07-streaming-live-transcript.md
+++ b/docs/plans/plan-2026-07-07-streaming-live-transcript.md
@@ -16,15 +16,16 @@ a display-only layer for the in-flight segment: a dimmed, italic "tail" bubble
 per source that updates as speech happens and settles into the committed
 caption when the chunk transcribes.
 
-The partials engine is FluidAudio's Parakeet Realtime EOU 120M model at its
-320 ms output cadence. Two independent cache-aware sessions process mic "You"
-and system "Others" audio. The selected meeting model still produces every
-durable caption; EOU text is provisional and replaced only when that existing
-VAD chunk finishes transcription.
+The partials engine can be FluidAudio's Parakeet Realtime EOU 120M model,
+Nemotron 3.5, or Apple Speech on macOS 26. Two independent sessions process mic
+"You" and system "Others" audio. The selected meeting model still produces
+every durable caption; live text is provisional and replaced only when that
+existing VAD chunk finishes transcription.
 
 ### Gating
 
-- Parakeet Realtime EOU explicitly downloaded from the Models screen
+- Parakeet Realtime EOU or Nemotron explicitly downloaded from the Models
+  screen, or Apple Speech assets managed by macOS 26
 - `enable_live_streaming_partials` config (default true) as a kill switch
 
 Without the model, the live view behaves exactly as before.
@@ -33,8 +34,8 @@ Without the model, the live view behaves exactly as before.
 
 - Replacing the VAD chunk pipeline, checkpoints, or selected meeting model.
 - Persisting provisional EOU output; live notes-on-demand; in-meeting chat.
-- Multilingual provisional captions. The dedicated EOU model is English-only;
-  the durable meeting pipeline retains its existing language support.
+- In-meeting translation. Apple Speech can provide multilingual provisional
+  captions, but it does not translate them.
 
 ## Architecture
 
@@ -45,6 +46,12 @@ Without the model, the live view behaves exactly as before.
   rotation) snapshots the cumulative EOU text length; `commitSegment()` (when
   the existing chunk retires) hides that prefix so the tail keeps only text
   newer than the committed caption.
+- **Apple Speech live adapter**: feeds a bounded `AsyncStream` into Apple's
+  progressive `SpeechAnalyzer`. Results can arrive after `process(samples:)`
+  returns, so callbacks carry the session lifecycle revision. Each VAD boundary
+  freezes that segment's provisional text and rebuilds the analyzer while a
+  bounded queue retains incoming audio. Pause/resume and source recovery use the
+  same generation reset before new results are accepted.
 - **`MeetingSession`**: taps AEC'd mic floats and raw system floats (the same
   streams the VADs consume), feeds the two sessions, marks boundaries in the
   rotation handlers, commits next to `onChunkTranscribed`, tears down with the
@@ -67,8 +74,16 @@ Without the model, the live view behaves exactly as before.
   provisional intervals before they can delay recording or durable chunks.
 - Rotation→commit gap: the frozen prefix stays visible until commit (no
   flicker-to-empty).
-- Pause: the existing VAD rotations run first, tails clear, buffered EOU audio
-  drops, and resume keeps the model warm while hiding the pre-pause prefix.
+- Pause: the existing VAD rotations run first, tails clear, and buffered live
+  audio drops. Cache-aware synchronous models stay warm; Apple Speech rebuilds
+  its analyzer on resume so delayed pre-pause results cannot enter the new
+  lifecycle.
+- Asynchronous boundary finalization: Apple Speech freezes each segment at its
+  VAD boundary. A durable commit removes only the matching frozen segment, so a
+  later segment remains visible even when chunk transcriptions finish out of
+  order. Delayed callbacks from the prior analyzer generation are ignored.
+- Capture source recovery resets the affected live session before accepting
+  audio from the rebuilt source.
 - Transcriber failure mid-meeting: the session logs once and goes dormant;
   committed path unaffected.
 
@@ -77,5 +92,13 @@ Without the model, the live view behaves exactly as before.
 - ANE contention and memory use from two EOU managers plus the durable chunk
   backend must be measured during a long meeting. Failure remains isolated to
   the provisional session and falls back to committed captions.
+- Apple Speech input uses a newest-wins bounded queue. Under sustained analyzer
+  backpressure, stale provisional audio may be dropped rather than increasing
+  memory or delaying recording and durable chunks.
+- Apple Speech's finalized live-text prefix is bounded by the existing VAD
+  maximum-duration rotation (currently five seconds); the analyzer and its live
+  accumulator restart at every boundary. At most 12 frozen provisional
+  segments are retained while durable chunks retire; older provisional text is
+  dropped without affecting the durable transcript.
 - Partial/committed text mismatch when the committed backend differs from
   Parakeet EOU — provisional text settles; inherent to the hybrid design.

--- a/docs/plans/plan-2026-07-07-streaming-live-transcript.md
+++ b/docs/plans/plan-2026-07-07-streaming-live-transcript.md
@@ -11,22 +11,22 @@ by a streaming-native model, not more VAD-chunk simulation.
 ## Approach: hybrid display layer
 
 VAD chunks stay the durable commit mechanism — checkpoints, diarization, crash
-recovery, resume, and the final transcript are untouched. Streaming partials are
-a display-only layer for the in-flight segment: a dimmed, italic "tail" bubble
+recovery, and resume are reused. Streaming partials appear in a dimmed, italic "tail" bubble
 per source that updates as speech happens and settles into the committed
 caption when the chunk transcribes.
 
 The partials engine can be FluidAudio's Parakeet Realtime EOU 120M model,
 Nemotron 3.5, or Apple Speech on macOS 26. Two independent sessions process mic
-"You" and system "Others" audio. The selected meeting model still produces
-every durable caption; live text is provisional and replaced only when that
-existing VAD chunk finishes transcription.
+"You" and system "Others" audio. Nemotron and Apple Speech supply final text
+through the existing chunk pipeline, with recorded-audio transcription as
+fallback. Parakeet EOU remains preview-only; its selected meeting model owns
+the final transcript. Volatile Apple results are never persisted.
 
 ### Gating
 
 - Parakeet Realtime EOU or Nemotron explicitly downloaded from the Models
   screen, or Apple Speech assets managed by macOS 26
-- `enable_live_streaming_partials` config (default true) as a kill switch
+- `enable_live_streaming_partials` config (default false) as a kill switch
 
 Without the model, the live view behaves exactly as before.
 
@@ -49,8 +49,9 @@ Without the model, the live view behaves exactly as before.
 - **Apple Speech live adapter**: feeds a bounded `AsyncStream` into Apple's
   progressive `SpeechAnalyzer`. Results can arrive after `process(samples:)`
   returns, so callbacks carry the session lifecycle revision. Each VAD boundary
-  freezes that segment's provisional text and rebuilds the analyzer while a
-  bounded queue retains incoming audio. Pause/resume and source recovery use the
+  drains submitted audio, finalizes the analyzer, consumes its final results,
+  and rebuilds it while a bounded queue retains incoming audio. Final text
+  replaces batch text through the same policy used for Nemotron. Pause/resume and source recovery use the
   same generation reset before new results are accepted.
 - **`MeetingSession`**: taps AEC'd mic floats and raw system floats (the same
   streams the VADs consume), feeds the two sessions, marks boundaries in the
@@ -78,8 +79,8 @@ Without the model, the live view behaves exactly as before.
   audio drops. Cache-aware synchronous models stay warm; Apple Speech rebuilds
   its analyzer on resume so delayed pre-pause results cannot enter the new
   lifecycle.
-- Asynchronous boundary finalization: Apple Speech freezes each segment at its
-  VAD boundary. A durable commit removes only the matching frozen segment, so a
+- Asynchronous boundary finalization: Apple Speech finalizes each segment at its
+  VAD boundary. A durable commit removes only the matching finalized segment, so a
   later segment remains visible even when chunk transcriptions finish out of
   order. Delayed callbacks from the prior analyzer generation are ignored.
 - Capture source recovery resets the affected live session before accepting
@@ -92,13 +93,14 @@ Without the model, the live view behaves exactly as before.
 - ANE contention and memory use from two EOU managers plus the durable chunk
   backend must be measured during a long meeting. Failure remains isolated to
   the provisional session and falls back to committed captions.
-- Apple Speech input uses a newest-wins bounded queue. Under sustained analyzer
-  backpressure, stale provisional audio may be dropped rather than increasing
-  memory or delaying recording and durable chunks.
+- Apple Speech input and boundary queues are bounded. Overflow or failed/timed-out
+  finalization makes the source dormant and selects recorded-audio transcription;
+  incomplete streaming text is never silently saved. Late startup and source
+  recovery also use recorded audio until a complete VAD segment can be captured.
 - Apple Speech's finalized live-text prefix is bounded by the existing VAD
   maximum-duration rotation (currently five seconds); the analyzer and its live
-  accumulator restart at every boundary. At most 12 frozen provisional
-  segments are retained while durable chunks retire; older provisional text is
-  dropped without affecting the durable transcript.
+  accumulator restart at every boundary. At most 12 finalized text
+  segments are retained while durable chunks retire; older text uses the
+  recorded-audio fallback.
 - Partial/committed text mismatch when the committed backend differs from
   Parakeet EOU — provisional text settles; inherent to the hybrid design.

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
@@ -5,23 +5,71 @@ import MuesliCore
 import Speech
 
 struct AppleSpeechTranscriptAccumulator: Sendable {
-    private var accumulatedText = ""
-    private(set) var segments: [SpeechSegment] = []
+    private struct Result: Sendable {
+        let rawText: String
+        let text: String
+        let isFinal: Bool
+        let start: Double
+        let end: Double
+    }
+
+    private var results: [Result] = []
 
     var text: String {
-        accumulatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        results
+            .sorted(by: Self.sortResults)
+            .map(\.rawText)
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var segments: [SpeechSegment] {
+        results
+            .filter(\.isFinal)
+            .sorted(by: Self.sortResults)
+            .map { SpeechSegment(start: $0.start, end: $0.end, text: $0.text) }
     }
 
     mutating func receive(text rawText: String, isFinal: Bool, start: Double, end: Double) {
-        guard isFinal else { return }
-        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-
-        accumulatedText.append(rawText)
-
         let safeStart = start.isFinite ? max(0, start) : 0
         let safeEnd = end.isFinite ? max(safeStart, end) : safeStart
-        segments.append(SpeechSegment(start: safeStart, end: safeEnd, text: trimmed))
+        results.removeAll { existing in
+            guard !existing.isFinal else { return false }
+            return Self.overlaps(
+                start: existing.start,
+                end: existing.end,
+                otherStart: safeStart,
+                otherEnd: safeEnd
+            )
+        }
+
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        results.append(Result(
+            rawText: rawText,
+            text: trimmed,
+            isFinal: isFinal,
+            start: safeStart,
+            end: safeEnd
+        ))
+    }
+
+    private static func overlaps(
+        start: Double,
+        end: Double,
+        otherStart: Double,
+        otherEnd: Double
+    ) -> Bool {
+        if start == end || otherStart == otherEnd {
+            return start == otherStart
+        }
+        return start < otherEnd && otherStart < end
+    }
+
+    private static func sortResults(_ lhs: Result, _ rhs: Result) -> Bool {
+        if lhs.start != rhs.start { return lhs.start < rhs.start }
+        if lhs.end != rhs.end { return lhs.end < rhs.end }
+        return lhs.isFinal && !rhs.isFinal
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
@@ -183,6 +183,11 @@ struct AppleSpeechLocaleResolver: Sendable {
 actor AppleSpeechPreparationTaskCache {
     private var tasks: [String: Task<Locale, Error>] = [:]
     private var tail: Task<Void, Never>?
+    private let serializesOperations: Bool
+
+    init(serializesOperations: Bool = false) {
+        self.serializesOperations = serializesOperations
+    }
 
     func value(
         for localeIdentifier: String,
@@ -192,13 +197,13 @@ actor AppleSpeechPreparationTaskCache {
             return try await task.value
         }
 
-        // Different locale requests also share one reservation mutation lane.
+        // Only inventory mutations need a serial lane, not downloads or probes.
         let predecessor = tail
         let task = Task {
             await predecessor?.value
             return try await operation()
         }
-        tail = Task { _ = try? await task.value }
+        if serializesOperations { tail = Task { _ = try? await task.value } }
         tasks[localeIdentifier] = task
         do {
             let locale = try await task.value
@@ -270,6 +275,7 @@ actor AppleSpeechAnalyzerTranscriber {
 
     private let localeResolver: AppleSpeechLocaleResolver
     private let preparationTasks = AppleSpeechPreparationTaskCache()
+    private let reservationTasks = AppleSpeechPreparationTaskCache(serializesOperations: true)
     private var preparedLocale: Locale?
     private var selectedLocale: Locale?
     private var activeUses = AppleSpeechReservationLeases()
@@ -352,28 +358,9 @@ actor AppleSpeechAnalyzerTranscriber {
             message: "Preparing Apple Speech..."
         ))
 
-        let reservations = await AssetInventory.reservedLocales
-        // Normal preparation/unloading never evicts assets. Reclaim stale
-        // reservations only when a new language needs a slot, preserving the
-        // explicit selection and every currently leased language.
-        if reservations.count >= AssetInventory.maximumReservedLocales,
-           !reservations.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
-            let protected = activeUses.identifiers.union([selectedLocale?.identifier(.bcp47)].compactMap { $0 })
-            for stale in AppleSpeechInitialReservationPolicy.localesToRelease(
-                reservations, keeping: locale,
-                activeIdentifiers: protected
-            ) {
-                _ = await AssetInventory.release(reservedLocale: stale)
-            }
-        }
-        do {
-            _ = try await AssetInventory.reserve(locale: locale)
-        } catch {
-            let reservedCount = (await AssetInventory.reservedLocales).count
-            if reservedCount >= AssetInventory.maximumReservedLocales {
-                throw AppleSpeechAnalyzerError.reservationUnavailable(AssetInventory.maximumReservedLocales)
-            }
-            throw error
+        _ = try await reservationTasks.value(for: locale.identifier(.bcp47)) { [self] in
+            try await reserve(locale)
+            return locale
         }
         try Task.checkCancellation()
         // Reassert our subscription even if another app keeps the assets installed.
@@ -420,6 +407,32 @@ actor AppleSpeechAnalyzerTranscriber {
         await analyzer.cancelAndFinishNow()
         preparedLocale = locale
         fputs("[muesli-native] Apple Speech ready for \(locale.identifier(.bcp47))\n", stderr)
+    }
+
+    private func reserve(_ locale: Locale) async throws {
+        let reservations = await AssetInventory.reservedLocales
+        // Normal preparation/unloading never evicts assets. Reclaim stale
+        // reservations only when a new language needs a slot, preserving the
+        // explicit selection and every currently leased language.
+        if reservations.count >= AssetInventory.maximumReservedLocales,
+           !reservations.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+            let protected = activeUses.identifiers.union([selectedLocale?.identifier(.bcp47)].compactMap { $0 })
+            for stale in AppleSpeechInitialReservationPolicy.localesToRelease(
+                reservations, keeping: locale,
+                activeIdentifiers: protected
+            ) {
+                _ = await AssetInventory.release(reservedLocale: stale)
+            }
+        }
+        do {
+            _ = try await AssetInventory.reserve(locale: locale)
+        } catch {
+            let reservedCount = (await AssetInventory.reservedLocales).count
+            if reservedCount >= AssetInventory.maximumReservedLocales {
+                throw AppleSpeechAnalyzerError.reservationUnavailable(AssetInventory.maximumReservedLocales)
+            }
+            throw error
+        }
     }
 
     func transcribe(wavURL: URL, requestedLocale: Locale = .current) async throws -> SpeechTranscriptionResult {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
@@ -108,9 +108,58 @@ struct AppleSpeechLanguageOption: Identifiable, Hashable, Sendable {
 }
 
 enum AppleSpeechInitialReservationPolicy {
-    static func localesToRelease(_ reservations: [Locale], keeping locale: Locale) -> [Locale] {
-        let keptIdentifier = locale.identifier(.bcp47)
-        return reservations.filter { $0.identifier(.bcp47) != keptIdentifier }
+    static func localesToRelease(_ reservations: [Locale], keeping locale: Locale,
+                                activeIdentifiers: Set<String> = []) -> [Locale] {
+        let protected = activeIdentifiers.union([locale.identifier(.bcp47)])
+        return reservations.filter { !protected.contains($0.identifier(.bcp47)) }
+    }
+}
+
+struct AppleSpeechReservationLeases {
+    private var locales: [UUID: Locale] = [:]
+    var identifiers: Set<String> { Set(locales.values.map { $0.identifier(.bcp47) }) }
+    mutating func retain(_ locale: Locale) -> UUID {
+        let id = UUID()
+        locales[id] = locale
+        return id
+    }
+    mutating func release(_ id: UUID) { locales.removeValue(forKey: id) }
+}
+
+/// Asset installation can return after an unsuccessful initial attempt. Retry
+/// only readiness/download failures, never unsupported hardware or languages.
+enum AppleSpeechPreparationRetry {
+    static func isTransient(_ error: Error) -> Bool {
+        if error is CancellationError { return false }
+        if let error = error as? AppleSpeechAnalyzerError {
+            if case .assetUnavailable = error { return true }
+            return false
+        }
+        let error = error as NSError
+        if error.domain == NSURLErrorDomain {
+            return [NSURLErrorTimedOut, NSURLErrorCannotFindHost, NSURLErrorCannotConnectToHost,
+                    NSURLErrorNetworkConnectionLost, NSURLErrorDNSLookupFailed,
+                    NSURLErrorNotConnectedToInternet].contains(error.code)
+        }
+        return error.domain == "SFSpeechErrorDomain" && error.code == 1
+    }
+
+    static func run(
+        delays: [Duration] = [.milliseconds(500), .seconds(1)],
+        sleep: @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+        operation: () async throws -> Void
+    ) async throws {
+        for attempt in 0...delays.count {
+            try Task.checkCancellation()
+            do {
+                try await operation()
+                try Task.checkCancellation()
+                return
+            } catch {
+                guard attempt < delays.count, isTransient(error), !Task.isCancelled else { throw error }
+                try await sleep(delays[attempt])
+            }
+        }
     }
 }
 
@@ -133,6 +182,7 @@ struct AppleSpeechLocaleResolver: Sendable {
 
 actor AppleSpeechPreparationTaskCache {
     private var tasks: [String: Task<Locale, Error>] = [:]
+    private var tail: Task<Void, Never>?
 
     func value(
         for localeIdentifier: String,
@@ -142,7 +192,13 @@ actor AppleSpeechPreparationTaskCache {
             return try await task.value
         }
 
-        let task = Task { try await operation() }
+        // Different locale requests also share one reservation mutation lane.
+        let predecessor = tail
+        let task = Task {
+            await predecessor?.value
+            return try await operation()
+        }
+        tail = Task { _ = try? await task.value }
         tasks[localeIdentifier] = task
         do {
             let locale = try await task.value
@@ -202,6 +258,7 @@ extension AppleSpeechLanguageOption {
 @available(macOS 26.0, *)
 actor AppleSpeechAnalyzerTranscriber {
     static let modelID = "apple-speech-transcriber"
+    static let shared = AppleSpeechAnalyzerTranscriber()
 
     static var isSupportedOnCurrentSystem: Bool {
         // Keep system-model discovery consistent with the shared OS guard and UI preview.
@@ -214,8 +271,8 @@ actor AppleSpeechAnalyzerTranscriber {
     private let localeResolver: AppleSpeechLocaleResolver
     private let preparationTasks = AppleSpeechPreparationTaskCache()
     private var preparedLocale: Locale?
-    private var initialReservationReconciliationTask: Task<Void, Never>?
-    private var didReconcileInitialReservations = false
+    private var selectedLocale: Locale?
+    private var activeUses = AppleSpeechReservationLeases()
 
     init(localeResolver: AppleSpeechLocaleResolver = .live) {
         self.localeResolver = localeResolver
@@ -226,35 +283,68 @@ actor AppleSpeechAnalyzerTranscriber {
         progress: ((Double, String?) -> Void)? = nil,
         progressSnapshot: ModelDownloadProgressHandler? = nil
     ) async throws -> Locale {
+        let use = try await prepareAndRetain(requestedLocale: requestedLocale,
+            progress: progress, progressSnapshot: progressSnapshot)
+        releaseUse(use.id)
+        return use.locale
+    }
+
+    func prepareSelectedLanguage(_ requestedLocale: Locale) async throws {
+        let locale = try await localeResolver.resolve(requestedLocale)
+        selectedLocale = locale
+        _ = try await prepare(requestedLocale: locale)
+    }
+
+    /// A lease protects a locale across dictation, both live meeting sources,
+    /// and concurrent preparation. Releasing it does not evict downloaded assets.
+    func prepareAndRetain(
+        requestedLocale: Locale,
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
+    ) async throws -> (locale: Locale, id: UUID) {
         guard SpeechTranscriber.isAvailable else {
             throw AppleSpeechAnalyzerError.unavailable
         }
 
         let locale = try await localeResolver.resolve(requestedLocale)
+        let id = activeUses.retain(locale)
         let callbacks = AppleSpeechPreparationCallbacks(
             progress: progress,
             progressSnapshot: progressSnapshot
         )
-        let prepared = try await preparationTasks.value(
-            for: locale.identifier(.bcp47)
-        ) { [self, callbacks] in
-            try await performPrepare(locale: locale, callbacks: callbacks)
+        do {
+            let prepared = try await preparationTasks.value(
+                for: locale.identifier(.bcp47)
+            ) { [self, callbacks] in
+                try await performPrepare(locale: locale, callbacks: callbacks)
+            }
+            try Task.checkCancellation()
+            callbacks.progress?(1, "Apple Speech ready")
+            callbacks.progressSnapshot?(readySnapshot())
+            return (prepared, id)
+        } catch {
+            releaseUse(id)
+            throw error
         }
-        callbacks.progress?(1, "Apple Speech ready")
-        callbacks.progressSnapshot?(readySnapshot())
-        return prepared
     }
+
+    func releaseUse(_ id: UUID) { activeUses.release(id) }
 
     private func performPrepare(
         locale: Locale,
         callbacks: AppleSpeechPreparationCallbacks
     ) async throws -> Locale {
-        let transcriber = makeTranscriber(locale: locale)
+        try await AppleSpeechPreparationRetry.run {
+            try await self.prepareAttempt(locale: locale, callbacks: callbacks)
+        }
+        return locale
+    }
+
+    private func prepareAttempt(locale: Locale, callbacks: AppleSpeechPreparationCallbacks) async throws {
+        let transcriber = SpeechTranscriber(locale: locale, preset: .timeIndexedProgressiveTranscription)
         let status = await AssetInventory.status(forModules: [transcriber])
 
-        if preparedLocale == locale, status == .installed {
-            return locale
-        }
+        let wasVerified = preparedLocale == locale && status == .installed
 
         callbacks.progress?(0.05, "Preparing Apple Speech for \(locale.localizedString(forIdentifier: locale.identifier) ?? locale.identifier)...")
         callbacks.progressSnapshot?(ModelDownloadProgress.preparing(
@@ -262,7 +352,20 @@ actor AppleSpeechAnalyzerTranscriber {
             message: "Preparing Apple Speech..."
         ))
 
-        await reconcileInitialReservations(keeping: locale)
+        let reservations = await AssetInventory.reservedLocales
+        // Normal preparation/unloading never evicts assets. Reclaim stale
+        // reservations only when a new language needs a slot, preserving the
+        // explicit selection and every currently leased language.
+        if reservations.count >= AssetInventory.maximumReservedLocales,
+           !reservations.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+            let protected = activeUses.identifiers.union([selectedLocale?.identifier(.bcp47)].compactMap { $0 })
+            for stale in AppleSpeechInitialReservationPolicy.localesToRelease(
+                reservations, keeping: locale,
+                activeIdentifiers: protected
+            ) {
+                _ = await AssetInventory.release(reservedLocale: stale)
+            }
+        }
         do {
             _ = try await AssetInventory.reserve(locale: locale)
         } catch {
@@ -273,6 +376,8 @@ actor AppleSpeechAnalyzerTranscriber {
             throw error
         }
         try Task.checkCancellation()
+        // Reassert our subscription even if another app keeps the assets installed.
+        if wasVerified { return }
 
         if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
             let progressBox = AppleSpeechProgressBox(request.progress)
@@ -299,43 +404,29 @@ actor AppleSpeechAnalyzerTranscriber {
             throw AppleSpeechAnalyzerError.assetUnavailable(locale.identifier(.bcp47))
         }
 
+        // Verify the actual live configuration, not merely framework support
+        // or completion of the download request. Release the probe afterwards.
+        let analyzer = SpeechAnalyzer(modules: [transcriber],
+            options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering))
+        do {
+            let format = AVAudioFormat(commonFormat: .pcmFormatInt16,
+                sampleRate: 16_000, channels: 1, interleaved: true)!
+            try await analyzer.prepareToAnalyze(in: format)
+            try Task.checkCancellation()
+        } catch {
+            await analyzer.cancelAndFinishNow()
+            throw error
+        }
+        await analyzer.cancelAndFinishNow()
         preparedLocale = locale
         fputs("[muesli-native] Apple Speech ready for \(locale.identifier(.bcp47))\n", stderr)
-        return locale
-    }
-
-    private func reconcileInitialReservations(keeping locale: Locale) async {
-        if didReconcileInitialReservations { return }
-        if let task = initialReservationReconciliationTask {
-            await task.value
-            return
-        }
-
-        let task = Task {
-            let reservations = await AssetInventory.reservedLocales
-            for reservedLocale in AppleSpeechInitialReservationPolicy.localesToRelease(
-                reservations,
-                keeping: locale
-            ) {
-                _ = await AssetInventory.release(reservedLocale: reservedLocale)
-            }
-        }
-        initialReservationReconciliationTask = task
-        await task.value
-        didReconcileInitialReservations = true
-        initialReservationReconciliationTask = nil
-    }
-
-    func releaseReservations() async {
-        for locale in await AssetInventory.reservedLocales {
-            _ = await AssetInventory.release(reservedLocale: locale)
-        }
-        preparedLocale = nil
     }
 
     func transcribe(wavURL: URL, requestedLocale: Locale = .current) async throws -> SpeechTranscriptionResult {
         let startedAt = CFAbsoluteTimeGetCurrent()
-        let locale = try await prepare(requestedLocale: requestedLocale)
+        let use = try await prepareAndRetain(requestedLocale: requestedLocale)
+        defer { releaseUse(use.id) }
+        let locale = use.locale
         let transcriber = makeTranscriber(locale: locale)
         let analyzer = SpeechAnalyzer(
             modules: [transcriber],

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -24,8 +24,7 @@ final class MeetingChunkCollector {
 
     /// Register a transcription task. Returns the retire ID to pass to retire(id:segments:)
     /// once the task completes.
-    func add(_ task: Task<[SpeechSegment], Never>) -> (registered: Bool, retireID: UUID) {
-        let id = UUID()
+    func add(_ task: Task<[SpeechSegment], Never>, id: UUID = UUID()) -> (registered: Bool, retireID: UUID) {
         let registered = lock.withLock { state in
             guard !state.isClosed else { return false }
             state.pendingTasks.append(PendingTask(id: id, task: task))
@@ -193,6 +192,7 @@ final class MeetingSession {
     private let systemChunkCollector = MeetingChunkCollector()
     private let micChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let systemChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
+    private let systemStreamingCoverageIsComplete = OSAllocatedUnfairLock(initialState: true)
     private let micHealthTracker = MeetingMicHealthTracker()
     private let micRecoveryCoordinator = MeetingMicRecoveryCoordinator()
     private let systemAudioWatchdog = MeetingSystemAudioWatchdog()
@@ -486,14 +486,6 @@ final class MeetingSession {
         systemPartialSession()?.enqueue(samples)
     }
 
-    private func markMicPartialBoundary(id: UUID) {
-        micPartialSession()?.markSegmentBoundary(id: id)
-    }
-
-    private func markSystemPartialBoundary(id: UUID) {
-        systemPartialSession()?.markSegmentBoundary(id: id)
-    }
-
     private func commitMicPartialSegment(id: UUID) {
         micPartialSession()?.commitSegment(id: id)
     }
@@ -509,11 +501,37 @@ final class MeetingSession {
         start: TimeInterval,
         end: TimeInterval
     ) async -> [SpeechSegment] {
+        // Apple chunks already chose their authoritative result before any batch work.
+        guard config.resolvedMeetingLiveCaptionBackend != .appleSpeech else { return segments }
         let prefersStreamingTranscript = config.enableLiveStreamingPartials
             && config.resolvedMeetingLiveCaptionBackend.producesFinalTranscript
         guard (segments.isEmpty || prefersStreamingTranscript),
               let text = await partialSession?.finalizedSegmentText(id: segmentID) else { return segments }
         return [SpeechSegment(start: start, end: max(end, start + 0.1), text: text)]
+    }
+
+    private func appleStreamingText(session: MeetingStreamingPartialSession?, id: UUID) async -> String? {
+        guard config.enableLiveStreamingPartials,
+              config.resolvedMeetingLiveCaptionBackend == .appleSpeech else { return nil }
+        return await session?.finalizedSegmentText(id: id)
+    }
+
+    /// nil requests recovery; a successfully finalized empty string represents silence.
+    static func resolveChunkTranscript(
+        timing: MeetingChunkTimingSnapshot,
+        finalizedText: () async -> String?,
+        recordedAudio: () async -> [SpeechSegment]
+    ) async -> [SpeechSegment] {
+        guard !Task.isCancelled else { return [] }
+        if let text = await finalizedText() { return segmentsFromFinalizedText(text, timing: timing) }
+        guard !Task.isCancelled else { return [] }
+        return await recordedAudio()
+    }
+
+    static func segmentsFromFinalizedText(_ text: String, timing: MeetingChunkTimingSnapshot) -> [SpeechSegment] {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        return [SpeechSegment(start: timing.startTimeSeconds,
+            end: timing.startTimeSeconds + max(timing.durationSeconds, 0.1), text: text)]
     }
 
     private func suspendPartialSessions() {
@@ -682,6 +700,8 @@ final class MeetingSession {
             }
         }
 
+        var micTailFinalized = false
+        var systemTailFinalized = false
         if usesStreamingFinalTranscript {
             async let micRetirement: Void = micChunkCollector.waitUntilRetired()
             async let systemRetirement: Void = systemChunkCollector.waitUntilRetired()
@@ -690,25 +710,20 @@ final class MeetingSession {
             async let micTail = micPartialSession()?.finish()
             async let systemTail = systemPartialSession()?.finish()
             let (finalMicText, finalSystemText) = await (micTail, systemTail)
+            micTailFinalized = finalMicText != nil
+            systemTailFinalized = finalSystemText != nil
+            if !systemTailFinalized { systemStreamingCoverageIsComplete.withLock { $0 = false } }
             if let finalMicText, let timing = lastChunkTiming {
-                micSegments.append(SpeechSegment(
-                    start: timing.startTimeSeconds,
-                    end: timing.startTimeSeconds + max(timing.durationSeconds, 0.1),
-                    text: finalMicText
-                ))
+                micSegments.append(contentsOf: Self.segmentsFromFinalizedText(finalMicText, timing: timing))
             }
             if let finalSystemText, let timing = lastSystemChunkTiming {
-                systemSegments.append(SpeechSegment(
-                    start: timing.startTimeSeconds,
-                    end: timing.startTimeSeconds + max(timing.durationSeconds, 0.1),
-                    text: finalSystemText
-                ))
+                systemSegments.append(contentsOf: Self.segmentsFromFinalizedText(finalSystemText, timing: timing))
             }
             stopPartialSessions()
         }
 
         // Recorded audio fills a tail the selected streaming backend could not finalize.
-        if !usesStreamingFinalTranscript || micSegments.isEmpty {
+        if !micTailFinalized {
             let finalMicSegments = await transcribeMicChunk(
                 rawURL: lastRawMicURL,
                 chunkTiming: lastChunkTiming,
@@ -722,7 +737,7 @@ final class MeetingSession {
         if let lastSystemChunkURL {
             let chunkOffset = lastSystemChunkTiming?.startTimeSeconds ?? 0
             let chunkDuration = lastSystemChunkTiming?.durationSeconds ?? 0
-            if !usesStreamingFinalTranscript || systemSegments.isEmpty {
+            if !systemTailFinalized {
                 fputs("[meeting] transcribing final system chunk (offset=\(String(format: "%.0f", chunkOffset))s)\n", stderr)
                 do {
                     let result = try await transcriptionCoordinator.transcribeMeetingChunk(
@@ -780,7 +795,9 @@ final class MeetingSession {
         if let systemAudioURL,
            Self.shouldAttemptSystemRecovery(
                usesStreamingFinalTranscript: usesStreamingFinalTranscript,
-               hasSystemSegments: !systemSegments.isEmpty
+               hasSystemSegments: !systemSegments.isEmpty,
+               hasCompleteStreamingCoverage: config.resolvedMeetingLiveCaptionBackend == .appleSpeech
+                   && systemStreamingCoverageIsComplete.withLock { $0 }
            ) {
             let systemRecovery = await repairSystemSegmentsIfNeeded(
                 existingSystemSegments: systemSegments,
@@ -917,9 +934,10 @@ final class MeetingSession {
 
     static func shouldAttemptSystemRecovery(
         usesStreamingFinalTranscript: Bool,
-        hasSystemSegments: Bool
+        hasSystemSegments: Bool,
+        hasCompleteStreamingCoverage: Bool = false
     ) -> Bool {
-        !usesStreamingFinalTranscript || !hasSystemSegments
+        !usesStreamingFinalTranscript || (!hasSystemSegments && !hasCompleteStreamingCoverage)
     }
 
     private func userEditedLiveTitle() async -> String? {
@@ -960,24 +978,24 @@ final class MeetingSession {
         let chunkOffset = chunkTiming.startTimeSeconds
 
         fputs("[meeting] rotating raw mic chunk at offset=\(String(format: "%.0f", chunkOffset))s\n", stderr)
+        let segmentID = UUID()
+        let partialSession = micPartialSession()
+        partialSession?.markSegmentBoundary(id: segmentID)
         let task = Task { [weak self] () -> [SpeechSegment] in
-            guard let self else { return [] }
-            if Task.isCancelled {
-                self.cleanupTemporaryChunkURLs(rawChunkURL)
-                return []
+            defer {
+                if let rawChunkURL { try? FileManager.default.removeItem(at: rawChunkURL) }
             }
-            let segments = await self.transcribeMicChunk(
-                rawURL: rawChunkURL,
-                chunkTiming: chunkTiming,
-                isFinalChunk: false
-            )
-            return segments
+            guard let self else { return [] }
+            return await Self.resolveChunkTranscript(timing: chunkTiming, finalizedText: {
+                await self.appleStreamingText(session: partialSession, id: segmentID)
+            }, recordedAudio: {
+                await self.transcribeMicChunk(rawURL: rawChunkURL, chunkTiming: chunkTiming, isFinalChunk: false)
+            })
         }
-        let (registered, retireID) = micChunkCollector.add(task)
+        let (registered, retireID) = micChunkCollector.add(task, id: segmentID)
         if registered {
             // Bind this frozen prefix to the collector ID because chunk tasks
             // may finish out of submission order.
-            markMicPartialBoundary(id: retireID)
             Task { [weak self] in
                 let segments = await task.value
                 guard let self else { return }
@@ -1015,49 +1033,53 @@ final class MeetingSession {
         let chunkOffset = chunkTiming.startTimeSeconds
         let chunkDuration = chunkTiming.durationSeconds
         fputs("[meeting] rotating system chunk at offset=\(String(format: "%.0f", chunkOffset))s\n", stderr)
+        let segmentID = UUID()
+        let partialSession = systemPartialSession()
+        partialSession?.markSegmentBoundary(id: segmentID)
         let task = Task { [weak self] () -> [SpeechSegment] in
             defer {
                 try? FileManager.default.removeItem(at: chunkURL)
             }
             guard let self else { return [] }
-            do {
-                if Task.isCancelled {
-                    return []
-                }
-                let backend = self.currentBackend()
-                let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(
-                    at: chunkURL,
-                    backend: backend,
-                    cohereLanguage: config.resolvedCohereLanguage,
-                    indicASRLanguage: config.resolvedIndicASRLanguage,
-                    whisperLanguage: config.resolvedWhisperLanguage,
-                    parakeetLanguage: config.resolvedParakeetLanguage,
-                    appleSpeechLanguage: config.resolvedAppleSpeechLanguage
-                )
-                if !result.text.isEmpty {
-                    fputs("[meeting] system chunk transcribed: \"\(String(result.text.prefix(60)))...\"\n", stderr)
-                    let normalizedSegments = self.normalizeSystemTranscription(
-                        result: result,
-                        startTime: chunkOffset,
-                        endTime: chunkOffset + max(chunkDuration, 0.1)
+            return await Self.resolveChunkTranscript(timing: chunkTiming, finalizedText: {
+                await self.appleStreamingText(session: partialSession, id: segmentID)
+            }, recordedAudio: {
+                self.systemStreamingCoverageIsComplete.withLock { $0 = false }
+                do {
+                    let backend = self.currentBackend()
+                    let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(
+                        at: chunkURL,
+                        backend: backend,
+                        cohereLanguage: config.resolvedCohereLanguage,
+                        indicASRLanguage: config.resolvedIndicASRLanguage,
+                        whisperLanguage: config.resolvedWhisperLanguage,
+                        parakeetLanguage: config.resolvedParakeetLanguage,
+                        appleSpeechLanguage: config.resolvedAppleSpeechLanguage
                     )
-                    if normalizedSegments.isEmpty {
-                        self.systemChunkHealthTracker.noteEmptyChunk()
-                    } else {
-                        self.systemChunkHealthTracker.noteSuccessfulChunk()
+                    if !result.text.isEmpty {
+                        fputs("[meeting] system chunk transcribed: \"\(String(result.text.prefix(60)))...\"\n", stderr)
+                        let normalizedSegments = self.normalizeSystemTranscription(
+                            result: result,
+                            startTime: chunkOffset,
+                            endTime: chunkOffset + max(chunkDuration, 0.1)
+                        )
+                        if normalizedSegments.isEmpty {
+                            self.systemChunkHealthTracker.noteEmptyChunk()
+                        } else {
+                            self.systemChunkHealthTracker.noteSuccessfulChunk()
+                        }
+                        return normalizedSegments
                     }
-                    return normalizedSegments
+                    self.systemChunkHealthTracker.noteEmptyChunk()
+                } catch {
+                    self.systemChunkHealthTracker.noteFailedChunk()
+                    fputs("[meeting] system chunk transcription failed: \(error)\n", stderr)
                 }
-                self.systemChunkHealthTracker.noteEmptyChunk()
-            } catch {
-                self.systemChunkHealthTracker.noteFailedChunk()
-                fputs("[meeting] system chunk transcription failed: \(error)\n", stderr)
-            }
-            return []
+                return []
+            })
         }
-        let (registered, retireID) = systemChunkCollector.add(task)
+        let (registered, retireID) = systemChunkCollector.add(task, id: segmentID)
         if registered {
-            markSystemPartialBoundary(id: retireID)
             Task { [weak self] in
                 let segments = await task.value
                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -308,9 +308,12 @@ final class MeetingSession {
                 selectedInputResolved: snapshot.route?.selectedInputDeviceResolved
             )
         }
-        meetingMicRecorder.onHandoffOutcome = { [weak micRecoveryCoordinator, weak systemAudioWatchdog] outcome in
+        meetingMicRecorder.onHandoffOutcome = { [weak self, weak micRecoveryCoordinator, weak systemAudioWatchdog] outcome in
             micRecoveryCoordinator?.noteHandoffOutcome(outcome)
             systemAudioWatchdog?.noteRouteChange()
+            if outcome == .promoted {
+                self?.micPartialSession()?.resetAfterSourceRestart()
+            }
         }
         systemAudioWatchdog.isCaptureActive = { [weak systemAudioRecorder] in
             guard let recorder = systemAudioRecorder else { return false }
@@ -328,8 +331,12 @@ final class MeetingSession {
         systemAudioWatchdog.lastMicCallbackAt = { [weak self] in
             self?.micHealthTracker.snapshot().lastRawMicCallbackAt
         }
-        systemAudioWatchdog.recoveryRequest = { [weak systemAudioRecorder] reason in
-            systemAudioRecorder?.rebuildForHealthRecovery(reason: reason) ?? false
+        systemAudioWatchdog.recoveryRequest = { [weak self, weak systemAudioRecorder] reason in
+            let started = systemAudioRecorder?.rebuildForHealthRecovery(reason: reason) ?? false
+            if started {
+                self?.systemPartialSession()?.resetAfterSourceRestart()
+            }
+            return started
         }
         systemAudioWatchdog.onMicBlindnessDegradation = { [weak self] reason in
             guard let self, let snapshot = self.micHealthTracker.noteRouteCallbackLoss() else { return }
@@ -422,7 +429,8 @@ final class MeetingSession {
             do {
                 let engines = try await MeetingLiveCaptionModelStore.makeEngines(
                     backend: backend,
-                    nemotronPromptId: self.config.resolvedNemotron35Language.promptId
+                    nemotronPromptId: self.config.resolvedNemotron35Language.promptId,
+                    appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage
                 )
                 guard self.chunkRotationQueue.sync(execute: { self.isRecording }),
                       self.partialSessionsStorage.withLock({ !$0.isShutDown }) else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -414,9 +414,9 @@ final class MeetingSession {
         setupStreamingPartialsIfAvailable()
     }
 
-    /// Display-only streaming partials (#99). The selected live-caption model
-    /// consumes the same cleaned mic and raw system streams as the VAD pipeline;
-    /// VAD chunk transcription remains the durable source of truth.
+    /// The selected live model consumes the same cleaned mic and raw system
+    /// streams as VAD. Final-capable backends reuse the durable chunk pipeline;
+    /// recorded-audio transcription recovers missing streaming results.
     private func setupStreamingPartialsIfAvailable() {
         guard config.enableLiveStreamingPartials else { return }
         let backend = config.resolvedMeetingLiveCaptionBackend
@@ -439,10 +439,10 @@ final class MeetingSession {
                     return
                 }
 
-                let mic = MeetingStreamingPartialSession(engine: engines.mic, label: "You")
+                let mic = MeetingStreamingPartialSession(engine: engines.mic, label: "You", startsAtSegmentBoundary: false)
                 mic.onPartialUpdate = { [weak self] text in self?.onPartialTranscript?("You", text) }
                 await mic.connect()
-                let system = MeetingStreamingPartialSession(engine: engines.system, label: "Others")
+                let system = MeetingStreamingPartialSession(engine: engines.system, label: "Others", startsAtSegmentBoundary: false)
                 system.onPartialUpdate = { [weak self] text in self?.onPartialTranscript?("Others", text) }
                 await system.connect()
 
@@ -508,11 +508,11 @@ final class MeetingSession {
         segmentID: UUID,
         start: TimeInterval,
         end: TimeInterval
-    ) -> [SpeechSegment] {
+    ) async -> [SpeechSegment] {
         let prefersStreamingTranscript = config.enableLiveStreamingPartials
-            && config.resolvedMeetingLiveCaptionBackend == .nemotron35
+            && config.resolvedMeetingLiveCaptionBackend.producesFinalTranscript
         guard (segments.isEmpty || prefersStreamingTranscript),
-              let text = partialSession?.pendingSegmentText(id: segmentID) else { return segments }
+              let text = await partialSession?.finalizedSegmentText(id: segmentID) else { return segments }
         return [SpeechSegment(start: start, end: max(end, start + 0.1), text: text)]
     }
 
@@ -629,11 +629,11 @@ final class MeetingSession {
         let endTime = Date()
         var micSegments: [SpeechSegment] = []
         var systemSegments: [SpeechSegment] = []
-        let usesUnifiedNemotronTranscript = config.enableLiveStreamingPartials
-            && config.resolvedMeetingLiveCaptionBackend == .nemotron35
+        let usesStreamingFinalTranscript = config.enableLiveStreamingPartials
+            && config.resolvedMeetingLiveCaptionBackend.producesFinalTranscript
 
         // Stop VAD controller
-        if !usesUnifiedNemotronTranscript {
+        if !usesStreamingFinalTranscript {
             stopPartialSessions()
         }
         vadController?.stop()
@@ -682,7 +682,7 @@ final class MeetingSession {
             }
         }
 
-        if usesUnifiedNemotronTranscript {
+        if usesStreamingFinalTranscript {
             async let micRetirement: Void = micChunkCollector.waitUntilRetired()
             async let systemRetirement: Void = systemChunkCollector.waitUntilRetired()
             _ = await (micRetirement, systemRetirement)
@@ -707,8 +707,8 @@ final class MeetingSession {
             stopPartialSessions()
         }
 
-        // The configured meeting model fills only a tail Nemotron could not finalize.
-        if !usesUnifiedNemotronTranscript || micSegments.isEmpty {
+        // Recorded audio fills a tail the selected streaming backend could not finalize.
+        if !usesStreamingFinalTranscript || micSegments.isEmpty {
             let finalMicSegments = await transcribeMicChunk(
                 rawURL: lastRawMicURL,
                 chunkTiming: lastChunkTiming,
@@ -722,7 +722,7 @@ final class MeetingSession {
         if let lastSystemChunkURL {
             let chunkOffset = lastSystemChunkTiming?.startTimeSeconds ?? 0
             let chunkDuration = lastSystemChunkTiming?.durationSeconds ?? 0
-            if !usesUnifiedNemotronTranscript || systemSegments.isEmpty {
+            if !usesStreamingFinalTranscript || systemSegments.isEmpty {
                 fputs("[meeting] transcribing final system chunk (offset=\(String(format: "%.0f", chunkOffset))s)\n", stderr)
                 do {
                     let result = try await transcriptionCoordinator.transcribeMeetingChunk(
@@ -779,7 +779,7 @@ final class MeetingSession {
 
         if let systemAudioURL,
            Self.shouldAttemptSystemRecovery(
-               usesUnifiedNemotronTranscript: usesUnifiedNemotronTranscript,
+               usesStreamingFinalTranscript: usesStreamingFinalTranscript,
                hasSystemSegments: !systemSegments.isEmpty
            ) {
             let systemRecovery = await repairSystemSegmentsIfNeeded(
@@ -916,10 +916,10 @@ final class MeetingSession {
     }
 
     static func shouldAttemptSystemRecovery(
-        usesUnifiedNemotronTranscript: Bool,
+        usesStreamingFinalTranscript: Bool,
         hasSystemSegments: Bool
     ) -> Bool {
-        !usesUnifiedNemotronTranscript || !hasSystemSegments
+        !usesStreamingFinalTranscript || !hasSystemSegments
     }
 
     private func userEditedLiveTitle() async -> String? {
@@ -981,7 +981,7 @@ final class MeetingSession {
             Task { [weak self] in
                 let segments = await task.value
                 guard let self else { return }
-                let resolvedSegments = self.segmentsUsingStreamingTranscript(
+                let resolvedSegments = await self.segmentsUsingStreamingTranscript(
                     segments,
                     partialSession: self.micPartialSession(),
                     segmentID: retireID,
@@ -1061,7 +1061,7 @@ final class MeetingSession {
             Task { [weak self] in
                 let segments = await task.value
                 guard let self else { return }
-                let resolvedSegments = self.segmentsUsingStreamingTranscript(
+                let resolvedSegments = await self.segmentsUsingStreamingTranscript(
                     segments,
                     partialSession: self.systemPartialSession(),
                     segmentID: retireID,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -3,6 +3,7 @@ import FluidAudio
 import Foundation
 import MuesliCore
 import os
+import Speech
 
 enum MeetingLiveCaptionModelStore {
     static let repo = Repo.parakeetEou320
@@ -60,7 +61,8 @@ enum MeetingLiveCaptionModelStore {
 
     static func makeEngines(
         backend: MeetingLiveCaptionBackend,
-        nemotronPromptId: Int32
+        nemotronPromptId: Int32,
+        appleSpeechLanguage: String
     ) async throws -> (mic: MeetingStreamingPartialEngine, system: MeetingStreamingPartialEngine) {
         switch backend {
         case .parakeetRealtimeEOU:
@@ -69,6 +71,25 @@ enum MeetingLiveCaptionModelStore {
                 return (mic, try await makeEngine(label: "Others"))
             } catch {
                 await mic.shutdown()
+                throw error
+            }
+        case .appleSpeech:
+            guard #available(macOS 26.0, *) else {
+                throw AppleSpeechAnalyzerError.unavailable
+            }
+            let preparation = AppleSpeechAnalyzerTranscriber()
+            let locale = try await preparation.prepare(
+                requestedLocale: AppleSpeechLanguageOption.requestedLocale(for: appleSpeechLanguage)
+            )
+            let mic = AppleSpeechMeetingPartialEngine(locale: locale, label: "You")
+            let system = AppleSpeechMeetingPartialEngine(locale: locale, label: "Others")
+            do {
+                try await mic.prepare()
+                try await system.prepare()
+                return (mic, system)
+            } catch {
+                await mic.shutdown()
+                await system.shutdown()
                 throw error
             }
         case .nemotron35:
@@ -98,15 +119,292 @@ enum MeetingLiveCaptionModelStore {
     }
 }
 
+enum MeetingStreamingPartialDeliveryMode: Sendable {
+    case inline
+    case asynchronous
+}
+
 protocol MeetingStreamingPartialEngine: AnyObject, Sendable {
+    var partialDeliveryMode: MeetingStreamingPartialDeliveryMode { get }
     func setPartialHandler(_ handler: @escaping @Sendable (String) -> Void) async
+    func setFailureHandler(_ handler: @escaping @Sendable (Error) -> Void) async
     func process(samples: [Float]) async throws
+    func restart(
+        partialHandler: @escaping @Sendable (String) -> Void,
+        failureHandler: @escaping @Sendable (Error) -> Void
+    ) async throws
     func finish() async throws
     func shutdown() async
 }
 
 extension MeetingStreamingPartialEngine {
+    var partialDeliveryMode: MeetingStreamingPartialDeliveryMode { .inline }
+    func setFailureHandler(_ handler: @escaping @Sendable (Error) -> Void) async {}
+    func restart(
+        partialHandler: @escaping @Sendable (String) -> Void,
+        failureHandler: @escaping @Sendable (Error) -> Void
+    ) async throws {
+        await setPartialHandler(partialHandler)
+        await setFailureHandler(failureHandler)
+    }
     func finish() async throws {}
+}
+
+@available(macOS 26.0, *)
+private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
+    nonisolated let partialDeliveryMode = MeetingStreamingPartialDeliveryMode.asynchronous
+    private static let maxBufferedInputs = MeetingStreamingPartialSession.maxQueuedChunks
+
+    private let locale: Locale
+    private let inputFormat: AVAudioFormat
+    private let label: String
+    private var transcriber: SpeechTranscriber?
+    private var analyzer: SpeechAnalyzer?
+    private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+    private var analysisTask: Task<CMTime?, Error>?
+    private var analysisMonitorTask: Task<Void, Never>?
+    private var resultsTask: Task<Void, Error>?
+    private var accumulator = AppleSpeechLiveTranscriptAccumulator()
+    private var partialHandler: (@Sendable (String) -> Void)?
+    private var failureHandler: (@Sendable (Error) -> Void)?
+    private var isFinished = false
+    private var didReportFailure = false
+    private var sessionGeneration: UInt64 = 0
+
+    init(locale: Locale, label: String) {
+        self.locale = locale
+        inputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: true
+        )!
+        self.label = label
+    }
+
+    func prepare() async throws {
+        guard analyzer == nil else { return }
+        try await startSession()
+        fputs("[meeting-partials] \(label) Apple Speech session ready\n", stderr)
+    }
+
+    func restart(
+        partialHandler: @escaping @Sendable (String) -> Void,
+        failureHandler: @escaping @Sendable (Error) -> Void
+    ) async throws {
+        await cancelCurrentSession()
+        self.partialHandler = partialHandler
+        self.failureHandler = failureHandler
+        try await startSession()
+        fputs("[meeting-partials] \(label) Apple Speech session restarted\n", stderr)
+    }
+
+    private func startSession() async throws {
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            preset: .timeIndexedProgressiveTranscription
+        )
+        let analyzer = SpeechAnalyzer(
+            modules: [transcriber],
+            options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering)
+        )
+        try await analyzer.prepareToAnalyze(in: inputFormat)
+        let (inputStream, continuation) = AsyncStream<AnalyzerInput>.makeStream(
+            bufferingPolicy: .bufferingNewest(Self.maxBufferedInputs)
+        )
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        self.transcriber = transcriber
+        self.analyzer = analyzer
+        inputContinuation = continuation
+        accumulator = AppleSpeechLiveTranscriptAccumulator()
+        isFinished = false
+        didReportFailure = false
+        let analysisTask = Task {
+            try await analyzer.analyzeSequence(inputStream)
+        }
+        self.analysisTask = analysisTask
+        analysisMonitorTask = Task { [weak self] in
+            do {
+                _ = try await analysisTask.value
+            } catch {
+                guard !Task.isCancelled, let self else { return }
+                await self.receiveFailure(error, generation: generation)
+            }
+        }
+        resultsTask = Task { [weak self] in
+            do {
+                for try await result in transcriber.results {
+                    guard !Task.isCancelled, let self else { return }
+                    await self.receive(result, generation: generation)
+                }
+            } catch {
+                guard !Task.isCancelled, let self else { throw error }
+                await self.receiveFailure(error, generation: generation)
+                throw error
+            }
+        }
+    }
+
+    func setPartialHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+        partialHandler = handler
+    }
+
+    func setFailureHandler(_ handler: @escaping @Sendable (Error) -> Void) async {
+        failureHandler = handler
+    }
+
+    func process(samples: [Float]) async throws {
+        guard !samples.isEmpty else { return }
+        guard !isFinished, let inputContinuation else {
+            throw NSError(
+                domain: "MeetingLiveCaptions",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Apple Speech live captions are not ready."]
+            )
+        }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: inputFormat,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ), let channel = buffer.int16ChannelData?[0] else {
+            throw NSError(
+                domain: "MeetingLiveCaptions",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not allocate a 16 kHz live-caption buffer."]
+            )
+        }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for (index, sample) in samples.enumerated() {
+            let clamped = min(max(sample, -1), 1)
+            channel[index] = Int16(clamped * Float(Int16.max))
+        }
+        if case .terminated = inputContinuation.yield(AnalyzerInput(buffer: buffer)) {
+            throw NSError(
+                domain: "MeetingLiveCaptions",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "Apple Speech stopped accepting live audio."]
+            )
+        }
+    }
+
+    func finish() async throws {
+        guard !isFinished else { return }
+        isFinished = true
+        inputContinuation?.finish()
+        inputContinuation = nil
+
+        if let lastSample = try await analysisTask?.value, let analyzer {
+            try await analyzer.finalizeAndFinish(through: lastSample)
+        } else if let analyzer {
+            await analyzer.cancelAndFinishNow()
+        }
+        try await resultsTask?.value
+        partialHandler?(accumulator.text)
+    }
+
+    func shutdown() async {
+        await cancelCurrentSession()
+        partialHandler = nil
+        failureHandler = nil
+        fputs("[meeting-partials] \(label) Apple Speech session stopped\n", stderr)
+    }
+
+    private func cancelCurrentSession() async {
+        sessionGeneration &+= 1
+        inputContinuation?.finish()
+        inputContinuation = nil
+        analysisTask?.cancel()
+        analysisMonitorTask?.cancel()
+        resultsTask?.cancel()
+        if let analyzer {
+            await analyzer.cancelAndFinishNow()
+        }
+        analysisTask = nil
+        analysisMonitorTask = nil
+        resultsTask = nil
+        analyzer = nil
+        transcriber = nil
+        accumulator = AppleSpeechLiveTranscriptAccumulator()
+        isFinished = false
+        didReportFailure = false
+    }
+
+    private func receive(_ result: SpeechTranscriber.Result, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+        accumulator.receive(
+            text: String(result.text.characters),
+            isFinal: result.isFinal,
+            start: CMTimeGetSeconds(result.range.start),
+            end: CMTimeGetSeconds(CMTimeRangeGetEnd(result.range))
+        )
+        partialHandler?(accumulator.text)
+    }
+
+    private func receiveFailure(_ error: Error, generation: UInt64) {
+        guard generation == sessionGeneration, !isFinished, !didReportFailure else { return }
+        didReportFailure = true
+        failureHandler?(error)
+    }
+}
+
+/// Keeps only the text required by the live preview plus a small set of
+/// progressive ranges. Durable timestamped segments are produced by the
+/// meeting transcription pipeline, so the live adapter does not retain every
+/// SpeechTranscriber result object for the lifetime of a meeting.
+struct AppleSpeechLiveTranscriptAccumulator: Sendable {
+    private struct Partial: Sendable {
+        let rawText: String
+        let start: Double
+        let end: Double
+    }
+
+    static let maxProgressiveResults = 8
+
+    private var finalizedText = ""
+    private var progressiveResults: [Partial] = []
+
+    var text: String {
+        (finalizedText + progressiveResults.sorted(by: { lhs, rhs in
+            if lhs.start != rhs.start { return lhs.start < rhs.start }
+            return lhs.end < rhs.end
+        }).map(\.rawText).joined())
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    mutating func receive(text rawText: String, isFinal: Bool, start: Double, end: Double) {
+        let safeStart = start.isFinite ? max(0, start) : 0
+        let safeEnd = end.isFinite ? max(safeStart, end) : safeStart
+        progressiveResults.removeAll { existing in
+            Self.overlaps(
+                start: existing.start,
+                end: existing.end,
+                otherStart: safeStart,
+                otherEnd: safeEnd
+            )
+        }
+
+        guard !rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        if isFinal {
+            finalizedText += rawText
+            return
+        }
+        progressiveResults.append(Partial(rawText: rawText, start: safeStart, end: safeEnd))
+        if progressiveResults.count > Self.maxProgressiveResults {
+            progressiveResults.removeFirst(progressiveResults.count - Self.maxProgressiveResults)
+        }
+    }
+
+    private static func overlaps(
+        start: Double,
+        end: Double,
+        otherStart: Double,
+        otherEnd: Double
+    ) -> Bool {
+        if start == end || otherStart == otherEnd {
+            return start == otherStart
+        }
+        return start < otherEnd && otherStart < end
+    }
 }
 
 private actor ParakeetEOUMeetingPartialEngine: MeetingStreamingPartialEngine {
@@ -237,6 +535,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// larger look-ahead window required by its cache-aware encoder.
     static let feedSamples = StreamingChunkSize.ms320.shiftSamples
     static let maxQueuedChunks = 3
+    static let maxFrozenSegments = 12
     static let publicationIntervalNanoseconds: UInt64 = 250_000_000
     static let finishDrainTimeoutNanoseconds: UInt64 = 30_000_000_000
 
@@ -246,6 +545,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     private struct PendingSegment {
         let id: UUID
         let prefixLength: Int
+        var frozenText: String?
         var isCommitted = false
     }
 
@@ -258,12 +558,14 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
         var pendingSegments: [PendingSegment] = []
         var isStopped = false
         var isSuspended = false
+        var isRestarting = false
         var didFail = false
         var pendingPublicationTail: String?
         var lastPublishedTail: String?
         var isPublicationScheduled = false
         var lifecycleRevision: UInt64 = 0
         var activeInferenceRevision: UInt64?
+        var resumeRevision: UInt64?
     }
     private let state = OSAllocatedUnfairLock(initialState: State())
 
@@ -273,8 +575,12 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     func connect() async {
+        let revision = state.withLock { $0.lifecycleRevision }
         await engine.setPartialHandler { [weak self] text in
-            self?.receiveEnginePartial(text)
+            self?.receiveEnginePartial(text, expectedRevision: revision)
+        }
+        await engine.setFailureHandler { [weak self] error in
+            self?.receiveEngineFailure(error, expectedRevision: revision)
         }
     }
 
@@ -283,7 +589,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     func enqueue(_ samples: [Float]) {
         guard !samples.isEmpty else { return }
         let shouldStartDrain = state.withLock { s -> Bool in
-            guard !s.isStopped, !s.isSuspended, !s.didFail else { return false }
+            guard !s.isStopped, !s.didFail, !s.isSuspended || s.isRestarting else { return false }
             s.sampleBuffer.append(contentsOf: samples)
             while s.sampleBuffer.count >= Self.feedSamples {
                 s.chunkQueue.append(Array(s.sampleBuffer.prefix(Self.feedSamples)))
@@ -292,7 +598,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             if s.chunkQueue.count > Self.maxQueuedChunks {
                 s.chunkQueue.removeFirst(s.chunkQueue.count - Self.maxQueuedChunks)
             }
-            guard !s.chunkQueue.isEmpty, !s.isDraining else { return false }
+            guard !s.isSuspended, !s.chunkQueue.isEmpty, !s.isDraining else { return false }
             s.isDraining = true
             return true
         }
@@ -304,8 +610,46 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     func markSegmentBoundary(id: UUID) {
-        state.withLock { s in
-            s.pendingSegments.append(PendingSegment(id: id, prefixLength: s.engineText.count))
+        let restartRevision: UInt64? = state.withLock { s in
+            guard engine.partialDeliveryMode == .asynchronous else {
+                s.pendingSegments.append(PendingSegment(
+                    id: id,
+                    prefixLength: s.engineText.count,
+                    frozenText: nil
+                ))
+                return nil
+            }
+            let frozenText = currentEngineTail(for: s)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            s.pendingSegments.append(PendingSegment(
+                id: id,
+                prefixLength: 0,
+                frozenText: frozenText.isEmpty ? nil : frozenText
+            ))
+            let frozenIndices = s.pendingSegments.indices.filter {
+                s.pendingSegments[$0].frozenText != nil
+            }
+            if frozenIndices.count > Self.maxFrozenSegments {
+                for index in frozenIndices.prefix(frozenIndices.count - Self.maxFrozenSegments) {
+                    s.pendingSegments[index].frozenText = nil
+                }
+            }
+            s.lifecycleRevision &+= 1
+            s.isSuspended = true
+            s.isRestarting = true
+            s.resumeRevision = s.lifecycleRevision
+            s.sampleBuffer.removeAll(keepingCapacity: true)
+            s.chunkQueue.removeAll(keepingCapacity: true)
+            s.engineText = ""
+            s.committedPrefixLength = 0
+            return s.lifecycleRevision
+        }
+        if let restartRevision {
+            let tail = state.withLock { visibleTail(for: $0) }
+            publishImmediately(tail, expectedRevision: restartRevision)
+            Task.detached(priority: .utility) { [weak self] in
+                await self?.resumeEngine(expectedRevision: restartRevision)
+            }
         }
     }
 
@@ -314,6 +658,9 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             guard !s.isStopped, !s.didFail,
                   let segmentIndex = s.pendingSegments.firstIndex(where: { $0.id == id }) else { return nil }
             let segment = s.pendingSegments[segmentIndex]
+            if let frozenText = segment.frozenText {
+                return frozenText
+            }
             let previousPrefixLength = segmentIndex > 0
                 ? s.pendingSegments[segmentIndex - 1].prefixLength
                 : s.committedPrefixLength
@@ -330,15 +677,19 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
 
     func commitSegment(id: UUID) {
         let publication: (tail: String, revision: UInt64)? = state.withLock { s in
-            guard !s.isStopped, !s.isSuspended, !s.didFail else { return nil }
+            let canCommitWhileRestarting = engine.partialDeliveryMode == .asynchronous
+                && s.isSuspended && s.isRestarting
+            guard !s.isStopped, (!s.isSuspended || canCommitWhileRestarting), !s.didFail else { return nil }
             guard let segmentIndex = s.pendingSegments.firstIndex(where: { $0.id == id }) else { return nil }
             s.pendingSegments[segmentIndex].isCommitted = true
             var didAdvance = false
             while let first = s.pendingSegments.first, first.isCommitted {
-                s.committedPrefixLength = max(
-                    s.committedPrefixLength,
-                    min(first.prefixLength, s.engineText.count)
-                )
+                if engine.partialDeliveryMode == .inline {
+                    s.committedPrefixLength = max(
+                        s.committedPrefixLength,
+                        min(first.prefixLength, s.engineText.count)
+                    )
+                }
                 s.pendingSegments.removeFirst()
                 didAdvance = true
             }
@@ -351,12 +702,15 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     /// Pause uses the existing VAD/chunk boundary as the durable commit point.
-    /// Buffered audio is dropped and the current engine prefix is hidden; the
-    /// cache-aware model state remains warm for a low-latency resume.
+    /// Buffered audio is dropped and the current engine prefix is hidden.
+    /// Resume restarts engines that deliver results asynchronously before new
+    /// audio is accepted, while cache-aware inline engines remain warm.
     func suspend() {
         state.withLock { s in
             s.isSuspended = true
+            s.isRestarting = false
             s.lifecycleRevision &+= 1
+            s.resumeRevision = nil
             s.sampleBuffer.removeAll(keepingCapacity: true)
             s.chunkQueue.removeAll(keepingCapacity: true)
             s.committedPrefixLength = s.engineText.count
@@ -366,9 +720,31 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     func resume() {
-        state.withLock { s in
-            s.isSuspended = false
+        if engine.partialDeliveryMode == .inline {
+            state.withLock { s in
+                guard !s.isStopped, !s.didFail, s.isSuspended else { return }
+                s.isSuspended = false
+            }
+            return
         }
+        let revision: UInt64? = state.withLock { s in
+            guard !s.isStopped, !s.didFail, s.isSuspended, s.resumeRevision == nil else { return nil }
+            s.isRestarting = true
+            s.resumeRevision = s.lifecycleRevision
+            return s.lifecycleRevision
+        }
+        guard let revision else { return }
+        Task.detached(priority: .utility) { [weak self] in
+            await self?.resumeEngine(expectedRevision: revision)
+        }
+    }
+
+    /// A rebuilt capture source starts a new live-ASR lifecycle. Existing
+    /// provisional text is cleared because audio before the discontinuity has
+    /// already entered the durable chunk pipeline.
+    func resetAfterSourceRestart() {
+        suspend()
+        resume()
     }
 
     func finish(
@@ -435,6 +811,8 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             s.pendingSegments.removeAll()
             s.pendingPublicationTail = nil
             s.activeInferenceRevision = nil
+            s.resumeRevision = nil
+            s.isRestarting = false
         }
         publishImmediately("")
         Task { await engine.shutdown() }
@@ -467,11 +845,72 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
         }
     }
 
-    private func receiveEnginePartial(_ text: String) {
+    private func resumeEngine(expectedRevision: UInt64) async {
+        do {
+            try await engine.restart(
+                partialHandler: { [weak self] text in
+                    self?.receiveEnginePartial(text, expectedRevision: expectedRevision)
+                },
+                failureHandler: { [weak self] error in
+                    self?.receiveEngineFailure(error, expectedRevision: expectedRevision)
+                }
+            )
+            guard state.withLock({ s in
+                !s.isStopped && !s.didFail && s.isSuspended
+                    && s.lifecycleRevision == expectedRevision
+                    && s.resumeRevision == expectedRevision
+            }) else {
+                if state.withLock({ $0.isStopped || $0.didFail }) {
+                    await engine.shutdown()
+                }
+                return
+            }
+            let activation = state.withLock { s -> (activated: Bool, shouldDrain: Bool) in
+                guard !s.isStopped, !s.didFail, s.isSuspended,
+                      s.lifecycleRevision == expectedRevision,
+                      s.resumeRevision == expectedRevision else { return (false, false) }
+                s.resumeRevision = nil
+                s.isSuspended = false
+                s.isRestarting = false
+                guard !s.chunkQueue.isEmpty, !s.isDraining else { return (true, false) }
+                s.isDraining = true
+                return (true, true)
+            }
+            if activation.shouldDrain {
+                Task.detached(priority: .utility) { [weak self] in
+                    await self?.drain()
+                }
+            }
+            if !activation.activated, state.withLock({ $0.isStopped || $0.didFail }) {
+                await engine.shutdown()
+            }
+        } catch {
+            let isCurrent = state.withLock { s in
+                s.lifecycleRevision == expectedRevision && s.resumeRevision == expectedRevision
+            }
+            if isCurrent {
+                goDormant(error: error)
+            }
+        }
+    }
+
+    private func receiveEngineFailure(_ error: Error, expectedRevision: UInt64) {
+        let isCurrent = state.withLock { s in
+            !s.isStopped && !s.didFail && (!s.isSuspended || s.isRestarting)
+                && expectedRevision == s.lifecycleRevision
+        }
+        if isCurrent {
+            goDormant(error: error)
+        }
+    }
+
+    private func receiveEnginePartial(_ text: String, expectedRevision: UInt64) {
         let filteredText = TranscriptionEngineArtifactsFilter.apply(text)
         let tail: String? = state.withLock { s in
             guard !s.isStopped, !s.isSuspended, !s.didFail,
-                  s.activeInferenceRevision == s.lifecycleRevision else { return nil }
+                  (engine.partialDeliveryMode == .asynchronous
+                    ? expectedRevision == s.lifecycleRevision
+                    : s.activeInferenceRevision == s.lifecycleRevision) else { return nil }
             if filteredText.count < s.committedPrefixLength {
                 s.committedPrefixLength = 0
                 s.pendingSegments.removeAll()
@@ -495,6 +934,8 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             s.committedPrefixLength = 0
             s.pendingSegments.removeAll()
             s.activeInferenceRevision = nil
+            s.resumeRevision = nil
+            s.isRestarting = false
         }
         fputs("[meeting-partials] \(label) session dormant after error: \(error)\n", stderr)
         publishImmediately("")
@@ -555,6 +996,19 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     private func visibleTail(for state: State) -> String {
+        if engine.partialDeliveryMode == .asynchronous {
+            let frozenText = state.pendingSegments
+                .filter { !$0.isCommitted }
+                .compactMap(\.frozenText)
+                .joined(separator: " ")
+            return [frozenText, state.engineText]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+        }
+        return currentEngineTail(for: state)
+    }
+
+    private func currentEngineTail(for state: State) -> String {
         let dropCount = min(state.committedPrefixLength, state.engineText.count)
         return String(state.engineText.dropFirst(dropCount))
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -134,6 +134,7 @@ protocol MeetingStreamingPartialEngine: AnyObject, Sendable {
         failureHandler: @escaping @Sendable (Error) -> Void
     ) async throws
     func finish() async throws
+    func finalizedText() async -> String?
     func shutdown() async
 }
 
@@ -148,12 +149,13 @@ extension MeetingStreamingPartialEngine {
         await setFailureHandler(failureHandler)
     }
     func finish() async throws {}
+    func finalizedText() async -> String? { nil }
 }
 
 @available(macOS 26.0, *)
 private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     nonisolated let partialDeliveryMode = MeetingStreamingPartialDeliveryMode.asynchronous
-    private static let maxBufferedInputs = MeetingStreamingPartialSession.maxQueuedChunks
+    private static let maxBufferedInputs = MeetingStreamingPartialSession.maxNativeQueuedChunks
 
     private let locale: Locale
     private let inputFormat: AVAudioFormat
@@ -284,17 +286,26 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
             let clamped = min(max(sample, -1), 1)
             channel[index] = Int16(clamped * Float(Int16.max))
         }
-        if case .terminated = inputContinuation.yield(AnalyzerInput(buffer: buffer)) {
+        switch inputContinuation.yield(AnalyzerInput(buffer: buffer)) {
+        case .enqueued:
+            break
+        case .dropped, .terminated:
             throw NSError(
                 domain: "MeetingLiveCaptions",
                 code: 4,
-                userInfo: [NSLocalizedDescriptionKey: "Apple Speech stopped accepting live audio."]
+                userInfo: [NSLocalizedDescriptionKey: "Apple Speech could not retain all live audio."]
             )
+        @unknown default:
+            throw CancellationError()
         }
     }
 
     func finish() async throws {
         guard !isFinished else { return }
+        let generation = sessionGeneration
+        let analysisTask = self.analysisTask
+        let analyzer = self.analyzer
+        let resultsTask = self.resultsTask
         isFinished = true
         inputContinuation?.finish()
         inputContinuation = nil
@@ -305,7 +316,14 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
             await analyzer.cancelAndFinishNow()
         }
         try await resultsTask?.value
+        guard generation == sessionGeneration else { throw CancellationError() }
         partialHandler?(accumulator.text)
+    }
+
+    func finalizedText() async -> String? {
+        guard isFinished, !didReportFailure else { return nil }
+        let text = accumulator.finalizedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
     }
 
     func shutdown() async {
@@ -352,10 +370,8 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     }
 }
 
-/// Keeps only the text required by the live preview plus a small set of
-/// progressive ranges. Durable timestamped segments are produced by the
-/// meeting transcription pipeline, so the live adapter does not retain every
-/// SpeechTranscriber result object for the lifetime of a meeting.
+/// Retains one VAD segment's final text and bounded provisional ranges. Only
+/// final text is eligible for persistence after the results stream is drained.
 struct AppleSpeechLiveTranscriptAccumulator: Sendable {
     private struct Partial: Sendable {
         let rawText: String
@@ -365,7 +381,7 @@ struct AppleSpeechLiveTranscriptAccumulator: Sendable {
 
     static let maxProgressiveResults = 8
 
-    private var finalizedText = ""
+    private(set) var finalizedText = ""
     private var progressiveResults: [Partial] = []
 
     var text: String {
@@ -524,13 +540,13 @@ private actor Nemotron35MeetingPartialEngine: MeetingStreamingPartialEngine {
     }
 }
 
-/// Display-only streaming partials for one meeting audio source ("You" or "Others").
+/// Streaming captions for one meeting audio source ("You" or "Others").
 ///
 /// The session receives the same 16 kHz samples as the existing meeting VAD and
 /// chunk recorders. Parakeet EOU supplies a low-latency cumulative transcript,
-/// while VAD rotation and durable chunk transcription remain authoritative:
-/// `markSegmentBoundary(id:)` freezes the provisional prefix and
-/// `commitSegment(id:)` removes it only after that chunk retires.
+/// while native asynchronous engines finalize at the existing VAD boundaries.
+/// Final-capable engines supply saved text through the existing chunk pipeline;
+/// missing or incomplete results fall back to recorded audio transcription.
 final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// Called with the current provisional tail text on a background thread.
     /// An empty string clears the tail.
@@ -540,23 +556,34 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// larger look-ahead window required by its cache-aware encoder.
     static let feedSamples = StreamingChunkSize.ms320.shiftSamples
     static let maxQueuedChunks = 3
+    // About ten seconds of 16 kHz audio while a native segment finalizes.
+    static let maxNativeQueuedChunks = 32
     static let maxFrozenSegments = 12
     static let publicationIntervalNanoseconds: UInt64 = 250_000_000
     static let finishDrainTimeoutNanoseconds: UInt64 = 30_000_000_000
 
     private let engine: MeetingStreamingPartialEngine
     private let label: String
+    private let finalizationTimeoutNanoseconds: UInt64
 
     private struct PendingSegment {
         let id: UUID
         let prefixLength: Int
         var frozenText: String?
         var isCommitted = false
+        var isFinalized = false
+        var finalizedText: String?
+    }
+
+    private enum Work {
+        case audio([Float])
+        case boundary(UUID)
+        case restart
     }
 
     private struct State {
         var sampleBuffer: [Float] = []
-        var chunkQueue: [[Float]] = []
+        var chunkQueue: [Work] = []
         var isDraining = false
         var engineText = ""
         var committedPrefixLength = 0
@@ -571,13 +598,20 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
         var lifecycleRevision: UInt64 = 0
         var activeInferenceRevision: UInt64?
         var resumeRevision: UInt64?
-        var isRestartWorkerRunning = false
+        var hasCompleteSegmentStart = true
     }
     private let state = OSAllocatedUnfairLock(initialState: State())
 
-    init(engine: MeetingStreamingPartialEngine, label: String) {
+    init(
+        engine: MeetingStreamingPartialEngine,
+        label: String,
+        startsAtSegmentBoundary: Bool = true,
+        finalizationTimeoutNanoseconds: UInt64 = MeetingStreamingPartialSession.finishDrainTimeoutNanoseconds
+    ) {
         self.engine = engine
         self.label = label
+        self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
+        state.withLock { $0.hasCompleteSegmentStart = startsAtSegmentBoundary }
     }
 
     func connect() async {
@@ -594,19 +628,31 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// single-flight and bounded so provisional captions cannot delay recording.
     func enqueue(_ samples: [Float]) {
         guard !samples.isEmpty else { return }
+        var lostAudio = false
         let shouldStartDrain = state.withLock { s -> Bool in
             guard !s.isStopped, !s.didFail, !s.isSuspended || s.isRestarting else { return false }
             s.sampleBuffer.append(contentsOf: samples)
             while s.sampleBuffer.count >= Self.feedSamples {
-                s.chunkQueue.append(Array(s.sampleBuffer.prefix(Self.feedSamples)))
+                s.chunkQueue.append(.audio(Array(s.sampleBuffer.prefix(Self.feedSamples))))
                 s.sampleBuffer.removeFirst(Self.feedSamples)
             }
-            if s.chunkQueue.count > Self.maxQueuedChunks {
+            let queueLimit = engine.partialDeliveryMode == .asynchronous
+                ? Self.maxNativeQueuedChunks : Self.maxQueuedChunks
+            if s.chunkQueue.count > queueLimit {
+                if engine.partialDeliveryMode == .asynchronous {
+                    lostAudio = true
+                    return false
+                }
                 s.chunkQueue.removeFirst(s.chunkQueue.count - Self.maxQueuedChunks)
             }
             guard !s.isSuspended, !s.chunkQueue.isEmpty, !s.isDraining else { return false }
             s.isDraining = true
             return true
+        }
+        if lostAudio {
+            goDormant(error: NSError(domain: "MeetingStreamingPartialSession", code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Live audio queue overflow; using recorded audio."]))
+            return
         }
         if shouldStartDrain {
             Task.detached(priority: .utility) { [weak self] in
@@ -616,47 +662,53 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     func markSegmentBoundary(id: UUID) {
-        let restartRevision: UInt64? = state.withLock { s in
-            guard engine.partialDeliveryMode == .asynchronous else {
-                s.pendingSegments.append(PendingSegment(
-                    id: id,
-                    prefixLength: s.engineText.count,
-                    frozenText: nil
-                ))
-                return nil
-            }
-            let frozenText = currentEngineTail(for: s)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            s.pendingSegments.append(PendingSegment(
-                id: id,
-                prefixLength: 0,
-                frozenText: frozenText.isEmpty ? nil : frozenText
-            ))
-            let frozenIndices = s.pendingSegments.indices.filter {
-                s.pendingSegments[$0].frozenText != nil
-            }
-            if frozenIndices.count > Self.maxFrozenSegments {
-                for index in frozenIndices.prefix(frozenIndices.count - Self.maxFrozenSegments) {
-                    s.pendingSegments[index].frozenText = nil
+        if engine.partialDeliveryMode == .asynchronous {
+            var overflow = false
+            let shouldDrain = state.withLock { s -> Bool in
+                guard !s.isStopped, !s.didFail else { return false }
+                s.pendingSegments.append(PendingSegment(id: id, prefixLength: 0))
+                if !s.sampleBuffer.isEmpty {
+                    s.chunkQueue.append(.audio(s.sampleBuffer))
+                    s.sampleBuffer.removeAll(keepingCapacity: true)
                 }
+                s.chunkQueue.append(.boundary(id))
+                if s.chunkQueue.count > Self.maxNativeQueuedChunks {
+                    overflow = true
+                    return false
+                }
+                guard !s.isDraining, !s.isSuspended else { return false }
+                s.isDraining = true
+                return true
             }
-            s.lifecycleRevision &+= 1
-            s.isSuspended = true
-            s.isRestarting = true
-            s.resumeRevision = s.lifecycleRevision
-            s.sampleBuffer.removeAll(keepingCapacity: true)
-            s.chunkQueue.removeAll(keepingCapacity: true)
-            s.engineText = ""
-            s.committedPrefixLength = 0
-            return s.lifecycleRevision
-        }
-        if let restartRevision {
-            let tail = state.withLock { visibleTail(for: $0) }
-            publishImmediately(tail, expectedRevision: restartRevision)
-            Task.detached(priority: .utility) { [weak self] in
-                await self?.resumeEngine(expectedRevision: restartRevision)
+            if overflow {
+                goDormant(error: NSError(domain: "MeetingStreamingPartialSession", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Live boundary queue overflow; using recorded audio."]))
+                return
             }
+            if shouldDrain { Task { await drain() } }
+            return
         }
+        state.withLock { s in
+            s.pendingSegments.append(PendingSegment(id: id, prefixLength: s.engineText.count))
+        }
+    }
+
+    /// Wait only for this chunk's native finalization; never persist a volatile
+    /// preview. Timeout, source discontinuity, or dropped audio selects fallback.
+    func finalizedSegmentText(id: UUID) async -> String? {
+        guard engine.partialDeliveryMode == .asynchronous else { return pendingSegmentText(id: id) }
+        let deadline = DispatchTime.now().uptimeNanoseconds &+ finalizationTimeoutNanoseconds
+        while !Task.isCancelled {
+            let result = state.withLock { s -> (done: Bool, text: String?) in
+                guard !s.isStopped, !s.didFail,
+                      let segment = s.pendingSegments.first(where: { $0.id == id }) else { return (true, nil) }
+                return (segment.isFinalized, segment.finalizedText)
+            }
+            if result.done { return result.text }
+            guard DispatchTime.now().uptimeNanoseconds < deadline else { return nil }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return nil
     }
 
     func pendingSegmentText(id: UUID) -> String? {
@@ -664,6 +716,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             guard !s.isStopped, !s.didFail,
                   let segmentIndex = s.pendingSegments.firstIndex(where: { $0.id == id }) else { return nil }
             let segment = s.pendingSegments[segmentIndex]
+            if engine.partialDeliveryMode == .asynchronous { return segment.finalizedText }
             if let frozenText = segment.frozenText {
                 return frozenText
             }
@@ -721,6 +774,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             s.chunkQueue.removeAll(keepingCapacity: true)
             s.committedPrefixLength = s.engineText.count
             s.pendingSegments.removeAll(keepingCapacity: true)
+            s.hasCompleteSegmentStart = false
         }
         publishImmediately("")
     }
@@ -733,16 +787,16 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             }
             return
         }
-        let revision: UInt64? = state.withLock { s in
-            guard !s.isStopped, !s.didFail, s.isSuspended, s.resumeRevision == nil else { return nil }
+        let shouldDrain = state.withLock { s -> Bool in
+            guard !s.isStopped, !s.didFail, s.isSuspended, s.resumeRevision == nil else { return false }
             s.isRestarting = true
             s.resumeRevision = s.lifecycleRevision
-            return s.lifecycleRevision
+            s.chunkQueue.insert(.restart, at: 0)
+            guard !s.isDraining else { return false }
+            s.isDraining = true
+            return true
         }
-        guard let revision else { return }
-        Task.detached(priority: .utility) { [weak self] in
-            await self?.resumeEngine(expectedRevision: revision)
-        }
+        if shouldDrain { Task { await drain() } }
     }
 
     /// A rebuilt capture source starts a new live-ASR lifecycle. Existing
@@ -757,10 +811,10 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
         drainTimeoutNanoseconds: UInt64 = MeetingStreamingPartialSession.finishDrainTimeoutNanoseconds
     ) async -> String? {
         let shouldDrain = state.withLock { s -> Bool in
-            guard !s.isStopped, !s.isSuspended, !s.didFail else { return false }
+            guard !s.isStopped, (!s.isSuspended || s.isRestarting), !s.didFail else { return false }
             if !s.sampleBuffer.isEmpty {
                 s.sampleBuffer.append(contentsOf: repeatElement(0, count: Self.feedSamples - s.sampleBuffer.count))
-                s.chunkQueue.append(s.sampleBuffer)
+                s.chunkQueue.append(.audio(s.sampleBuffer))
                 s.sampleBuffer.removeAll(keepingCapacity: true)
             }
             guard !s.chunkQueue.isEmpty, !s.isDraining else { return false }
@@ -784,23 +838,22 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             }
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        guard !state.withLock({ $0.didFail || $0.isStopped }) else { return nil }
+        guard !state.withLock({ $0.didFail || $0.isStopped || $0.isSuspended }) else { return nil }
         let finishRevision = state.withLock { s -> UInt64 in
             s.activeInferenceRevision = s.lifecycleRevision
             return s.lifecycleRevision
         }
-        do {
-            try await engine.finish()
-        } catch {
-            goDormant(error: error)
-            return nil
-        }
+        let finalized = await finalizeEngine(revision: finishRevision, timeout: drainTimeoutNanoseconds)
         state.withLock { s in
             if s.activeInferenceRevision == finishRevision {
                 s.activeInferenceRevision = nil
             }
         }
         return state.withLock { s in
+            guard !s.isStopped, !s.didFail, s.lifecycleRevision == finishRevision else { return nil }
+            if engine.partialDeliveryMode == .asynchronous {
+                return s.hasCompleteSegmentStart ? finalized : nil
+            }
             let text = visibleTail(for: s).trimmingCharacters(in: .whitespacesAndNewlines)
             return text.isEmpty ? nil : text
         }
@@ -826,8 +879,8 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
 
     private func drain() async {
         while true {
-            let work: (chunk: [Float], revision: UInt64)? = state.withLock { s in
-                guard !s.isStopped, !s.isSuspended, !s.didFail, !s.chunkQueue.isEmpty else {
+            let work: (item: Work, revision: UInt64)? = state.withLock { s in
+                guard !s.isStopped, (!s.isSuspended || s.isRestarting), !s.didFail, !s.chunkQueue.isEmpty else {
                     s.isDraining = false
                     return nil
                 }
@@ -838,39 +891,88 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             guard let work else { return }
 
             do {
-                try await engine.process(samples: work.chunk)
+                switch work.item {
+                case .audio(let samples):
+                    try await engine.process(samples: samples)
+                case .boundary(let id):
+                    await finalizeBoundary(id: id, revision: work.revision)
+                case .restart:
+                    await restartEngine(expectedRevision: work.revision)
+                }
                 state.withLock { s in
                     if s.activeInferenceRevision == work.revision {
                         s.activeInferenceRevision = nil
                     }
                 }
             } catch {
-                goDormant(error: error)
-                return
+                if state.withLock({ $0.lifecycleRevision == work.revision }) {
+                    goDormant(error: error)
+                    return
+                }
             }
         }
     }
 
-    private func resumeEngine(expectedRevision: UInt64) async {
-        // One worker owns engine mutation across suspension points. New boundaries
-        // only replace resumeRevision; stale tasks must never replace its handlers.
-        let acquired = state.withLock { s -> Bool in
-            guard !s.isRestartWorkerRunning, s.resumeRevision == expectedRevision,
-                  !s.isStopped, !s.didFail else { return false }
-            s.isRestartWorkerRunning = true
-            return true
-        }
-        guard acquired else { return }
-        while let revision = state.withLock({ s -> UInt64? in
-            guard !s.isStopped, !s.didFail, s.isSuspended,
-                  let revision = s.resumeRevision else {
-                s.isRestartWorkerRunning = false
-                return nil
+    private func finalizeBoundary(id: UUID, revision: UInt64) async {
+        let finalized = await finalizeEngine(revision: revision)
+        let restartRevision = state.withLock { s -> UInt64? in
+            guard !s.isStopped, !s.didFail, s.lifecycleRevision == revision else { return nil }
+            if let index = s.pendingSegments.firstIndex(where: { $0.id == id }) {
+                s.pendingSegments[index].isFinalized = true
+                s.pendingSegments[index].finalizedText = s.hasCompleteSegmentStart ? finalized : nil
+                s.pendingSegments[index].frozenText = finalized
             }
-            return revision
-        }) {
-            await restartEngine(expectedRevision: revision)
+            // Bound unretired display/lookup text; evicted chunks use recorded audio.
+            for index in s.pendingSegments.indices.dropLast(Self.maxFrozenSegments) {
+                s.pendingSegments[index].frozenText = nil
+                s.pendingSegments[index].finalizedText = nil
+            }
+            s.engineText = ""
+            s.committedPrefixLength = 0
+            s.hasCompleteSegmentStart = true
+            s.lifecycleRevision &+= 1
+            s.isSuspended = true
+            s.isRestarting = true
+            s.resumeRevision = s.lifecycleRevision
+            return s.lifecycleRevision
         }
+        guard let restartRevision else { return }
+        publishImmediately(state.withLock { visibleTail(for: $0) }, expectedRevision: restartRevision)
+        await restartEngine(expectedRevision: restartRevision)
+    }
+
+    /// Unlike a task-group timeout, this does not wait for an uncooperative
+    /// Speech call to acknowledge cancellation before recorded-audio fallback.
+    private func finalizeEngine(
+        revision: UInt64,
+        timeout: UInt64? = nil
+    ) async -> String? {
+        let result = OSAllocatedUnfairLock<Result<String?, Error>?>(initialState: nil)
+        let task = Task { [engine] in
+            do {
+                try await engine.finish()
+                let text = await engine.finalizedText()
+                result.withLock { $0 = .success(text) }
+            } catch {
+                result.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { task.cancel() }
+        let deadline = DispatchTime.now().uptimeNanoseconds &+ (timeout ?? finalizationTimeoutNanoseconds)
+        while !Task.isCancelled {
+            guard state.withLock({ !$0.isStopped && !$0.didFail && $0.lifecycleRevision == revision }) else { return nil }
+            if let completed = result.withLock({ $0 }) {
+                switch completed {
+                case .success(let text): return text
+                case .failure(let error): goDormant(error: error); return nil
+                }
+            }
+            guard DispatchTime.now().uptimeNanoseconds < deadline else { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        goDormant(error: NSError(domain: "MeetingStreamingPartialSession", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out finalizing live transcript; using recorded audio."]))
+        return nil
     }
 
     private func restartEngine(expectedRevision: UInt64) async {
@@ -893,23 +995,17 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
                 }
                 return
             }
-            let activation = state.withLock { s -> (activated: Bool, shouldDrain: Bool) in
+            let activated = state.withLock { s -> Bool in
                 guard !s.isStopped, !s.didFail, s.isSuspended,
                       s.lifecycleRevision == expectedRevision,
-                      s.resumeRevision == expectedRevision else { return (false, false) }
+                      s.resumeRevision == expectedRevision else { return false }
                 s.resumeRevision = nil
                 s.isSuspended = false
                 s.isRestarting = false
-                guard !s.chunkQueue.isEmpty, !s.isDraining else { return (true, false) }
-                s.isDraining = true
-                return (true, true)
+                return true
             }
-            if activation.shouldDrain {
-                Task.detached(priority: .utility) { [weak self] in
-                    await self?.drain()
-                }
-            }
-            if !activation.activated, state.withLock({ $0.isStopped || $0.didFail }) {
+            // The same serial drain resumes queued audio after this returns.
+            if !activated, state.withLock({ $0.isStopped || $0.didFail }) {
                 await engine.shutdown()
             }
         } catch {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -77,19 +77,23 @@ enum MeetingLiveCaptionModelStore {
             guard #available(macOS 26.0, *) else {
                 throw AppleSpeechAnalyzerError.unavailable
             }
-            let preparation = AppleSpeechAnalyzerTranscriber()
-            let locale = try await preparation.prepare(
-                requestedLocale: AppleSpeechLanguageOption.requestedLocale(for: appleSpeechLanguage)
-            )
-            let mic = AppleSpeechMeetingPartialEngine(locale: locale, label: "You")
-            let system = AppleSpeechMeetingPartialEngine(locale: locale, label: "Others")
+            let preparation = AppleSpeechAnalyzerTranscriber.shared
+            let requestedLocale = AppleSpeechLanguageOption.requestedLocale(for: appleSpeechLanguage)
+            let micUse = try await preparation.prepareAndRetain(requestedLocale: requestedLocale)
+            let mic = AppleSpeechMeetingPartialEngine(locale: micUse.locale, lease: micUse.id, label: "You")
             do {
-                try await mic.prepare()
-                try await system.prepare()
-                return (mic, system)
+                let systemUse = try await preparation.prepareAndRetain(requestedLocale: requestedLocale)
+                let system = AppleSpeechMeetingPartialEngine(locale: systemUse.locale, lease: systemUse.id, label: "Others")
+                do {
+                    try await mic.prepare()
+                    try await system.prepare()
+                    return (mic, system)
+                } catch {
+                    await system.shutdown()
+                    throw error
+                }
             } catch {
                 await mic.shutdown()
-                await system.shutdown()
                 throw error
             }
         case .nemotron35:
@@ -158,6 +162,7 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     private static let maxBufferedInputs = MeetingStreamingPartialSession.maxNativeQueuedChunks
 
     private let locale: Locale
+    private var lease: UUID?
     private let inputFormat: AVAudioFormat
     private let label: String
     private var transcriber: SpeechTranscriber?
@@ -173,8 +178,9 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     private var didReportFailure = false
     private var sessionGeneration: UInt64 = 0
 
-    init(locale: Locale, label: String) {
+    init(locale: Locale, lease: UUID, label: String) {
         self.locale = locale
+        self.lease = lease
         inputFormat = AVAudioFormat(
             commonFormat: .pcmFormatInt16,
             sampleRate: 16_000,
@@ -327,7 +333,12 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     }
 
     func shutdown() async {
+        let retiringLease = lease
+        lease = nil
         await cancelCurrentSession()
+        if let retiringLease {
+            await AppleSpeechAnalyzerTranscriber.shared.releaseUse(retiringLease)
+        }
         partialHandler = nil
         failureHandler = nil
         fputs("[meeting-partials] \(label) Apple Speech session stopped\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -192,7 +192,9 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
         partialHandler: @escaping @Sendable (String) -> Void,
         failureHandler: @escaping @Sendable (Error) -> Void
     ) async throws {
+        let cancellationGeneration = sessionGeneration &+ 1
         await cancelCurrentSession()
+        guard sessionGeneration == cancellationGeneration else { throw CancellationError() }
         self.partialHandler = partialHandler
         self.failureHandler = failureHandler
         try await startSession()
@@ -200,6 +202,8 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     }
 
     private func startSession() async throws {
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
         let transcriber = SpeechTranscriber(
             locale: locale,
             preset: .timeIndexedProgressiveTranscription
@@ -209,11 +213,13 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
             options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering)
         )
         try await analyzer.prepareToAnalyze(in: inputFormat)
+        guard generation == sessionGeneration else {
+            await analyzer.cancelAndFinishNow()
+            throw CancellationError()
+        }
         let (inputStream, continuation) = AsyncStream<AnalyzerInput>.makeStream(
             bufferingPolicy: .bufferingNewest(Self.maxBufferedInputs)
         )
-        sessionGeneration &+= 1
-        let generation = sessionGeneration
         self.transcriber = transcriber
         self.analyzer = analyzer
         inputContinuation = continuation
@@ -316,9 +322,7 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
         analysisTask?.cancel()
         analysisMonitorTask?.cancel()
         resultsTask?.cancel()
-        if let analyzer {
-            await analyzer.cancelAndFinishNow()
-        }
+        let retiringAnalyzer = analyzer
         analysisTask = nil
         analysisMonitorTask = nil
         resultsTask = nil
@@ -327,6 +331,7 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
         accumulator = AppleSpeechLiveTranscriptAccumulator()
         isFinished = false
         didReportFailure = false
+        await retiringAnalyzer?.cancelAndFinishNow()
     }
 
     private func receive(_ result: SpeechTranscriber.Result, generation: UInt64) {
@@ -566,6 +571,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
         var lifecycleRevision: UInt64 = 0
         var activeInferenceRevision: UInt64?
         var resumeRevision: UInt64?
+        var isRestartWorkerRunning = false
     }
     private let state = OSAllocatedUnfairLock(initialState: State())
 
@@ -846,6 +852,28 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     private func resumeEngine(expectedRevision: UInt64) async {
+        // One worker owns engine mutation across suspension points. New boundaries
+        // only replace resumeRevision; stale tasks must never replace its handlers.
+        let acquired = state.withLock { s -> Bool in
+            guard !s.isRestartWorkerRunning, s.resumeRevision == expectedRevision,
+                  !s.isStopped, !s.didFail else { return false }
+            s.isRestartWorkerRunning = true
+            return true
+        }
+        guard acquired else { return }
+        while let revision = state.withLock({ s -> UInt64? in
+            guard !s.isStopped, !s.didFail, s.isSuspended,
+                  let revision = s.resumeRevision else {
+                s.isRestartWorkerRunning = false
+                return nil
+            }
+            return revision
+        }) {
+            await restartEngine(expectedRevision: revision)
+        }
+    }
+
+    private func restartEngine(expectedRevision: UInt64) async {
         do {
             try await engine.restart(
                 partialHandler: { [weak self] text in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -329,7 +329,7 @@ private actor AppleSpeechMeetingPartialEngine: MeetingStreamingPartialEngine {
     func finalizedText() async -> String? {
         guard isFinished, !didReportFailure else { return nil }
         let text = accumulator.finalizedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return text.isEmpty ? nil : text
+        return text
     }
 
     func shutdown() async {
@@ -551,13 +551,41 @@ private actor Nemotron35MeetingPartialEngine: MeetingStreamingPartialEngine {
     }
 }
 
-/// Streaming captions for one meeting audio source ("You" or "Others").
-///
-/// The session receives the same 16 kHz samples as the existing meeting VAD and
-/// chunk recorders. Parakeet EOU supplies a low-latency cumulative transcript,
-/// while native asynchronous engines finalize at the existing VAD boundaries.
-/// Final-capable engines supply saved text through the existing chunk pipeline;
-/// missing or incomplete results fall back to recorded audio transcription.
+/// Broadcasts state transitions to bounded, cancellation-aware waiters without polling.
+final class MeetingStreamingSignal: Sendable {
+    private let listeners = OSAllocatedUnfairLock(initialState: [UUID: AsyncStream<Void>.Continuation]())
+
+    func notify() {
+        let current = listeners.withLock { Array($0.values) }
+        for listener in current { listener.yield(()) }
+    }
+
+    func wait(timeoutNanoseconds: UInt64, until predicate: @Sendable () -> Bool) async -> Bool {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        listeners.withLock { $0[id] = continuation }
+        // Subscribe before checking the predicate, so a concurrent completion cannot be lost.
+        continuation.yield(())
+        let timeout = Task {
+            do { try await Task.sleep(nanoseconds: timeoutNanoseconds) }
+            catch { return }
+            continuation.finish()
+        }
+        defer {
+            timeout.cancel()
+            listeners.withLock { _ = $0.removeValue(forKey: id) }
+            continuation.finish()
+        }
+        for await _ in stream {
+            if Task.isCancelled { return false }
+            if predicate() { return true }
+        }
+        return !Task.isCancelled && predicate()
+    }
+}
+
+/// Streaming captions for one audio source. Native asynchronous engines finalize
+/// at VAD boundaries; missing or incomplete results fall back to recorded audio.
 final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// Called with the current provisional tail text on a background thread.
     /// An empty string clears the tail.
@@ -576,6 +604,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     private let engine: MeetingStreamingPartialEngine
     private let label: String
     private let finalizationTimeoutNanoseconds: UInt64
+    private let changes = MeetingStreamingSignal()
 
     private struct PendingSegment {
         let id: UUID
@@ -708,18 +737,16 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// preview. Timeout, source discontinuity, or dropped audio selects fallback.
     func finalizedSegmentText(id: UUID) async -> String? {
         guard engine.partialDeliveryMode == .asynchronous else { return pendingSegmentText(id: id) }
-        let deadline = DispatchTime.now().uptimeNanoseconds &+ finalizationTimeoutNanoseconds
-        while !Task.isCancelled {
-            let result = state.withLock { s -> (done: Bool, text: String?) in
-                guard !s.isStopped, !s.didFail,
-                      let segment = s.pendingSegments.first(where: { $0.id == id }) else { return (true, nil) }
-                return (segment.isFinalized, segment.finalizedText)
+        let completed = await changes.wait(timeoutNanoseconds: finalizationTimeoutNanoseconds) {
+            self.state.withLock { s in
+                s.isStopped || s.didFail || s.pendingSegments.first(where: { $0.id == id })?.isFinalized != false
             }
-            if result.done { return result.text }
-            guard DispatchTime.now().uptimeNanoseconds < deadline else { return nil }
-            try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        return nil
+        guard completed else { return nil }
+        return state.withLock { s in
+            guard !s.isStopped, !s.didFail else { return nil }
+            return s.pendingSegments.first(where: { $0.id == id })?.finalizedText
+        }
     }
 
     func pendingSegmentText(id: UUID) -> String? {
@@ -776,6 +803,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     /// Resume restarts engines that deliver results asynchronously before new
     /// audio is accepted, while cache-aware inline engines remain warm.
     func suspend() {
+        defer { changes.notify() }
         state.withLock { s in
             s.isSuspended = true
             s.isRestarting = false
@@ -837,17 +865,16 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
                 await self?.drain()
             }
         }
-        let drainDeadline = DispatchTime.now().uptimeNanoseconds &+ drainTimeoutNanoseconds
-        while state.withLock({ $0.isDraining || !$0.chunkQueue.isEmpty }) {
-            guard DispatchTime.now().uptimeNanoseconds < drainDeadline else {
-                goDormant(error: NSError(
-                    domain: "MeetingStreamingPartialSession",
-                    code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Timed out finalizing live transcript audio."]
-                ))
-                return nil
-            }
-            try? await Task.sleep(nanoseconds: 10_000_000)
+        let drained = await changes.wait(timeoutNanoseconds: drainTimeoutNanoseconds) {
+            self.state.withLock { $0.isStopped || $0.didFail || (!$0.isDraining && $0.chunkQueue.isEmpty) }
+        }
+        guard drained else {
+            goDormant(error: NSError(
+                domain: "MeetingStreamingPartialSession",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Timed out finalizing live transcript audio."]
+            ))
+            return nil
         }
         guard !state.withLock({ $0.didFail || $0.isStopped || $0.isSuspended }) else { return nil }
         let finishRevision = state.withLock { s -> UInt64 in
@@ -871,6 +898,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     func stop() {
+        defer { changes.notify() }
         state.withLock { s in
             s.isStopped = true
             s.lifecycleRevision &+= 1
@@ -889,6 +917,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     private func drain() async {
+        defer { changes.notify() }
         while true {
             let work: (item: Work, revision: UInt64)? = state.withLock { s in
                 guard !s.isStopped, (!s.isSuspended || s.isRestarting), !s.didFail, !s.chunkQueue.isEmpty else {
@@ -947,6 +976,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             s.resumeRevision = s.lifecycleRevision
             return s.lifecycleRevision
         }
+        changes.notify()
         guard let restartRevision else { return }
         publishImmediately(state.withLock { visibleTail(for: $0) }, expectedRevision: restartRevision)
         await restartEngine(expectedRevision: restartRevision)
@@ -959,7 +989,8 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
         timeout: UInt64? = nil
     ) async -> String? {
         let result = OSAllocatedUnfairLock<Result<String?, Error>?>(initialState: nil)
-        let task = Task { [engine] in
+        let task = Task { [engine, changes] in
+            defer { changes.notify() }
             do {
                 try await engine.finish()
                 let text = await engine.finalizedText()
@@ -969,17 +1000,17 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
             }
         }
         defer { task.cancel() }
-        let deadline = DispatchTime.now().uptimeNanoseconds &+ (timeout ?? finalizationTimeoutNanoseconds)
-        while !Task.isCancelled {
-            guard state.withLock({ !$0.isStopped && !$0.didFail && $0.lifecycleRevision == revision }) else { return nil }
-            if let completed = result.withLock({ $0 }) {
-                switch completed {
-                case .success(let text): return text
-                case .failure(let error): goDormant(error: error); return nil
-                }
+        _ = await changes.wait(timeoutNanoseconds: timeout ?? finalizationTimeoutNanoseconds) {
+            self.state.withLock { $0.isStopped || $0.didFail || $0.lifecycleRevision != revision }
+                || result.withLock { $0 != nil }
+        }
+        guard !Task.isCancelled,
+              state.withLock({ !$0.isStopped && !$0.didFail && $0.lifecycleRevision == revision }) else { return nil }
+        if let completed = result.withLock({ $0 }) {
+            switch completed {
+            case .success(let text): return text
+            case .failure(let error): goDormant(error: error); return nil
             }
-            guard DispatchTime.now().uptimeNanoseconds < deadline else { break }
-            try? await Task.sleep(nanoseconds: 10_000_000)
         }
         goDormant(error: NSError(domain: "MeetingStreamingPartialSession", code: 1,
             userInfo: [NSLocalizedDescriptionKey: "Timed out finalizing live transcript; using recorded audio."]))
@@ -1059,6 +1090,7 @@ final class MeetingStreamingPartialSession: @unchecked Sendable {
     }
 
     private func goDormant(error: Error) {
+        defer { changes.notify() }
         state.withLock { s in
             s.didFail = true
             s.lifecycleRevision &+= 1

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -689,6 +689,7 @@ enum WhisperKitLanguage: String, CaseIterable, Codable, Sendable {
 
 enum MeetingLiveCaptionBackend: String, CaseIterable, Codable, Sendable {
     case parakeetRealtimeEOU = "parakeet_realtime_eou"
+    case appleSpeech = "apple-speech"
     case nemotron35 = "nemotron35"
 
     static let defaultBackend: Self = .parakeetRealtimeEOU
@@ -696,6 +697,7 @@ enum MeetingLiveCaptionBackend: String, CaseIterable, Codable, Sendable {
     var label: String {
         switch self {
         case .parakeetRealtimeEOU: return MeetingLiveCaptionModelStore.label
+        case .appleSpeech: return BackendOption.appleSpeechAnalyzer.label
         case .nemotron35: return BackendOption.nemotron35Multilingual.label
         }
     }
@@ -703,6 +705,7 @@ enum MeetingLiveCaptionBackend: String, CaseIterable, Codable, Sendable {
     var settingsLabel: String {
         switch self {
         case .parakeetRealtimeEOU: return "\(label) (live preview only)"
+        case .appleSpeech: return "\(label) (live preview only)"
         case .nemotron35: return "\(label) (live + final)"
         }
     }
@@ -710,6 +713,11 @@ enum MeetingLiveCaptionBackend: String, CaseIterable, Codable, Sendable {
     var isDownloaded: Bool {
         switch self {
         case .parakeetRealtimeEOU: return MeetingLiveCaptionModelStore.isDownloaded()
+        case .appleSpeech:
+            if #available(macOS 26.0, *) {
+                return AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem
+            }
+            return false
         case .nemotron35:
             guard #available(macOS 15, *) else { return false }
             return BackendOption.nemotron35Multilingual.isDownloaded

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -705,10 +705,12 @@ enum MeetingLiveCaptionBackend: String, CaseIterable, Codable, Sendable {
     var settingsLabel: String {
         switch self {
         case .parakeetRealtimeEOU: return "\(label) (live preview only)"
-        case .appleSpeech: return "\(label) (live preview only)"
+        case .appleSpeech: return "\(label) (live + final)"
         case .nemotron35: return "\(label) (live + final)"
         }
     }
+
+    var producesFinalTranscript: Bool { self == .nemotron35 || self == .appleSpeech }
 
     var isDownloaded: Bool {
         switch self {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -286,7 +286,7 @@ struct ModelsView: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(MuesliTheme.textTertiary)
 
-                Text("Choose how words appear while a meeting is in progress. Nemotron also creates the saved transcript; Parakeet prioritizes a faster English preview.")
+                Text("Choose how words appear while a meeting is in progress. Nemotron also creates the saved transcript; Apple Speech and Parakeet provide provisional previews.")
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textSecondary)
             }
@@ -294,6 +294,24 @@ struct ModelsView: View {
             .padding(.top, MuesliTheme.spacing8)
             .id(FeatureTourTarget.streamingModels.rawValue)
             .featureTourTarget(.streamingModels)
+
+            if BackendOption.systemManaged.contains(.appleSpeechAnalyzer) {
+                let option = BackendOption.appleSpeechAnalyzer
+                modelCard(
+                    option: option,
+                    logo: logoForBackend(option),
+                    isActive: appState.config.enableLiveStreamingPartials
+                        && appState.config.resolvedMeetingLiveCaptionBackend == .appleSpeech,
+                    onSetActive: {
+                        controller.updateConfig {
+                            $0.meetingLiveCaptionBackend = MeetingLiveCaptionBackend.appleSpeech.rawValue
+                            $0.enableLiveStreamingPartials = true
+                        }
+                    },
+                    description: "Apple's private, on-device live captions for system-supported languages on macOS 26. This is a provisional preview; your regular meeting model creates the transcript you keep.",
+                    downloadedLabel: "Available"
+                )
+            }
 
             ForEach(BackendOption.streaming, id: \.model) { option in
                 if let liveCaptionBackend = MeetingLiveCaptionBackend(rawValue: option.backend) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -286,7 +286,7 @@ struct ModelsView: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(MuesliTheme.textTertiary)
 
-                Text("Choose how words appear while a meeting is in progress. Nemotron also creates the saved transcript; Apple Speech and Parakeet provide provisional previews.")
+                Text("Choose how words appear while a meeting is in progress. Apple Speech and Nemotron also create the saved transcript; Parakeet provides a provisional preview.")
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textSecondary)
             }
@@ -308,7 +308,7 @@ struct ModelsView: View {
                             $0.enableLiveStreamingPartials = true
                         }
                     },
-                    description: "Apple's private, on-device live captions for system-supported languages on macOS 26. This is a provisional preview; your regular meeting model creates the transcript you keep.",
+                    description: "Apple's private, on-device streaming transcription on macOS 26. Finalized speech becomes your saved transcript; your regular meeting model recovers any audio the live stream could not finish.",
                     downloadedLabel: "Available"
                 )
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1548,6 +1548,10 @@ public final class MuesliController: NSObject {
         let wasICloudSyncEnabled = config.iCloudSyncEnabled
         let wasUsingAppleSpeech = selectedBackend.backend == "apple-speech"
             || selectedMeetingTranscriptionBackend.backend == "apple-speech"
+            || (config.enableLiveStreamingPartials && config.resolvedMeetingLiveCaptionBackend == .appleSpeech)
+        let previousAppleSpeechLanguage = config.resolvedAppleSpeechLanguage
+        let wasUsingAppleSpeechLive = config.enableLiveStreamingPartials
+            && config.resolvedMeetingLiveCaptionBackend == .appleSpeech
         let previousMeetingInputDeviceUID = config.meetingInputDeviceUID
         let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         let previousQuilHotkeyTriggerThresholdMS = config.quilHotkeyTriggerThresholdMS
@@ -1610,9 +1614,26 @@ public final class MuesliController: NSObject {
         }
         let isUsingAppleSpeech = selectedBackend.backend == "apple-speech"
             || selectedMeetingTranscriptionBackend.backend == "apple-speech"
+            || (config.enableLiveStreamingPartials && config.resolvedMeetingLiveCaptionBackend == .appleSpeech)
         if wasUsingAppleSpeech && !isUsingAppleSpeech {
             Task { [weak self] in
                 await self?.transcriptionCoordinator.unloadAppleSpeechTranscriber()
+            }
+        }
+        if previousAppleSpeechLanguage != config.resolvedAppleSpeechLanguage
+            || (isUsingAppleSpeech && (!wasUsingAppleSpeech
+            || (!wasUsingAppleSpeechLive && config.enableLiveStreamingPartials
+                && config.resolvedMeetingLiveCaptionBackend == .appleSpeech))) {
+            let language = config.resolvedAppleSpeechLanguage
+            Task { [weak self] in
+                guard let self, self.config.resolvedAppleSpeechLanguage == language,
+                      #available(macOS 26.0, *) else { return }
+                do {
+                    try await AppleSpeechAnalyzerTranscriber.shared.prepareSelectedLanguage(
+                        AppleSpeechLanguageOption.requestedLocale(for: language))
+                } catch {
+                    fputs("[muesli-native] Apple Speech selection preparation failed: \(error)\n", stderr)
+                }
             }
         }
         configStore.save(config)
@@ -3077,20 +3098,6 @@ public final class MuesliController: NSObject {
         let normalized = AppleSpeechLanguageOption.normalize(identifier)
         guard normalized != config.resolvedAppleSpeechLanguage else { return }
         updateConfig { $0.appleSpeechLanguage = normalized }
-
-        Task { [weak self] in
-            guard let self else { return }
-            await self.transcriptionCoordinator.unloadAppleSpeechTranscriber()
-            let usesAppleSpeech = self.selectedBackend.backend == "apple-speech"
-                || self.selectedMeetingTranscriptionBackend.backend == "apple-speech"
-            guard usesAppleSpeech else { return }
-            await self.transcriptionCoordinator.preload(
-                backend: .appleSpeechAnalyzer,
-                enablePostProcessor: false,
-                includeMeetingHelpers: false,
-                appleSpeechLanguage: normalized
-            )
-        }
     }
 
     var isPostProcessorReady: Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -290,8 +290,8 @@ struct SettingsView: View {
 
     private var usesUnifiedMeetingTranscript: Bool {
         appState.config.enableLiveStreamingPartials
-            && appState.config.resolvedMeetingLiveCaptionBackend == .nemotron35
-            && downloadedMeetingLiveCaptionBackends.contains(.nemotron35)
+            && appState.config.resolvedMeetingLiveCaptionBackend.producesFinalTranscript
+            && downloadedMeetingLiveCaptionBackends.contains(appState.config.resolvedMeetingLiveCaptionBackend)
     }
 
     private var meetingLiveTranscriptDescription: String {
@@ -1232,7 +1232,7 @@ struct SettingsView: View {
             }
             Divider().background(MuesliTheme.surfaceBorder)
             settingsRow(
-                "Live preview model",
+                "Live transcript model",
                 description: meetingLiveTranscriptDescription,
                 controlWidth: meetingControlWidth
             ) {
@@ -1266,7 +1266,7 @@ struct SettingsView: View {
             Divider().background(MuesliTheme.surfaceBorder)
             settingsRow("Final transcript", controlWidth: meetingControlWidth) {
                 if usesUnifiedMeetingTranscript {
-                    Text("\(MeetingLiveCaptionBackend.nemotron35.label) (same model)")
+                    Text("\(appState.config.resolvedMeetingLiveCaptionBackend.label) (same model)")
                         .font(MuesliTheme.body())
                         .foregroundStyle(MuesliTheme.textSecondary)
                         .frame(width: meetingControlWidth, alignment: .trailing)
@@ -1289,7 +1289,13 @@ struct SettingsView: View {
             if usesUnifiedMeetingTranscript {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Language", controlWidth: meetingControlWidth) {
-                    nemotron35LanguageMenu
+                    if appState.config.resolvedMeetingLiveCaptionBackend == .nemotron35 {
+                        nemotron35LanguageMenu
+                    } else {
+                        Text("Set in Models → Apple Speech")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
                 }
             } else if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {
                 Divider().background(MuesliTheme.surfaceBorder)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -231,7 +231,8 @@ actor TranscriptionCoordinator {
     @available(macOS 26.0, *)
     private func releaseAppleSpeechTranscriber() async {
         guard let transcriber = _appleSpeechTranscriber as? AppleSpeechAnalyzerTranscriber else { return }
-        await transcriber.releaseReservations()
+        // Runtime unloading must not unsubscribe the app's selected language
+        // or a live meeting's assets. The shared owner retires only unused locales.
         guard let current = _appleSpeechTranscriber as? AppleSpeechAnalyzerTranscriber,
               current === transcriber else { return }
         _appleSpeechTranscriber = nil
@@ -468,7 +469,7 @@ actor TranscriptionCoordinator {
     @available(macOS 26.0, *)
     private var appleSpeechTranscriber: AppleSpeechAnalyzerTranscriber {
         if _appleSpeechTranscriber == nil {
-            _appleSpeechTranscriber = AppleSpeechAnalyzerTranscriber()
+            _appleSpeechTranscriber = AppleSpeechAnalyzerTranscriber.shared
         }
         return _appleSpeechTranscriber as! AppleSpeechAnalyzerTranscriber
     }

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -16,6 +16,30 @@ struct AppleSpeechAnalyzerBackendTests {
         #expect(accumulator.segments[0].end == 1.25)
     }
 
+    @Test("progressive results replace and revoke the current live phrase")
+    func accumulatorTracksProgressiveResults() {
+        var accumulator = AppleSpeechTranscriptAccumulator()
+        accumulator.receive(text: "今天天气", isFinal: false, start: 0, end: 0.8)
+        #expect(accumulator.text == "今天天气")
+
+        accumulator.receive(text: "今天天气很好", isFinal: false, start: 0, end: 1.2)
+        #expect(accumulator.text == "今天天气很好")
+
+        accumulator.receive(text: "", isFinal: false, start: 0, end: 1.2)
+        #expect(accumulator.text.isEmpty)
+    }
+
+    @Test("progressive tail revisions preserve finalized text")
+    func accumulatorPreservesFinalizedPrefix() {
+        var accumulator = AppleSpeechTranscriptAccumulator()
+        accumulator.receive(text: "会议开始。", isFinal: true, start: 0, end: 1)
+        accumulator.receive(text: "今天讨论", isFinal: false, start: 1, end: 2)
+        accumulator.receive(text: "今天讨论苹果语音。", isFinal: false, start: 1, end: 3)
+
+        #expect(accumulator.text == "会议开始。今天讨论苹果语音。")
+        #expect(accumulator.segments.map(\.text) == ["会议开始。"])
+    }
+
     @Test("final segments are normalized and joined")
     func accumulatorBuildsTimestampedTranscript() {
         var accumulator = AppleSpeechTranscriptAccumulator()
@@ -37,6 +61,31 @@ struct AppleSpeechAnalyzerBackendTests {
 
         #expect(accumulator.text == "Hello,\nNext line")
         #expect(accumulator.segments.map(\.text) == ["Hello", ",", "Next line"])
+    }
+
+    @Test("live accumulation preserves final text while replacing progressive ranges")
+    func liveAccumulatorReplacesProgressiveRanges() {
+        var accumulator = AppleSpeechLiveTranscriptAccumulator()
+        accumulator.receive(text: "会议开始。", isFinal: true, start: 0, end: 1)
+        accumulator.receive(text: "今天讨论", isFinal: false, start: 1, end: 2)
+        accumulator.receive(text: "今天讨论苹果语音。", isFinal: false, start: 1, end: 3)
+
+        #expect(accumulator.text == "会议开始。今天讨论苹果语音。")
+    }
+
+    @Test("live accumulation bounds non-overlapping progressive results")
+    func liveAccumulatorBoundsProgressiveResults() {
+        var accumulator = AppleSpeechLiveTranscriptAccumulator()
+        for index in 0..<(AppleSpeechLiveTranscriptAccumulator.maxProgressiveResults + 2) {
+            accumulator.receive(
+                text: "\(index)",
+                isFinal: false,
+                start: Double(index),
+                end: Double(index) + 0.5
+            )
+        }
+
+        #expect(accumulator.text == "23456789")
     }
 
     @Test("locale resolver uses exact or language-equivalent supported locale")
@@ -152,6 +201,7 @@ struct AppleSpeechAnalyzerBackendTests {
         #expect(option.backend == "apple-speech")
         #expect(option.isSystemManaged)
         #expect(option.supportsMeetingTranscription)
+        #expect(MeetingLiveCaptionBackend(rawValue: option.backend)?.settingsLabel == "Apple Speech (live preview only)")
         #expect(!BackendOption.experimental.contains(option))
         if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
             #expect(BackendOption.systemManaged.contains(option))

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 @testable import MuesliNativeApp
 
@@ -85,7 +86,7 @@ struct AppleSpeechAnalyzerBackendTests {
 
     @Test("preparation of different languages serializes reservation changes")
     func differentLanguagesPrepareSerially() async throws {
-        let cache = AppleSpeechPreparationTaskCache()
+        let cache = AppleSpeechPreparationTaskCache(serializesOperations: true)
         let order = AppleSpeechPreparationOrder()
         async let first = cache.value(for: "en-IN") {
             await order.begin()
@@ -101,6 +102,31 @@ struct AppleSpeechAnalyzerBackendTests {
         }
         _ = try await (first, second)
         #expect(await order.peak == 1)
+    }
+
+    @Test("a stalled language preparation does not block another language")
+    func differentLanguagesPrepareIndependently() async throws {
+        let cache = AppleSpeechPreparationTaskCache()
+        let started = OSAllocatedUnfairLock(initialState: false)
+        let released = OSAllocatedUnfairLock(initialState: false)
+        let signal = MeetingStreamingSignal()
+        let first = Task {
+            try await cache.value(for: "en-IN") {
+                started.withLock { $0 = true }
+                signal.notify()
+                #expect(await signal.wait(timeoutNanoseconds: 2_000_000_000) { released.withLock { $0 } })
+                return Locale(identifier: "en-IN")
+            }
+        }
+        #expect(await signal.wait(timeoutNanoseconds: 1_000_000_000) { started.withLock { $0 } })
+        let second = try await cache.value(for: "fr-FR") {
+            #expect(!released.withLock { $0 })
+            released.withLock { $0 = true }
+            signal.notify()
+            return Locale(identifier: "fr-FR")
+        }
+        #expect(second.identifier == "fr-FR")
+        _ = try await first.value
     }
 
     @Test("reservation reclamation protects live and dictation users plus the selected language")

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -4,6 +4,113 @@ import Testing
 
 @Suite("Apple SpeechAnalyzer backend")
 struct AppleSpeechAnalyzerBackendTests {
+    @Test("releasing one source keeps the shared language leased by other consumers")
+    func sharedReservationLeases() {
+        var leases = AppleSpeechReservationLeases()
+        let mic = leases.retain(Locale(identifier: "en-IN"))
+        let system = leases.retain(Locale(identifier: "en-IN"))
+        let dictation = leases.retain(Locale(identifier: "fr-FR"))
+        leases.release(mic)
+        leases.release(mic) // Duplicate shutdown must not retire another source.
+        #expect(leases.identifiers == ["en-IN", "fr-FR"])
+        leases.release(system)
+        #expect(leases.identifiers == ["fr-FR"])
+        leases.release(dictation)
+        #expect(leases.identifiers.isEmpty)
+    }
+
+    @Test("transient asset readiness failures retry and can recover")
+    func transientPreparationRetries() async throws {
+        let attempts = AppleSpeechTestCounter()
+        try await AppleSpeechPreparationRetry.run(sleep: { _ in }) {
+            await attempts.increment()
+            if await attempts.value < 3 { throw AppleSpeechAnalyzerError.assetUnavailable("en-IN") }
+        }
+        #expect(await attempts.value == 3)
+    }
+
+    @Test("readiness retries are bounded when Apple assets remain unavailable")
+    func readinessRetryBudget() async {
+        let attempts = AppleSpeechTestCounter()
+        do {
+            try await AppleSpeechPreparationRetry.run(sleep: { _ in }) {
+                await attempts.increment()
+                throw AppleSpeechAnalyzerError.assetUnavailable("en-IN")
+            }
+            Issue.record("Expected the final readiness error")
+        } catch {
+            #expect(AppleSpeechPreparationRetry.isTransient(error))
+        }
+        #expect(await attempts.value == 3)
+    }
+
+    @Test("permanent errors and cancellation do not trigger download retries")
+    func permanentPreparationDoesNotRetry() async {
+        let errors: [Error] = [CancellationError(), AppleSpeechAnalyzerError.unavailable,
+            AppleSpeechAnalyzerError.unsupportedLocale("zz"),
+            AppleSpeechAnalyzerError.reservationUnavailable(2), AppleSpeechTestError.preparationFailed]
+        for error in errors {
+            let attempts = AppleSpeechTestCounter()
+            do {
+                try await AppleSpeechPreparationRetry.run(sleep: { _ in }) {
+                    await attempts.increment()
+                    throw error
+                }
+                Issue.record("Expected preparation to fail")
+            } catch {}
+            #expect(await attempts.value == 1)
+        }
+    }
+
+    @Test("cancellation during backoff prevents another preparation attempt")
+    func cancelledBackoffDoesNotRetry() async {
+        let attempts = AppleSpeechTestCounter()
+        do {
+            try await AppleSpeechPreparationRetry.run(sleep: { _ in throw CancellationError() }) {
+                await attempts.increment()
+                throw AppleSpeechAnalyzerError.assetUnavailable("en-IN")
+            }
+            Issue.record("Expected cancellation")
+        } catch { #expect(error is CancellationError) }
+        #expect(await attempts.value == 1)
+    }
+
+    @Test("only known transient Apple and network errors retry")
+    func preparationRetryClassification() {
+        #expect(AppleSpeechPreparationRetry.isTransient(NSError(domain: "SFSpeechErrorDomain", code: 1)))
+        #expect(AppleSpeechPreparationRetry.isTransient(NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)))
+        #expect(!AppleSpeechPreparationRetry.isTransient(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
+        #expect(!AppleSpeechPreparationRetry.isTransient(NSError(domain: "SFSpeechErrorDomain", code: 99)))
+    }
+
+    @Test("preparation of different languages serializes reservation changes")
+    func differentLanguagesPrepareSerially() async throws {
+        let cache = AppleSpeechPreparationTaskCache()
+        let order = AppleSpeechPreparationOrder()
+        async let first = cache.value(for: "en-IN") {
+            await order.begin()
+            try await Task.sleep(for: .milliseconds(30))
+            await order.end()
+            return Locale(identifier: "en-IN")
+        }
+        async let second = cache.value(for: "fr-FR") {
+            await order.begin()
+            try await Task.sleep(for: .milliseconds(30))
+            await order.end()
+            return Locale(identifier: "fr-FR")
+        }
+        _ = try await (first, second)
+        #expect(await order.peak == 1)
+    }
+
+    @Test("reservation reclamation protects live and dictation users plus the selected language")
+    func reservationCleanupProtectsActiveUsers() {
+        let releases = AppleSpeechInitialReservationPolicy.localesToRelease(
+            ["en-IN", "en-US", "fr-FR", "de-DE"].map { Locale(identifier: $0) },
+            keeping: Locale(identifier: "de-DE"), activeIdentifiers: ["en-IN", "fr-FR"])
+        #expect(releases.map { $0.identifier(.bcp47) } == ["en-US"])
+    }
+
     @Test("volatile results do not duplicate finalized text")
     func accumulatorIgnoresVolatileResults() {
         var accumulator = AppleSpeechTranscriptAccumulator()
@@ -250,6 +357,13 @@ private actor AppleSpeechTestCounter {
     func increment() {
         value += 1
     }
+}
+
+private actor AppleSpeechPreparationOrder {
+    private var active = 0
+    private(set) var peak = 0
+    func begin() { active += 1; peak = max(peak, active) }
+    func end() { active -= 1 }
 }
 
 private enum AppleSpeechTestError: Error {

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -71,6 +71,7 @@ struct AppleSpeechAnalyzerBackendTests {
         accumulator.receive(text: "今天讨论苹果语音。", isFinal: false, start: 1, end: 3)
 
         #expect(accumulator.text == "会议开始。今天讨论苹果语音。")
+        #expect(accumulator.finalizedText == "会议开始。")
     }
 
     @Test("live accumulation bounds non-overlapping progressive results")
@@ -201,7 +202,10 @@ struct AppleSpeechAnalyzerBackendTests {
         #expect(option.backend == "apple-speech")
         #expect(option.isSystemManaged)
         #expect(option.supportsMeetingTranscription)
-        #expect(MeetingLiveCaptionBackend(rawValue: option.backend)?.settingsLabel == "Apple Speech (live preview only)")
+        #expect(MeetingLiveCaptionBackend(rawValue: option.backend)?.settingsLabel == "Apple Speech (live + final)")
+        #expect(MeetingLiveCaptionBackend.appleSpeech.producesFinalTranscript)
+        #expect(MeetingLiveCaptionBackend.nemotron35.producesFinalTranscript)
+        #expect(!MeetingLiveCaptionBackend.parakeetRealtimeEOU.producesFinalTranscript)
         #expect(!BackendOption.experimental.contains(option))
         if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
             #expect(BackendOption.systemManaged.contains(option))

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSessionTitleTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSessionTitleTests.swift
@@ -132,7 +132,7 @@ struct MeetingSessionRecoveryPolicyTests {
     @Test("Nemotron falls back to system audio when streaming produced no segments")
     func unifiedNemotronRecoversEmptySystemTranscript() {
         #expect(MeetingSession.shouldAttemptSystemRecovery(
-            usesUnifiedNemotronTranscript: true,
+            usesStreamingFinalTranscript: true,
             hasSystemSegments: false
         ))
     }
@@ -140,7 +140,7 @@ struct MeetingSessionRecoveryPolicyTests {
     @Test("Nemotron skips redundant system recovery when streaming produced segments")
     func unifiedNemotronKeepsStreamingSystemTranscript() {
         #expect(!MeetingSession.shouldAttemptSystemRecovery(
-            usesUnifiedNemotronTranscript: true,
+            usesStreamingFinalTranscript: true,
             hasSystemSegments: true
         ))
     }
@@ -148,7 +148,7 @@ struct MeetingSessionRecoveryPolicyTests {
     @Test("batch meeting paths retain their existing system recovery behavior")
     func batchPathStillAttemptsSystemRecovery() {
         #expect(MeetingSession.shouldAttemptSystemRecovery(
-            usesUnifiedNemotronTranscript: false,
+            usesStreamingFinalTranscript: false,
             hasSystemSegments: true
         ))
     }
@@ -156,7 +156,7 @@ struct MeetingSessionRecoveryPolicyTests {
     @Test("batch meeting paths recover when no system segments exist")
     func batchPathRecoversEmptySystemTranscript() {
         #expect(MeetingSession.shouldAttemptSystemRecovery(
-            usesUnifiedNemotronTranscript: false,
+            usesStreamingFinalTranscript: false,
             hasSystemSegments: false
         ))
     }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSessionTitleTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSessionTitleTests.swift
@@ -145,6 +145,15 @@ struct MeetingSessionRecoveryPolicyTests {
         ))
     }
 
+    @Test("verified streaming silence does not retranscribe the entire system recording")
+    func finalizedSilenceSkipsSystemRecovery() {
+        #expect(!MeetingSession.shouldAttemptSystemRecovery(
+            usesStreamingFinalTranscript: true,
+            hasSystemSegments: false,
+            hasCompleteStreamingCoverage: true
+        ))
+    }
+
     @Test("batch meeting paths retain their existing system recovery behavior")
     func batchPathStillAttemptsSystemRecovery() {
         #expect(MeetingSession.shouldAttemptSystemRecovery(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -102,6 +102,190 @@ struct MeetingStreamingPartialSessionTests {
         #expect(engine.processCalls == 2)
     }
 
+    @Test("publishes progressive callbacks that arrive after audio submission")
+    func publishesOutOfBandProgressiveCallback() async throws {
+        let engine = DelayedPartialEngine(text: "中文实时字幕")
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+
+        #expect(await waitUntil { collector.latest == "中文实时字幕" })
+    }
+
+    @Test("an asynchronous pre-pause callback cannot publish after resume")
+    func prePauseAsynchronousCallbackCannotPublishAfterResume() async throws {
+        let engine = DelayedPartialEngine(text: "stale", delayNanoseconds: 100_000_000)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        session.suspend()
+        session.resume()
+
+        #expect(await remainsTrue(for: 0.5) { collector.latest == "" })
+    }
+
+    @Test("an asynchronous boundary freezes one segment without hiding the next")
+    func asynchronousBoundaryKeepsSegmentsIndependent() async throws {
+        let engine = ManualAsynchronousPartialEngine()
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        engine.emit("one")
+        #expect(await waitUntil { collector.latest == "one" })
+
+        let segmentID = UUID()
+        session.markSegmentBoundary(id: segmentID)
+        #expect(await waitUntil { engine.restartCalls == 1 })
+        engine.emit("two")
+        #expect(await waitUntil { collector.latest == "one two" })
+
+        session.commitSegment(id: segmentID)
+        #expect(await waitUntil { collector.latest == "two" })
+    }
+
+    @Test("multiple asynchronous boundaries retire only their matching frozen segments")
+    func asynchronousBoundariesRetireInOrder() async throws {
+        let engine = ManualAsynchronousPartialEngine()
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        engine.emit("one")
+        #expect(await waitUntil { collector.latest == "one" })
+        let firstID = UUID()
+        session.markSegmentBoundary(id: firstID)
+        #expect(await waitUntil { engine.restartCalls == 1 })
+
+        engine.emit("two")
+        #expect(await waitUntil { collector.latest == "one two" })
+        let secondID = UUID()
+        session.markSegmentBoundary(id: secondID)
+        #expect(await waitUntil { engine.restartCalls == 2 })
+
+        engine.emit("three")
+        #expect(await waitUntil { collector.latest == "one two three" })
+        session.commitSegment(id: firstID)
+        #expect(await waitUntil { collector.latest == "two three" })
+        session.commitSegment(id: secondID)
+        #expect(await waitUntil { collector.latest == "three" })
+    }
+
+    @Test("a durable commit can retire frozen text while the analyzer restarts")
+    func asynchronousCommitDuringRestartRetiresFrozenText() async throws {
+        let engine = ManualAsynchronousPartialEngine(blocksRestart: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        engine.emit("one")
+        #expect(await waitUntil { collector.latest == "one" })
+
+        let segmentID = UUID()
+        session.markSegmentBoundary(id: segmentID)
+        #expect(await waitUntil { engine.isRestarting })
+        session.commitSegment(id: segmentID)
+        #expect(await waitUntil { collector.latest == "" })
+
+        engine.releaseRestart()
+        #expect(await waitUntil { !engine.isRestarting })
+    }
+
+    @Test("an asynchronous failure during restart makes the session dormant")
+    func asynchronousFailureDuringRestartGoesDormant() async throws {
+        let engine = ManualAsynchronousPartialEngine(blocksRestart: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        engine.emit("one")
+        #expect(await waitUntil { collector.latest == "one" })
+        session.markSegmentBoundary(id: UUID())
+        #expect(await waitUntil { engine.isRestarting })
+
+        engine.fail()
+
+        #expect(await waitUntil { collector.latest == "" && engine.shutdownCalls > 0 })
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await remainsTrue { engine.processCalls == 0 })
+    }
+
+    @Test("asynchronous frozen preview text has a fixed segment bound")
+    func asynchronousFrozenPreviewIsBounded() async throws {
+        let engine = ManualAsynchronousPartialEngine()
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        for index in 0..<(MeetingStreamingPartialSession.maxFrozenSegments + 2) {
+            engine.emit("[segment\(index)]")
+            #expect(await waitUntil { collector.latest?.contains("[segment\(index)]") == true })
+            session.markSegmentBoundary(id: UUID())
+            #expect(await waitUntil { engine.restartCalls == index + 1 })
+        }
+
+        let latest = try #require(collector.latest)
+        #expect(!latest.contains("[segment0]"))
+        #expect(!latest.contains("[segment1]"))
+        #expect(latest.contains("[segment2]"))
+        #expect(latest.contains("[segment13]"))
+    }
+
+    @Test("a capture source restart rebuilds an asynchronous partial engine")
+    func sourceRestartRebuildsAsynchronousEngine() async throws {
+        let engine = ManualAsynchronousPartialEngine()
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        engine.emit("before restart")
+        #expect(await waitUntil { collector.latest == "before restart" })
+
+        session.resetAfterSourceRestart()
+
+        #expect(await waitUntil { engine.restartCalls == 1 && collector.latest == "" })
+    }
+
+    @Test("an asynchronous engine failure clears the tail and goes dormant")
+    func asynchronousFailureGoesDormant() async throws {
+        let engine = FailingAsynchronousPartialEngine()
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        engine.emit("before failure")
+        #expect(await waitUntil { collector.latest == "before failure" })
+        engine.fail()
+        #expect(await waitUntil { collector.latest == "" && engine.shutdownCalls == 1 })
+
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await remainsTrue { engine.processCalls == 1 })
+    }
+
     @Test("coalesces rapid partials and suppresses duplicate UI updates")
     func coalescesAndDeduplicatesPartials() async throws {
         let engine = ScriptedPartialEngine(script: ["one", "one", "one two"])
@@ -465,6 +649,157 @@ private final class ThrowingPartialEngine: MeetingStreamingPartialEngine, @unche
     }
 
     func shutdown() async {}
+}
+
+private final class DelayedPartialEngine: MeetingStreamingPartialEngine, @unchecked Sendable {
+    let partialDeliveryMode = MeetingStreamingPartialDeliveryMode.asynchronous
+    private let text: String
+    private let delayNanoseconds: UInt64
+    private let handler = OSAllocatedUnfairLock<(@Sendable (String) -> Void)?>(initialState: nil)
+    private let calls = OSAllocatedUnfairLock(initialState: 0)
+
+    init(text: String, delayNanoseconds: UInt64 = 20_000_000) {
+        self.text = text
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    var processCalls: Int { calls.withLock { $0 } }
+
+    func setPartialHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+        self.handler.withLock { $0 = handler }
+    }
+
+    func process(samples: [Float]) async throws {
+        calls.withLock { $0 += 1 }
+        let text = text
+        let delayNanoseconds = delayNanoseconds
+        let handler = handler.withLock { $0 }
+        Task.detached {
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+            handler?(text)
+        }
+    }
+
+    func shutdown() async {}
+}
+
+private final class ManualAsynchronousPartialEngine: MeetingStreamingPartialEngine, @unchecked Sendable {
+    let partialDeliveryMode = MeetingStreamingPartialDeliveryMode.asynchronous
+    private struct State {
+        var handler: (@Sendable (String) -> Void)?
+        var failureHandler: (@Sendable (Error) -> Void)?
+        var processCalls = 0
+        var restartCalls = 0
+        var shutdownCalls = 0
+        var restartContinuation: CheckedContinuation<Void, Never>?
+        var isRestarting = false
+    }
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let blocksRestart: Bool
+
+    init(blocksRestart: Bool = false) {
+        self.blocksRestart = blocksRestart
+    }
+
+    var processCalls: Int { state.withLock { $0.processCalls } }
+    var restartCalls: Int { state.withLock { $0.restartCalls } }
+    var shutdownCalls: Int { state.withLock { $0.shutdownCalls } }
+    var isRestarting: Bool { state.withLock { $0.isRestarting } }
+
+    func setPartialHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+        state.withLock { $0.handler = handler }
+    }
+
+    func setFailureHandler(_ handler: @escaping @Sendable (Error) -> Void) async {
+        state.withLock { $0.failureHandler = handler }
+    }
+
+    func process(samples: [Float]) async throws {
+        state.withLock { $0.processCalls += 1 }
+    }
+
+    func restart(
+        partialHandler: @escaping @Sendable (String) -> Void,
+        failureHandler: @escaping @Sendable (Error) -> Void
+    ) async throws {
+        state.withLock { s in
+            s.handler = partialHandler
+            s.failureHandler = failureHandler
+            s.restartCalls += 1
+        }
+        guard blocksRestart else { return }
+        await withCheckedContinuation { continuation in
+            state.withLock { s in
+                s.isRestarting = true
+                s.restartContinuation = continuation
+            }
+        }
+        state.withLock { $0.isRestarting = false }
+    }
+
+    func releaseRestart() {
+        let continuation = state.withLock { s -> CheckedContinuation<Void, Never>? in
+            let continuation = s.restartContinuation
+            s.restartContinuation = nil
+            return continuation
+        }
+        continuation?.resume()
+    }
+
+    func emit(_ text: String) {
+        state.withLock { $0.handler }?(text)
+    }
+
+    func fail() {
+        state.withLock { $0.failureHandler }?(
+            NSError(domain: "ManualAsynchronousPartialEngine", code: 1)
+        )
+    }
+
+    func shutdown() async {
+        releaseRestart()
+        state.withLock { $0.shutdownCalls += 1 }
+    }
+}
+
+private final class FailingAsynchronousPartialEngine: MeetingStreamingPartialEngine, @unchecked Sendable {
+    let partialDeliveryMode = MeetingStreamingPartialDeliveryMode.asynchronous
+    private struct State {
+        var partialHandler: (@Sendable (String) -> Void)?
+        var failureHandler: (@Sendable (Error) -> Void)?
+        var processCalls = 0
+        var shutdownCalls = 0
+    }
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var processCalls: Int { state.withLock { $0.processCalls } }
+    var shutdownCalls: Int { state.withLock { $0.shutdownCalls } }
+
+    func setPartialHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+        state.withLock { $0.partialHandler = handler }
+    }
+
+    func setFailureHandler(_ handler: @escaping @Sendable (Error) -> Void) async {
+        state.withLock { $0.failureHandler = handler }
+    }
+
+    func process(samples: [Float]) async throws {
+        state.withLock { $0.processCalls += 1 }
+    }
+
+    func emit(_ text: String) {
+        state.withLock { $0.partialHandler }?(text)
+    }
+
+    func fail() {
+        state.withLock { $0.failureHandler }?(
+            NSError(domain: "FailingAsynchronousPartialEngine", code: 1)
+        )
+    }
+
+    func shutdown() async {
+        state.withLock { $0.shutdownCalls += 1 }
+    }
 }
 
 private final class BlockingPartialEngine: MeetingStreamingPartialEngine, @unchecked Sendable {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -249,6 +249,47 @@ struct MeetingStreamingPartialSessionTests {
         #expect(latest.contains("[segment13]"))
     }
 
+    @Test("overlapping boundaries serialize restarts and retain the newest callbacks")
+    func overlappingRestartsKeepNewestSession() async throws {
+        let engine = ManualAsynchronousPartialEngine(blocksRestart: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        defer { session.stop() }
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+
+        session.markSegmentBoundary(id: UUID())
+        #expect(await waitUntil { engine.isRestarting })
+        session.markSegmentBoundary(id: UUID())
+        session.resetAfterSourceRestart()
+        #expect(await remainsTrue { engine.restartCalls == 1 })
+
+        engine.releaseRestart()
+        #expect(await waitUntil { engine.restartCalls == 2 && engine.isRestarting })
+        engine.releaseRestart()
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await waitUntil { engine.processCalls == 1 })
+        engine.emit("newest")
+        #expect(await waitUntil { collector.latest == "newest" })
+        #expect(engine.restartCalls == 2)
+    }
+
+    @Test("stop during a blocked restart cannot reactivate caption delivery")
+    func stopDuringRestartRemainsStopped() async throws {
+        let engine = ManualAsynchronousPartialEngine(blocksRestart: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "Others")
+        let collector = PartialCollector()
+        session.onPartialUpdate = { collector.record($0) }
+        await session.connect()
+        session.markSegmentBoundary(id: UUID())
+        #expect(await waitUntil { engine.isRestarting })
+        session.stop()
+        #expect(await waitUntil { !engine.isRestarting && engine.shutdownCalls > 0 })
+        engine.emit("stale")
+        session.enqueue(samples(chunkCount: 1))
+        #expect(await remainsTrue { collector.latest == "" && engine.processCalls == 0 })
+    }
+
     @Test("a capture source restart rebuilds an asynchronous partial engine")
     func sourceRestartRebuildsAsynchronousEngine() async throws {
         let engine = ManualAsynchronousPartialEngine()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -7,6 +7,74 @@ import Testing
 
 @Suite("Meeting streaming partial session")
 struct MeetingStreamingPartialSessionTests {
+    @Test("successful streaming text and silence never invoke recorded-audio transcription")
+    func streamingSuccessSkipsBatch() async {
+        let timing = MeetingChunkTimingSnapshot(startSampleIndex: 0, sampleCount: 16_000)
+        for text in ["Final words.", ""] {
+            let result = await MeetingSession.resolveChunkTranscript(timing: timing, finalizedText: { text }) {
+                Issue.record("Recorded audio must not be transcribed after successful streaming")
+                return []
+            }
+            #expect(result.map(\.text) == (text.isEmpty ? [] : [text]))
+        }
+    }
+
+    @Test("unavailable streaming invokes recorded-audio transcription exactly once")
+    func missingStreamingUsesBatchOnce() async {
+        let timing = MeetingChunkTimingSnapshot(startSampleIndex: 0, sampleCount: 16_000)
+        var calls = 0
+        let result = await MeetingSession.resolveChunkTranscript(timing: timing, finalizedText: { nil }) {
+            calls += 1
+            return [SpeechSegment(start: 0, end: 1, text: "Recovered.")]
+        }
+        #expect(calls == 1)
+        #expect(result.map(\.text) == ["Recovered."])
+    }
+
+    @Test("cancellation while finalizing does not launch recorded-audio transcription")
+    func cancelledStreamingDoesNotStartBatch() async {
+        let timing = MeetingChunkTimingSnapshot(startSampleIndex: 0, sampleCount: 16_000)
+        let task = Task {
+            await MeetingSession.resolveChunkTranscript(timing: timing, finalizedText: {
+                withUnsafeCurrentTask { $0?.cancel() }
+                return nil
+            }) {
+                Issue.record("Cancellation must not start batch transcription")
+                return []
+            }
+        }
+        #expect(await task.value.isEmpty)
+    }
+
+    @Test("finalized silence is successful at both chunk and stop boundaries")
+    func nativeFinalizedSilence() async {
+        let engine = ManualAsynchronousPartialEngine(finalText: "")
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        defer { session.stop() }
+        await session.connect()
+        let id = UUID()
+        session.markSegmentBoundary(id: id)
+        #expect(await session.finalizedSegmentText(id: id) == "")
+        #expect(await session.finish() == "")
+        let timing = MeetingChunkTimingSnapshot(startSampleIndex: 16_000, sampleCount: 32_000)
+        #expect(MeetingSession.segmentsFromFinalizedText("", timing: timing).isEmpty)
+        let segments = MeetingSession.segmentsFromFinalizedText("Final correction.", timing: timing)
+        #expect(segments.count == 1)
+        #expect(segments.first?.text == "Final correction.")
+        #expect(segments.first?.start == 1)
+        #expect(segments.first?.end == 3)
+    }
+
+    @Test("event wait handles completion, timeout, and cancellation")
+    func signalWaitLifecycle() async {
+        let signal = MeetingStreamingSignal()
+        #expect(await signal.wait(timeoutNanoseconds: 1_000_000) { true })
+        #expect(!(await signal.wait(timeoutNanoseconds: 1_000_000) { false }))
+        let waiter = Task { await signal.wait(timeoutNanoseconds: 30_000_000_000) { false } }
+        waiter.cancel()
+        #expect(!(await waiter.value))
+    }
+
     @Test("stale live caption downloads cannot finish after an immediate restart")
     func liveCaptionDownloadGenerationRejectsStaleCompletion() {
         var state = ModelDownloadGenerationState()
@@ -915,7 +983,7 @@ private final class ManualAsynchronousPartialEngine: MeetingStreamingPartialEngi
     }
 
     func finalizedText() async -> String? {
-        state.withLock { $0.text.isEmpty ? nil : $0.text }
+        state.withLock { $0.text }
     }
 
     func finish() async throws {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -131,6 +131,114 @@ struct MeetingStreamingPartialSessionTests {
         #expect(await remainsTrue(for: 0.5) { collector.latest == "" })
     }
 
+    @Test("native boundaries save finalized corrections and serialize the next audio")
+    func nativeFinalizationPrecedesNextAudio() async {
+        let engine = ManualAsynchronousPartialEngine(blocksFinish: true, finalText: "Final correction.")
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        defer { session.stop() }
+        await session.connect()
+        engine.emit("provisional guess")
+        let id = UUID()
+        session.markSegmentBoundary(id: id)
+        #expect(await waitUntil { engine.isFinishing })
+        #expect(session.pendingSegmentText(id: id) == nil)
+        session.enqueue(samples(chunkCount: 1))
+        #expect(engine.processCalls == 0)
+        engine.releaseFinish()
+        #expect(await session.finalizedSegmentText(id: id) == "Final correction.")
+        #expect(await waitUntil { engine.processCalls == 1 && engine.restartCalls == 1 })
+    }
+
+    @Test("native stop saves final text instead of the last provisional caption")
+    func nativeStopUsesFinalText() async {
+        let engine = ManualAsynchronousPartialEngine(finalText: "Final correction.")
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        defer { session.stop() }
+        await session.connect()
+        engine.emit("provisional guess")
+        #expect(await session.finish() == "Final correction.")
+    }
+
+    @Test("stop during native restart retains the sub-interval audio tail")
+    func nativeStopDuringRestartFlushesResidualAudio() async {
+        let engine = ManualAsynchronousPartialEngine(blocksRestart: true, finalText: "final")
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        defer { session.stop() }
+        await session.connect()
+        session.markSegmentBoundary(id: UUID())
+        #expect(await waitUntil { engine.isRestarting })
+        session.enqueue([0.1, 0.2, 0.3])
+        let finishing = Task { await session.finish() }
+        // Keep the restart blocked long enough for finish to queue the residual.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        engine.releaseRestart()
+        #expect(await finishing.value == "final")
+        #expect(engine.processCalls == 1)
+    }
+
+    @Test("failed native finalization falls back instead of saving provisional text")
+    func nativeFinalizationFailureFallsBack() async {
+        let engine = ManualAsynchronousPartialEngine(failsFinish: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        defer { session.stop() }
+        await session.connect()
+        engine.emit("must not save")
+        let id = UUID()
+        session.markSegmentBoundary(id: id)
+        #expect(await session.finalizedSegmentText(id: id) == nil)
+        #expect(await waitUntil { engine.shutdownCalls > 0 })
+    }
+
+    @Test("hung native finalization times out and recovers from recorded audio")
+    func nativeFinalizationTimeoutFallsBack() async {
+        let engine = ManualAsynchronousPartialEngine(blocksFinish: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You",
+            finalizationTimeoutNanoseconds: 50_000_000)
+        defer { session.stop() }
+        await session.connect()
+        engine.emit("must not save")
+        let id = UUID()
+        session.markSegmentBoundary(id: id)
+        #expect(await session.finalizedSegmentText(id: id) == nil)
+        #expect(await waitUntil { engine.shutdownCalls > 0 })
+        #expect(session.pendingSegmentText(id: id) == nil)
+    }
+
+    @Test("late startup and capture recovery use recording until a complete segment")
+    func nativeIncompleteStartFallsBack() async {
+        let engine = ManualAsynchronousPartialEngine(finalText: "complete sentence")
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You", startsAtSegmentBoundary: false)
+        defer { session.stop() }
+        await session.connect()
+        let first = UUID()
+        session.markSegmentBoundary(id: first)
+        #expect(await session.finalizedSegmentText(id: first) == nil)
+        #expect(await waitUntil { engine.restartCalls == 1 })
+        let second = UUID()
+        session.markSegmentBoundary(id: second)
+        #expect(await session.finalizedSegmentText(id: second) == "complete sentence")
+        #expect(await waitUntil { engine.restartCalls == 2 })
+        session.resetAfterSourceRestart()
+        #expect(await waitUntil { engine.restartCalls == 3 })
+        let recovered = UUID()
+        session.markSegmentBoundary(id: recovered)
+        #expect(await session.finalizedSegmentText(id: recovered) == nil)
+    }
+
+    @Test("native audio overflow selects recording rather than silently dropping speech")
+    func nativeBackpressureFallsBack() async {
+        let engine = ManualAsynchronousPartialEngine(blocksFinish: true)
+        let session = MeetingStreamingPartialSession(engine: engine, label: "You")
+        defer { session.stop() }
+        await session.connect()
+        let id = UUID()
+        session.markSegmentBoundary(id: id)
+        #expect(await waitUntil { engine.isFinishing })
+        session.enqueue(samples(chunkCount: MeetingStreamingPartialSession.maxNativeQueuedChunks + 1))
+        #expect(await waitUntil { engine.shutdownCalls > 0 })
+        #expect(await session.finalizedSegmentText(id: id) == nil)
+    }
+
     @Test("an asynchronous boundary freezes one segment without hiding the next")
     func asynchronousBoundaryKeepsSegmentsIndependent() async throws {
         let engine = ManualAsynchronousPartialEngine()
@@ -734,14 +842,24 @@ private final class ManualAsynchronousPartialEngine: MeetingStreamingPartialEngi
         var shutdownCalls = 0
         var restartContinuation: CheckedContinuation<Void, Never>?
         var isRestarting = false
+        var text = ""
+        var finishContinuation: CheckedContinuation<Void, Never>?
+        var isFinishing = false
     }
     private let state = OSAllocatedUnfairLock(initialState: State())
     private let blocksRestart: Bool
+    private let blocksFinish: Bool
+    private let finalText: String?
+    private let failsFinish: Bool
 
-    init(blocksRestart: Bool = false) {
+    init(blocksRestart: Bool = false, blocksFinish: Bool = false, finalText: String? = nil, failsFinish: Bool = false) {
         self.blocksRestart = blocksRestart
+        self.blocksFinish = blocksFinish
+        self.finalText = finalText
+        self.failsFinish = failsFinish
     }
 
+    var isFinishing: Bool { state.withLock { $0.isFinishing } }
     var processCalls: Int { state.withLock { $0.processCalls } }
     var restartCalls: Int { state.withLock { $0.restartCalls } }
     var shutdownCalls: Int { state.withLock { $0.shutdownCalls } }
@@ -767,6 +885,7 @@ private final class ManualAsynchronousPartialEngine: MeetingStreamingPartialEngi
             s.handler = partialHandler
             s.failureHandler = failureHandler
             s.restartCalls += 1
+            s.text = ""
         }
         guard blocksRestart else { return }
         await withCheckedContinuation { continuation in
@@ -788,7 +907,38 @@ private final class ManualAsynchronousPartialEngine: MeetingStreamingPartialEngi
     }
 
     func emit(_ text: String) {
-        state.withLock { $0.handler }?(text)
+        let handler = state.withLock { s in
+            s.text = text
+            return s.handler
+        }
+        handler?(text)
+    }
+
+    func finalizedText() async -> String? {
+        state.withLock { $0.text.isEmpty ? nil : $0.text }
+    }
+
+    func finish() async throws {
+        if blocksFinish {
+            await withCheckedContinuation { continuation in
+                state.withLock { s in
+                    s.finishContinuation = continuation
+                    s.isFinishing = true
+                }
+            }
+        }
+        if failsFinish { throw NSError(domain: "ManualAsynchronousPartialEngine", code: 2) }
+        if let finalText { emit(finalText) }
+    }
+
+    func releaseFinish() {
+        let continuation = state.withLock { s -> CheckedContinuation<Void, Never>? in
+            let continuation = s.finishContinuation
+            s.finishContinuation = nil
+            s.isFinishing = false
+            return continuation
+        }
+        continuation?.resume()
     }
 
     func fail() {
@@ -799,6 +949,7 @@ private final class ManualAsynchronousPartialEngine: MeetingStreamingPartialEngi
 
     func shutdown() async {
         releaseRestart()
+        releaseFinish()
         state.withLock { $0.shutdownCalls += 1 }
     }
 }


### PR DESCRIPTION
## Summary

- Add Apple Speech as a system-managed live **and final** meeting transcription backend on supported macOS 26+ systems.
- Use independent progressive analyzers for microphone and system audio. Replace provisional captions with native finalized text and use the same final text in the saved transcript.
- Avoid routine parallel batch transcription: recorded-audio transcription recovers only chunks that streaming could not completely finalize. Successfully finalized silence does not trigger a second pass.
- Prepare the selected language early, retain shared language reservations across dictation and meetings, retry known transient preparation failures, and verify analyzer preparation before reporting readiness.
- Coalesce preparation per language; serialize only reservation mutations so a slow language download does not block preparation of another language.
- Preserve generation-scoped pause, resume, source recovery, and stop behavior, with bounded buffering and event-driven finalization waits.

## Behavior and recovery

Apple Speech now supplies live and saved meeting transcripts, rather than preview-only text. Audio recording continues throughout. Missing, incomplete, failed, or timed-out streaming results use the existing configured meeting transcription backend on recorded audio. Initial startup and source-recovery chunks may require this recovery because the live analyzer may have missed their beginning. Existing Parakeet and Nemotron transcription policies are unchanged.

Language preparation reduces transient asset failures but does not guarantee that macOS-managed assets can never fail. Existing meeting capture startup behavior is unchanged.

## Verification

- Latest head: `add1d69d509b8c2bdfc015d2106c83e2e6523480`.
- 365 focused tests in 33 suites passed using the existing shared SwiftPM cache. Coverage includes final-text reuse, silence, lazy recorded-audio recovery, cancellation, timeout, source recovery, serialized restarts, and independent language preparation.
- CI passed: release build; core, dictation-transcription, and meeting test shards; macOS 26 Apple Speech validation; CLI smoke; update flow; classifier tests; required `ci-gate`.
- Local DevA testing and language switching were reported successful by the maintainer. No claim that transient OS asset failures are permanently eliminated.
- Self-review improvements are included. Greptile credits are exhausted and CodeRabbit review is paused; their older comments are not fresh approval of this head. The stale-restart finding is addressed by serialized restart handling and regression coverage.

## Contribution disclosure

This implementation was materially assisted by OpenAI Codex. The contributor's authorship and DCO sign-offs are preserved alongside signed-off maintainer follow-up commits.

No third-party source code, assets, or model files were copied into this change. It uses Apple public Speech APIs and dependencies already present in the project.

Closes #469
