### PR TITLE
Parakeet language picker + Parakeet-first onboarding

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -190,6 +190,7 @@ enum AudioFileImportController {
             cohereLanguage: config.resolvedCohereLanguage,
             indicASRLanguage: config.resolvedIndicASRLanguage,
             whisperLanguage: config.resolvedWhisperLanguage,
+            parakeetLanguage: config.resolvedParakeetLanguage,
             appleSpeechLanguage: config.resolvedAppleSpeechLanguage
         )
         let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
@@ -58,10 +58,13 @@ actor FluidAudioTranscriber {
     }
 
     /// Transcribe a WAV file URL directly.
-    func transcribe(wavURL: URL) async throws -> ASRResult {
+    /// `language` is an optional ISO code enabling FluidAudio's script-level
+    /// token filter on the v3 joint decoder (v2 ignores the hint; nil = auto).
+    func transcribe(wavURL: URL, language: String? = nil) async throws -> ASRResult {
         guard let asrManager else { throw TranscriberError.notLoaded }
+        let languageHint = language.flatMap(Language.init(rawValue:))
         var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
-        return try await asrManager.transcribe(wavURL, decoderState: &decoderState)
+        return try await asrManager.transcribe(wavURL, decoderState: &decoderState, language: languageHint)
     }
 
     func shutdown() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -781,6 +781,7 @@ final class MeetingSession {
                         cohereLanguage: config.resolvedCohereLanguage,
                         indicASRLanguage: config.resolvedIndicASRLanguage,
                         whisperLanguage: config.resolvedWhisperLanguage,
+                        parakeetLanguage: config.resolvedParakeetLanguage,
                         appleSpeechLanguage: config.resolvedAppleSpeechLanguage
                     )
                     let normalizedSegments = normalizeSystemTranscription(
@@ -1080,6 +1081,7 @@ final class MeetingSession {
                     cohereLanguage: config.resolvedCohereLanguage,
                     indicASRLanguage: config.resolvedIndicASRLanguage,
                     whisperLanguage: config.resolvedWhisperLanguage,
+                    parakeetLanguage: config.resolvedParakeetLanguage,
                     appleSpeechLanguage: config.resolvedAppleSpeechLanguage
                 )
                 if !result.text.isEmpty {
@@ -1312,6 +1314,7 @@ final class MeetingSession {
                 cohereLanguage: config.resolvedCohereLanguage,
                 indicASRLanguage: config.resolvedIndicASRLanguage,
                 whisperLanguage: config.resolvedWhisperLanguage,
+                parakeetLanguage: config.resolvedParakeetLanguage,
                 appleSpeechLanguage: config.resolvedAppleSpeechLanguage
             )
             if !result.text.isEmpty {
@@ -1421,6 +1424,7 @@ final class MeetingSession {
                         cohereLanguage: config.resolvedCohereLanguage,
                         indicASRLanguage: config.resolvedIndicASRLanguage,
                         whisperLanguage: config.resolvedWhisperLanguage,
+                        parakeetLanguage: config.resolvedParakeetLanguage,
                         appleSpeechLanguage: config.resolvedAppleSpeechLanguage
                     )
                     repairedSegments.append(contentsOf: normalizeSystemTranscription(
@@ -1455,6 +1459,7 @@ final class MeetingSession {
                 cohereLanguage: config.resolvedCohereLanguage,
                 indicASRLanguage: config.resolvedIndicASRLanguage,
                 whisperLanguage: config.resolvedWhisperLanguage,
+                parakeetLanguage: config.resolvedParakeetLanguage,
                 appleSpeechLanguage: config.resolvedAppleSpeechLanguage
             )
             return normalizeSystemTranscription(

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -22,7 +22,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/parakeet-unified-en-0.6b-coreml",
         label: "Parakeet Unified",
         sizeLabel: "~565 MB",
-        description: "The newest Parakeet generation and the best choice for English dictation: a lower error rate than Parakeet v3 with a newer architecture. English-focused; pick Parakeet v3 for multilingual needs.",
+        description: "The best English dictation. Lowest error rate, newest architecture, instant. For other languages, choose Parakeet v3.",
         recommended: true
     )
 
@@ -31,7 +31,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/parakeet-tdt-0.6b-v3-coreml",
         label: "Parakeet v3",
         sizeLabel: "~450 MB",
-        description: "The multilingual Parakeet: quick enough to feel responsive, reliable in normal rooms, and able to follow 25 languages.",
+        description: "Fast, reliable dictation in 25 languages.",
         recommended: false
     )
 
@@ -209,7 +209,9 @@ struct BackendOption: Equatable {
             + [.cohereTranscribe]
             + streaming
             + experimental
-        let onboardingDefault = systemManaged.first ?? .parakeetUnified
+        // Parakeet Unified (English) and v3 (multilingual) are the preferred
+        // onboarding models; Apple Speech remains available in the catalog.
+        let onboardingDefault: BackendOption = .parakeetUnified
         let onboardingCandidates: [BackendOption] = [
             onboardingDefault,
             .parakeetUnified,
@@ -458,6 +460,97 @@ enum Qwen3AsrLanguage: Hashable, Sendable {
             return .pinned(language)
         }
         return defaultLanguage
+    }
+
+    static func resolvedCode(_ rawValue: String?) -> String {
+        resolved(rawValue).rawValue
+    }
+}
+
+/// Language selection for Parakeet TDT v2/v3.
+/// `auto` leaves decoding unfiltered; explicit codes enable FluidAudio's
+/// script-level token filter (v3 joint decoder; v2 ignores the hint).
+enum ParakeetLanguage: String, CaseIterable, Codable, Sendable {
+    case auto = "auto"
+    case english = "en"
+    case spanish = "es"
+    case french = "fr"
+    case german = "de"
+    case italian = "it"
+    case portuguese = "pt"
+    case romanian = "ro"
+    case dutch = "nl"
+    case danish = "da"
+    case swedish = "sv"
+    case finnish = "fi"
+    case hungarian = "hu"
+    case estonian = "et"
+    case latvian = "lv"
+    case lithuanian = "lt"
+    case maltese = "mt"
+    case polish = "pl"
+    case czech = "cs"
+    case slovak = "sk"
+    case slovenian = "sl"
+    case croatian = "hr"
+    case bosnian = "bs"
+    case russian = "ru"
+    case ukrainian = "uk"
+    case belarusian = "be"
+    case bulgarian = "bg"
+    case serbian = "sr"
+    case greek = "el"
+
+    static let defaultLanguage: Self = .auto
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto-detect"
+        case .english: return "English"
+        case .spanish: return "Spanish"
+        case .french: return "French"
+        case .german: return "German"
+        case .italian: return "Italian"
+        case .portuguese: return "Portuguese"
+        case .romanian: return "Romanian"
+        case .dutch: return "Dutch"
+        case .danish: return "Danish"
+        case .swedish: return "Swedish"
+        case .finnish: return "Finnish"
+        case .hungarian: return "Hungarian"
+        case .estonian: return "Estonian"
+        case .latvian: return "Latvian"
+        case .lithuanian: return "Lithuanian"
+        case .maltese: return "Maltese"
+        case .polish: return "Polish"
+        case .czech: return "Czech"
+        case .slovak: return "Slovak"
+        case .slovenian: return "Slovenian"
+        case .croatian: return "Croatian"
+        case .bosnian: return "Bosnian"
+        case .russian: return "Russian"
+        case .ukrainian: return "Ukrainian"
+        case .belarusian: return "Belarusian"
+        case .bulgarian: return "Bulgarian"
+        case .serbian: return "Serbian"
+        case .greek: return "Greek"
+        }
+    }
+
+    /// ISO code passed to FluidAudio's token language filter, or nil for auto.
+    var isoCode: String? {
+        switch self {
+        case .auto: return nil
+        default: return rawValue
+        }
+    }
+
+    static func resolved(_ rawValue: String?) -> Self {
+        guard let rawValue,
+              let language = Self(rawValue: rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) else {
+            return defaultLanguage
+        }
+        return language
     }
 
     static func resolvedCode(_ rawValue: String?) -> String {
@@ -1324,6 +1417,7 @@ struct AppConfig: Codable {
     var nemotron35Language: String = Nemotron35Language.defaultLanguage.rawValue
     var whisperLanguage: String = WhisperKitLanguage.defaultLanguage.rawValue
     var qwen3AsrLanguage: String = Qwen3AsrLanguage.defaultLanguage.rawValue
+    var parakeetLanguage: String = ParakeetLanguage.defaultLanguage.rawValue
     var appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier
     var meetingTranscriptionBackend: String = BackendOption.whisper.backend
     var meetingTranscriptionModel: String = BackendOption.whisper.model
@@ -1458,6 +1552,7 @@ struct AppConfig: Codable {
         case nemotron35Language = "nemotron35_language"
         case whisperLanguage = "whisper_language"
         case qwen3AsrLanguage = "qwen3_asr_language"
+        case parakeetLanguage = "parakeet_language"
         case appleSpeechLanguage = "apple_speech_language"
         case meetingTranscriptionBackend = "meeting_transcription_backend"
         case meetingTranscriptionModel = "meeting_transcription_model"
@@ -1598,6 +1693,7 @@ struct AppConfig: Codable {
         nemotron35Language = Nemotron35Language.resolvedCode(try? c.decode(String.self, forKey: .nemotron35Language))
         whisperLanguage = WhisperKitLanguage.resolvedCode(try? c.decode(String.self, forKey: .whisperLanguage))
         qwen3AsrLanguage = Qwen3AsrLanguage.resolvedCode(try? c.decode(String.self, forKey: .qwen3AsrLanguage))
+        parakeetLanguage = ParakeetLanguage.resolvedCode(try? c.decode(String.self, forKey: .parakeetLanguage))
         appleSpeechLanguage = AppleSpeechLanguageOption.normalize(try? c.decode(String.self, forKey: .appleSpeechLanguage))
         meetingTranscriptionBackend = (try? c.decode(String.self, forKey: .meetingTranscriptionBackend)) ?? sttBackend
         meetingTranscriptionModel = (try? c.decode(String.self, forKey: .meetingTranscriptionModel)) ?? sttModel
@@ -1804,6 +1900,10 @@ struct AppConfig: Codable {
 
     var resolvedQwen3AsrLanguage: Qwen3AsrLanguage {
         Qwen3AsrLanguage.resolved(qwen3AsrLanguage)
+    }
+
+    var resolvedParakeetLanguage: ParakeetLanguage {
+        ParakeetLanguage.resolved(parakeetLanguage)
     }
 
     var resolvedAppleSpeechLanguage: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -247,8 +247,9 @@ struct BackendOption: Equatable {
     /// Models available for download and use.
     static let all = currentCatalog.all
 
-    /// The first-run default uses the system-managed backend when the OS exposes it.
-    /// Parakeet remains the deterministic fallback for older or unsupported Macs.
+    /// The first-run default is Parakeet Unified (English), with Parakeet v3
+    /// (multilingual) as the second candidate; Apple Speech remains available
+    /// in the catalog but is not the onboarding default.
     static let onboardingDefault = currentCatalog.onboardingDefault
 
     /// Curated first-run choices. Experimental models are excluded by default.

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -600,6 +600,13 @@ struct ModelsView: View {
         )
     }
 
+    private var parakeetLanguageSelection: Binding<ParakeetLanguage> {
+        Binding(
+            get: { appState.config.resolvedParakeetLanguage },
+            set: { controller.selectParakeetLanguage($0) }
+        )
+    }
+
     private var qwen3AsrLanguageSelection: Binding<Qwen3AsrLanguage> {
         Binding(
             get: { appState.config.resolvedQwen3AsrLanguage },
@@ -860,6 +867,24 @@ struct ModelsView: View {
 
                     Picker("", selection: whisperLanguageSelection) {
                         ForEach(WhisperKitLanguage.allCases, id: \.self) { language in
+                            Text(language.label).tag(language)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: 220, alignment: .leading)
+                }
+            }
+
+            if selectedOption.backend == "fluidaudio" {
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    Text("Language")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 64, alignment: .leading)
+
+                    Picker("", selection: parakeetLanguageSelection) {
+                        ForEach(ParakeetLanguage.allCases, id: \.self) { language in
                             Text(language.label).tag(language)
                         }
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -892,6 +892,10 @@ struct ModelsView: View {
                     .pickerStyle(.menu)
                     .frame(maxWidth: 220, alignment: .leading)
                 }
+
+                Text("Script filter: keeps the chosen language's writing script in the transcript. Parakeet v3 only — v2 ignores this setting.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
             }
 
             if showsDownloadStatus {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -876,7 +876,7 @@ struct ModelsView: View {
                 }
             }
 
-            if selectedOption.backend == "fluidaudio" {
+            if selectedOption.backend == BackendOption.parakeetMultilingual.backend {
                 HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
                     Text("Language")
                         .font(MuesliTheme.caption())

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2910,6 +2910,12 @@ public final class MuesliController: NSObject {
         }
     }
 
+    func selectParakeetLanguage(_ language: ParakeetLanguage) {
+        updateConfig {
+            $0.parakeetLanguage = language.rawValue
+        }
+    }
+
     func selectIndicASRLanguage(_ language: IndicASRLanguage) {
         updateConfig {
             $0.indicASRLanguage = language.rawValue
@@ -5017,6 +5023,7 @@ public final class MuesliController: NSObject {
                     indicASRLanguage: self.config.resolvedIndicASRLanguage,
                     whisperLanguage: self.config.resolvedWhisperLanguage,
                     qwen3AsrLanguage: self.config.resolvedQwen3AsrLanguage,
+                    parakeetLanguage: self.config.resolvedParakeetLanguage,
                     appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage
                 )
                 let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -8887,6 +8894,7 @@ public final class MuesliController: NSObject {
                     indicASRLanguage: self.config.resolvedIndicASRLanguage,
                     whisperLanguage: self.config.resolvedWhisperLanguage,
                     qwen3AsrLanguage: self.config.resolvedQwen3AsrLanguage,
+                    parakeetLanguage: self.config.resolvedParakeetLanguage,
                     appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage,
                     enablePostProcessor: false,
                     customWords: self.serializedCustomWords(),
@@ -10312,6 +10320,7 @@ public final class MuesliController: NSObject {
                     indicASRLanguage: indicTranscriptionLanguage,
                     whisperLanguage: whisperTranscriptionLanguage,
                     qwen3AsrLanguage: self.config.resolvedQwen3AsrLanguage,
+                    parakeetLanguage: self.config.resolvedParakeetLanguage,
                     appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage,
                     enablePostProcessor: enableTranscriptCleanup,
                     customWords: self.serializedCustomWords(),

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8503,6 +8503,7 @@ public final class MuesliController: NSObject {
                     indicASRLanguage: configSnapshot.resolvedIndicASRLanguage,
                     whisperLanguage: configSnapshot.resolvedWhisperLanguage,
                     qwen3AsrLanguage: configSnapshot.resolvedQwen3AsrLanguage,
+                    parakeetLanguage: configSnapshot.resolvedParakeetLanguage,
                     appleSpeechLanguage: configSnapshot.resolvedAppleSpeechLanguage,
                     enablePostProcessor: false,
                     customWords: self.serializedCustomWords(),

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -91,10 +91,7 @@ struct OnboardingView: View {
     }
 
     private var onboardingModelDescription: String {
-        if BackendOption.onboardingDefault == .appleSpeechAnalyzer {
-            return "Use Apple Speech, or choose another local model to download while you continue setup."
-        }
-        return "Start with a fast local model. Larger models can download while you continue setup."
+        "Start with a fast local model. Larger models can download while you continue setup."
     }
 
     init(

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -909,6 +909,7 @@ actor TranscriptionCoordinator {
         indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
         whisperLanguage: WhisperKitLanguage = WhisperKitLanguage.defaultLanguage,
         qwen3AsrLanguage: Qwen3AsrLanguage = Qwen3AsrLanguage.defaultLanguage,
+        parakeetLanguage: ParakeetLanguage = ParakeetLanguage.defaultLanguage,
         appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier,
         enablePostProcessor: Bool = false,
         customWords: [[String: Any]] = [],
@@ -935,6 +936,7 @@ actor TranscriptionCoordinator {
             indicASRLanguage: indicASRLanguage,
             whisperLanguage: whisperLanguage,
             qwen3AsrLanguage: qwen3AsrLanguage,
+            parakeetLanguage: parakeetLanguage,
             appleSpeechLanguage: appleSpeechLanguage
         )
         result = removeArtifacts(result)
@@ -966,6 +968,7 @@ actor TranscriptionCoordinator {
         indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
         whisperLanguage: WhisperKitLanguage = WhisperKitLanguage.defaultLanguage,
         qwen3AsrLanguage: Qwen3AsrLanguage = Qwen3AsrLanguage.defaultLanguage,
+        parakeetLanguage: ParakeetLanguage = ParakeetLanguage.defaultLanguage,
         appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier
     ) async throws -> SpeechTranscriptionResult {
         // Meetings intentionally skip Qwen/custom-word post-processing. Keep deterministic artifact/filler cleanup only.
@@ -976,6 +979,7 @@ actor TranscriptionCoordinator {
             indicASRLanguage: indicASRLanguage,
             whisperLanguage: whisperLanguage,
             qwen3AsrLanguage: qwen3AsrLanguage,
+            parakeetLanguage: parakeetLanguage,
             appleSpeechLanguage: appleSpeechLanguage
         ))
     }
@@ -987,6 +991,7 @@ actor TranscriptionCoordinator {
         indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
         whisperLanguage: WhisperKitLanguage = WhisperKitLanguage.defaultLanguage,
         qwen3AsrLanguage: Qwen3AsrLanguage = Qwen3AsrLanguage.defaultLanguage,
+        parakeetLanguage: ParakeetLanguage = ParakeetLanguage.defaultLanguage,
         appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier
     ) async throws -> SpeechTranscriptionResult {
         // Meeting chunks intentionally skip Qwen/custom-word post-processing for reconciliation.
@@ -1010,6 +1015,7 @@ actor TranscriptionCoordinator {
             indicASRLanguage: indicASRLanguage,
             whisperLanguage: whisperLanguage,
             qwen3AsrLanguage: qwen3AsrLanguage,
+            parakeetLanguage: parakeetLanguage,
             appleSpeechLanguage: appleSpeechLanguage
         ))
     }
@@ -1348,6 +1354,7 @@ actor TranscriptionCoordinator {
         indicASRLanguage: IndicASRLanguage,
         whisperLanguage: WhisperKitLanguage,
         qwen3AsrLanguage: Qwen3AsrLanguage,
+        parakeetLanguage: ParakeetLanguage,
         appleSpeechLanguage: String
     ) async throws -> SpeechTranscriptionResult {
         switch backend.backend {
@@ -1379,15 +1386,15 @@ actor TranscriptionCoordinator {
             }
             throw AppleSpeechAnalyzerError.unavailable
         default:
-            return try await transcribeWithFluidAudio(url: url)
+            return try await transcribeWithFluidAudio(url: url, language: parakeetLanguage)
         }
     }
 
     // MARK: - FluidAudio (Parakeet on ANE)
 
-    private func transcribeWithFluidAudio(url: URL) async throws -> SpeechTranscriptionResult {
+    private func transcribeWithFluidAudio(url: URL, language: ParakeetLanguage) async throws -> SpeechTranscriptionResult {
         fputs("[muesli-native] transcribing with FluidAudio: \(url.lastPathComponent)\n", stderr)
-        let result = try await fluidTranscriber.transcribe(wavURL: url)
+        let result = try await fluidTranscriber.transcribe(wavURL: url, language: language.isoCode)
         fputs("[muesli-native] FluidAudio result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
         let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
         let segments = (result.tokenTimings ?? []).map { timing in

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -156,8 +156,10 @@ struct AppleSpeechAnalyzerBackendTests {
         if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
             #expect(BackendOption.systemManaged.contains(option))
             #expect(BackendOption.all.contains(option))
-            #expect(BackendOption.onboardingDefault == option)
-            #expect(BackendOption.onboarding.contains(option))
+            // Parakeet Unified is the preferred onboarding model; Apple Speech
+            // stays available in the catalog but is not the default.
+            #expect(BackendOption.onboardingDefault == .parakeetUnified)
+            #expect(!BackendOption.onboarding.contains(option))
         } else {
             #expect(!BackendOption.systemManaged.contains(option))
             #expect(!BackendOption.all.contains(option))
@@ -166,14 +168,15 @@ struct AppleSpeechAnalyzerBackendTests {
         }
     }
 
-    @Test("supported catalogue makes Apple Speech the onboarding default")
+    @Test("supported catalogue keeps Apple Speech available without making it the default")
     func supportedCatalogue() {
         let catalog = BackendOption.catalog(appleSpeechAvailable: true)
 
         #expect(catalog.systemManaged == [.appleSpeechAnalyzer])
         #expect(catalog.all.contains(.appleSpeechAnalyzer))
-        #expect(catalog.onboardingDefault == .appleSpeechAnalyzer)
-        #expect(catalog.onboarding.first == .appleSpeechAnalyzer)
+        #expect(catalog.onboardingDefault == .parakeetUnified)
+        #expect(catalog.onboarding.first == .parakeetUnified)
+        #expect(!catalog.onboarding.contains(.appleSpeechAnalyzer))
     }
 
     @Test("unsupported catalogue falls back to Parakeet")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -305,9 +305,11 @@ struct BackendOptionTests {
         #expect(!BackendOption.experimental.contains(.cohereTranscribe))
     }
 
-    @Test("onboarding defaults to Apple Speech when available and keeps conservative alternatives")
+    @Test("onboarding prefers Parakeet Unified and v3 over Apple Speech")
     func onboardingModelChoices() {
         #expect(BackendOption.onboarding.first == BackendOption.onboardingDefault)
+        #expect(BackendOption.onboardingDefault == .parakeetUnified)
+        #expect(BackendOption.onboarding.contains(.parakeetUnified))
         #expect(BackendOption.onboarding.contains(.parakeetMultilingual))
         #expect(BackendOption.onboarding.contains(.whisperTiny))
         #expect(BackendOption.onboarding.contains(.whisperSmall))
@@ -317,10 +319,8 @@ struct BackendOptionTests {
         }
         #expect(BackendOption.onboarding.contains(.nemotron35Multilingual))
         if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
-            #expect(BackendOption.onboardingDefault == .appleSpeechAnalyzer)
-            #expect(BackendOption.onboarding.contains(.appleSpeechAnalyzer))
+            #expect(!BackendOption.onboarding.contains(.appleSpeechAnalyzer))
         } else {
-            #expect(BackendOption.onboardingDefault == .parakeetUnified)
             #expect(!BackendOption.onboarding.contains(.appleSpeechAnalyzer))
         }
     }
@@ -3063,5 +3063,38 @@ struct ParakeetUnifiedPlanTests {
                 .appendingPathComponent("parakeet_unified_encoder_int8.mlmodelc/weights/weight.bin")
         )
         #expect(!plan.isAvailableLocally(fileManager: fm))
+    }
+}
+
+struct ParakeetLanguageTests {
+
+    @Test("ParakeetLanguage resolves auto and pinned ISO codes")
+    func resolvesAutoAndPinned() {
+        #expect(ParakeetLanguage.resolved(nil) == .auto)
+        #expect(ParakeetLanguage.resolved("") == .auto)
+        #expect(ParakeetLanguage.resolved("auto") == .auto)
+        #expect(ParakeetLanguage.resolved("en") == .english)
+        #expect(ParakeetLanguage.resolved("EL") == .greek)
+        #expect(ParakeetLanguage.resolved("bogus") == .auto)
+    }
+
+    @Test("ParakeetLanguage exposes labels and ISO codes")
+    func exposesLabelsAndCodes() {
+        #expect(ParakeetLanguage.auto.isoCode == nil)
+        #expect(ParakeetLanguage.auto.label == "Auto-detect")
+        #expect(ParakeetLanguage.english.isoCode == "en")
+        #expect(ParakeetLanguage.english.label == "English")
+        #expect(ParakeetLanguage.allCases.count == 29)
+    }
+
+    @Test("ParakeetLanguage selection survives config encode/decode round-trip")
+    func persistenceRoundTrip() throws {
+        var config = AppConfig()
+        config.parakeetLanguage = ParakeetLanguage.german.rawValue
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.resolvedParakeetLanguage == .german)
     }
 }


### PR DESCRIPTION
## Summary
Two related changes, one PR:

1. **Parakeet TDT v2/v3 language picker** — reuses the existing language-picker pattern (Whisper/Cohere/Indic/Qwen3): `ParakeetLanguage` (auto + 28 ISO codes), persisted via `AppConfig.parakeetLanguage`, shown on the Parakeet family card for **v2/v3 only** (hidden for English-only Parakeet Unified), and threaded through dictation/meetings into `FluidAudioTranscriber`, where the ISO code enables FluidAudio's **script-level token filter** on the v3 joint decoder (`AsrManager.transcribe(language:)`; v2 ignores the hint, nil = unfiltered).

2. **Parakeet-first onboarding** — onboarding default is now **Parakeet Unified (English)** with **v3 (multilingual)** as the second candidate, instead of Apple Speech; Apple Speech stays fully available in the catalog. Unified/v3 descriptions rewritten to be concise:
   - Unified: "The best English dictation. Lowest error rate, newest architecture, instant. For other languages, choose Parakeet v3."
   - v3: "Fast, reliable dictation in 25 languages."

## Details
- `ParakeetLanguage`: `String`-raw, CaseIterable, Codable — mirrors the existing language enums; `resolved`/`resolvedCode` with `auto` → nil ISO at the decode boundary.
- AppConfig: `parakeet_language` CodingKey + decode + `resolvedParakeetLanguage` (persists across restarts).
- `FluidAudioBackend.transcribe(wavURL:language:)` → `AsrManager.transcribe(url, decoderState:language:)` with `FluidAudio.Language(rawValue:)`.
- Models tab: Language picker on the Parakeet family card (v2/v3), same UI as the other backends.
- Tests: resolver/label/ISO coverage, config round-trip, onboarding + Apple-Speech catalogue expectations updated.

## Validation
- `swift build` clean · full suite **1,912 tests / 171 suites passed**
- DevB lane built/installed/launched (stable signing identity, reused scratch cache)

## Notes
- Unified is English-only by design — no language picker for it.
- FluidAudio's language hint is a script filter (Latin/Cyrillic/Greek), not per-language acoustic conditioning; it primarily prevents wrong-script bleed on multilingual v3 audio.
- Draft: bot reviews + CI pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790423791&installation_model_id=422865&pr_number=486&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F486&signature=fc41c1cc34cb4853ad12a7abe5f42aac069761cbf90e7976bf22e02944633aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added language selection for Parakeet transcription in settings.
  - Selected language is applied across dictation, meetings, re-transcription, audio imports, and voice commands.
  - Parakeet Unified is now the default onboarding transcription option; Apple Speech remains available.
  - Improved transcription backend descriptions for clearer model selection.

- **Bug Fixes**
  - Preserves automatic language detection when no language is selected.

- **Tests**
  - Added coverage for language selection, persistence, supported languages, and onboarding defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->