### PR TITLE
Add OpenRouter OAuth dictation transcription

### DIFF
--- a/Context/handoff-2026-08-28-openrouter-asr-dictation.md
+++ b/Context/handoff-2026-08-28-openrouter-asr-dictation.md
@@ -23,12 +23,18 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 
 ## Verification
 
-- Focused OpenRouter dictation suite: 14 tests passed.
+- Focused OpenRouter dictation suite: 15 tests passed.
 - OpenRouter OAuth suite: 11 tests passed.
 - Provider/config suite: 6 tests passed.
-- Full native suite: 1,936 tests across 173 suites passed.
+- Full native suite: 1,937 tests across 173 suites passed.
 - Changed-file classification, CI shard assignment, update-flow verification with DMG skipped, and `git diff --check` passed.
 - Dev lane B was rebuilt through the canonical shared SwiftPM cache, installed with bundle ID `com.muesli.dev.b`, and launched. Both the source and installed LocalVQE runtimes passed completeness validation.
+- Three consecutive Dev B dictations using `fish-audio/transcribe-1` completed through OpenRouter with HTTP 200 responses; no local fallback ran.
+
+## Review follow-up
+
+- OpenRouter disconnect now moves dictation to Local and immediately starts preparing the selected local backend while retaining the OpenRouter model for reconnection.
+- Standard dictation finalization retains its task and detached hosted session until completion. Cancelling during transcription now cancels the OpenRouter upload, and stale cancellation completion cannot reset a newer dictation.
 
 ## Deferred scope
 

--- a/Context/handoff-2026-08-28-openrouter-asr-dictation.md
+++ b/Context/handoff-2026-08-28-openrouter-asr-dictation.md
@@ -18,15 +18,15 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 - Provider and model values are snapshotted in the in-flight hosted session, so settings changes cannot reroute a transcription already being finalized.
 - OpenRouter text-summary and transcription catalogs use separate shared caches. The STT catalog is discovered through `output_modalities=transcription`, retains the configured custom ID, and exposes retry after failures.
 - Settings reuse the existing OpenRouter account control and add explicit STT model/custom model selection plus the generalized hosted fallback row. The status menu exposes dynamic OpenRouter models and applies provider plus model atomically.
-- Disconnecting an actively selected OpenRouter dictation account returns dictation to Local while retaining the chosen OpenRouter model.
+- Disconnecting an actively selected OpenRouter dictation account cancels live or finalizing OpenRouter work, returns dictation to Local, and retains the chosen OpenRouter model.
 - README, privacy, and terms describe optional OpenAI/OpenRouter dictation and the OpenRouter upstream data path while preserving local-by-default language.
 
 ## Verification
 
-- Focused OpenRouter dictation suite: 15 tests passed.
+- Focused OpenRouter dictation suite: 16 tests passed.
 - OpenRouter OAuth suite: 11 tests passed.
 - Provider/config suite: 6 tests passed.
-- Full native suite: 1,937 tests across 173 suites passed.
+- Full native suite: 1,938 tests across 173 suites passed.
 - Changed-file classification, CI shard assignment, update-flow verification with DMG skipped, and `git diff --check` passed.
 - Dev lane B was rebuilt through the canonical shared SwiftPM cache, installed with bundle ID `com.muesli.dev.b`, and launched. Both the source and installed LocalVQE runtimes passed completeness validation.
 - Three consecutive Dev B dictations using `fish-audio/transcribe-1` completed through OpenRouter with HTTP 200 responses; no local fallback ran.
@@ -35,6 +35,7 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 
 - OpenRouter disconnect now moves dictation to Local and immediately starts preparing the selected local backend while retaining the OpenRouter model for reconnection.
 - Standard dictation finalization retains its task and detached hosted session until completion. Cancelling during transcription now cancels the OpenRouter upload, and stale cancellation completion cannot reset a newer dictation.
+- Disconnect is treated as withdrawal of permission to send audio: it cancels both an active OpenRouter recording session and any upload already finalizing from a credential snapshot. Cancelled or stale work is also barred from starting local fallback.
 
 ## Deferred scope
 

--- a/Context/handoff-2026-08-28-openrouter-asr-dictation.md
+++ b/Context/handoff-2026-08-28-openrouter-asr-dictation.md
@@ -19,7 +19,7 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 - OpenRouter text-summary and transcription catalogs use separate shared caches. The STT catalog is discovered through `output_modalities=transcription`, retains the configured custom ID, and exposes retry after failures.
 - Settings reuse the existing OpenRouter account control and add explicit STT model/custom model selection plus the generalized hosted fallback row. The status menu exposes dynamic OpenRouter models and applies provider plus model atomically.
 - Hosted model selectors are credential-gated in both Settings and the status menu. With no hosted credentials only Local models are listed; an OpenAI key exposes only OpenAI presets, and an authenticated OpenRouter account exposes only its discovered/custom choices. OpenRouter catalog loading is also suppressed and cleared while unauthenticated.
-- Disconnecting an actively selected OpenRouter dictation account cancels live or finalizing OpenRouter work, returns dictation to Local, and retains the chosen OpenRouter model.
+- Disconnecting an actively selected OpenRouter account returns future dictations to Local and retains the chosen OpenRouter model. A dictation that already began through OpenRouter keeps its snapshotted provider, model, and credential and is allowed to finish, matching ordinary mid-dictation provider changes.
 - README, privacy, and terms describe optional OpenAI/OpenRouter dictation and the OpenRouter upstream data path while preserving local-by-default language.
 
 ## Verification
@@ -37,7 +37,7 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 
 - OpenRouter disconnect now moves dictation to Local and immediately starts preparing the selected local backend while retaining the OpenRouter model for reconnection.
 - Standard dictation finalization retains its task and detached hosted session until completion. Cancelling during transcription now cancels the OpenRouter upload, and stale cancellation completion cannot reset a newer dictation.
-- Disconnect is treated as withdrawal of permission to send audio: it cancels both an active OpenRouter recording session and any upload already finalizing from a credential snapshot. Cancelled or stale work is also barred from starting local fallback.
+- Provider changes and account disconnects apply to the next dictation. An active dictation keeps the provider, model, and credential selected when it began; the explicit dictation Cancel action still cancels its upload, and cancelled or stale work is barred from starting local fallback.
 
 ## Deferred scope
 

--- a/Context/handoff-2026-08-28-openrouter-asr-dictation.md
+++ b/Context/handoff-2026-08-28-openrouter-asr-dictation.md
@@ -19,6 +19,8 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 - OpenRouter text-summary and transcription catalogs use separate shared caches. The STT catalog is discovered through `output_modalities=transcription`, retains the configured custom ID, and exposes retry after failures.
 - Settings reuse the existing OpenRouter account control and add explicit STT model/custom model selection plus the generalized hosted fallback row. The status menu exposes dynamic OpenRouter models and applies provider plus model atomically.
 - Hosted model selectors are credential-gated in both Settings and the status menu. With no hosted credentials only Local models are listed; an OpenAI key exposes only OpenAI presets, and an authenticated OpenRouter account exposes only its discovered/custom choices. OpenRouter catalog loading is also suppressed and cleared while unauthenticated.
+- OpenRouter model visibility uses the same environment, protected-store, and legacy credential resolution as actual transcription, so a recoverable legacy credential cannot leave working dictation hidden from the UI.
+- Transcription catalog loads carry a generation token. A cancelled request from before disconnect cannot clear or overwrite a newer reconnect/reload, while normal catalogs remain cached once per app process with no periodic refresh.
 - Disconnecting an actively selected OpenRouter account returns future dictations to Local and retains the chosen OpenRouter model. A dictation that already began through OpenRouter keeps its snapshotted provider, model, and credential and is allowed to finish, matching ordinary mid-dictation provider changes.
 - README, privacy, and terms describe optional OpenAI/OpenRouter dictation and the OpenRouter upstream data path while preserving local-by-default language.
 
@@ -28,7 +30,7 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 - Focused hosted-provider visibility and catalog checks: 26 tests passed.
 - OpenRouter OAuth suite: 11 tests passed.
 - Provider/config suite: 6 tests passed.
-- Full native suite: 1,941 tests across 173 suites passed.
+- Full native suite: 1,943 tests across 173 suites passed.
 - Changed-file classification, CI shard assignment, update-flow verification with DMG skipped, and `git diff --check` passed.
 - Dev lane B was rebuilt through the canonical shared SwiftPM cache, installed with bundle ID `com.muesli.dev.b`, and launched. Both the source and installed LocalVQE runtimes passed completeness validation.
 - Three consecutive Dev B dictations using `fish-audio/transcribe-1` completed through OpenRouter with HTTP 200 responses; no local fallback ran.

--- a/Context/handoff-2026-08-28-openrouter-asr-dictation.md
+++ b/Context/handoff-2026-08-28-openrouter-asr-dictation.md
@@ -1,0 +1,36 @@
+# OpenRouter ASR dictation handoff (2026-08-28)
+
+## Objective
+
+Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local by default and leaving meeting transcription unchanged.
+
+## Transport decision
+
+- OpenRouter documents `POST /api/v1/audio/transcriptions` with base64 audio and a 60-second upstream timeout, but no realtime STT WebSocket. This implementation therefore uploads the completed WAV after recording stops and uses a 65-second client timeout.
+- Hosted dictation now routes through a shared session seam. OpenAI wraps its existing Realtime WebSocket; OpenRouter snapshots its credential and selected model and finalizes from the recorded WAV. A future documented streaming transport can replace the OpenRouter session without changing controller or menu routing.
+
+## Implementation
+
+- `DictationProvider` includes OpenRouter and persists a separate, empty-by-default `open_router_dictation_model`, requiring explicit model selection.
+- OpenRouter authentication reuses the shared credential resolver with environment, protected OAuth/manual, and legacy precedence.
+- The transcription client sends the selected model and raw base64 WAV, uses the existing OpenRouter app identity header, sanitizes provider errors, supports injected networking, and propagates cancellation.
+- Missing authentication or model selection blocks before microphone capture. Successful hosted output bypasses cleanup. Non-cancellation failures fall back to an installed non-streaming local backend; cancellation never triggers fallback.
+- Provider and model values are snapshotted in the in-flight hosted session, so settings changes cannot reroute a transcription already being finalized.
+- OpenRouter text-summary and transcription catalogs use separate shared caches. The STT catalog is discovered through `output_modalities=transcription`, retains the configured custom ID, and exposes retry after failures.
+- Settings reuse the existing OpenRouter account control and add explicit STT model/custom model selection plus the generalized hosted fallback row. The status menu exposes dynamic OpenRouter models and applies provider plus model atomically.
+- Disconnecting an actively selected OpenRouter dictation account returns dictation to Local while retaining the chosen OpenRouter model.
+- README, privacy, and terms describe optional OpenAI/OpenRouter dictation and the OpenRouter upstream data path while preserving local-by-default language.
+
+## Verification
+
+- Focused OpenRouter dictation suite: 14 tests passed.
+- OpenRouter OAuth suite: 11 tests passed.
+- Provider/config suite: 6 tests passed.
+- Full native suite: 1,936 tests across 173 suites passed.
+- Changed-file classification, CI shard assignment, update-flow verification with DMG skipped, and `git diff --check` passed.
+- Dev lane B was rebuilt through the canonical shared SwiftPM cache, installed with bundle ID `com.muesli.dev.b`, and launched. Both the source and installed LocalVQE runtimes passed completeness validation.
+
+## Deferred scope
+
+- A realtime OpenRouter transport remains deferred until OpenRouter documents a WebSocket STT API.
+- Audio splitting, provider-specific language/options, usage/cost UI, and synthetic paid connection tests remain out of scope.

--- a/Context/handoff-2026-08-28-openrouter-asr-dictation.md
+++ b/Context/handoff-2026-08-28-openrouter-asr-dictation.md
@@ -18,15 +18,17 @@ Add OpenRouter as an opt-in hosted dictation provider while keeping Muesli local
 - Provider and model values are snapshotted in the in-flight hosted session, so settings changes cannot reroute a transcription already being finalized.
 - OpenRouter text-summary and transcription catalogs use separate shared caches. The STT catalog is discovered through `output_modalities=transcription`, retains the configured custom ID, and exposes retry after failures.
 - Settings reuse the existing OpenRouter account control and add explicit STT model/custom model selection plus the generalized hosted fallback row. The status menu exposes dynamic OpenRouter models and applies provider plus model atomically.
+- Hosted model selectors are credential-gated in both Settings and the status menu. With no hosted credentials only Local models are listed; an OpenAI key exposes only OpenAI presets, and an authenticated OpenRouter account exposes only its discovered/custom choices. OpenRouter catalog loading is also suppressed and cleared while unauthenticated.
 - Disconnecting an actively selected OpenRouter dictation account cancels live or finalizing OpenRouter work, returns dictation to Local, and retains the chosen OpenRouter model.
 - README, privacy, and terms describe optional OpenAI/OpenRouter dictation and the OpenRouter upstream data path while preserving local-by-default language.
 
 ## Verification
 
 - Focused OpenRouter dictation suite: 16 tests passed.
+- Focused hosted-provider visibility and catalog checks: 26 tests passed.
 - OpenRouter OAuth suite: 11 tests passed.
 - Provider/config suite: 6 tests passed.
-- Full native suite: 1,938 tests across 173 suites passed.
+- Full native suite: 1,941 tests across 173 suites passed.
 - Changed-file classification, CI shard assignment, update-flow verification with DMG skipped, and `git diff --check` passed.
 - Dev lane B was rebuilt through the canonical shared SwiftPM cache, installed with bundle ID `com.muesli.dev.b`, and launched. Both the source and installed LocalVQE runtimes passed completeness validation.
 - Three consecutive Dev B dictations using `fish-audio/transcribe-1` completed through OpenRouter with HTTP 200 responses; no local fallback ran.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <strong>Local-by-default dictation & meeting transcription for macOS</strong><br>
-  On-device speech-to-text by default · Optional OpenAI BYOK dictation · Privacy by default
+  On-device speech-to-text by default · Optional OpenAI or OpenRouter dictation · Privacy by default
 </p>
 
 <p align="center">
@@ -24,7 +24,7 @@
 
 ## What is Muesli?
 
-Muesli is a **lightweight native macOS app** that combines **WisprFlow-style dictation** and **Granola-style meeting transcription** in one tool. Dictation and meeting transcription run locally on Apple Silicon by default. Audio leaves your device only when you explicitly select the optional OpenAI BYOK dictation provider; cloud-backed cleanup and meeting-summary providers can also receive the text you choose to send them.
+Muesli is a **lightweight native macOS app** that combines **WisprFlow-style dictation** and **Granola-style meeting transcription** in one tool. Dictation and meeting transcription run locally on Apple Silicon by default. Audio leaves your device only when you explicitly select an optional hosted dictation provider such as OpenAI or OpenRouter; cloud-backed cleanup and meeting-summary providers can also receive the text you choose to send them.
 
 <p align="center">
   <img src="assets/muesli-github-ss.png" alt="Muesli interface showing dictations and meeting history" width="900" />
@@ -33,7 +33,7 @@ Muesli is a **lightweight native macOS app** that combines **WisprFlow-style dic
 ### Dictation
 Hold your hotkey (or double-tap for hands-free mode) → speak → release → transcribed text is pasted at your cursor. **~0.13 second latency** via Parakeet TDT on the Apple Neural Engine.
 
-By default, dictation uses an on-device model. You can instead opt into OpenAI Speech-to-Text with your own API key; in that mode, microphone audio is streamed directly to OpenAI over a Realtime WebSocket for transcription. Muesli retains the local recording only long enough to fall back to a compatible installed on-device model if the hosted request fails; streaming-only models are excluded from fallback.
+By default, dictation uses an on-device model. You can instead opt into OpenAI Speech-to-Text with your own API key, which streams microphone audio directly to OpenAI over a Realtime WebSocket, or connect OpenRouter and explicitly choose a transcription model. OpenRouter dictation sends the completed recording through OpenRouter to the selected upstream model. Muesli retains the local recording only long enough to fall back to a compatible installed on-device model if the hosted request fails; streaming-only models are excluded from fallback.
 
 ### Meeting Transcription
 Start a meeting recording → Muesli captures your mic (You) and system audio (Others) simultaneously → VAD-driven chunked transcription happens during the meeting at natural speech boundaries → speaker diarization identifies individual remote speakers (Speaker 1, Speaker 2, etc.) → when you stop, the transcript is ready in seconds, not minutes. Generate structured meeting notes via OpenAI, free OpenRouter models, your ChatGPT Plus/Pro subscription, or local Ollama models.

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -116,19 +116,19 @@
   <a href="./" class="back">&larr; freedspeech.xyz</a>
 
   <h1>Privacy Policy</h1>
-  <p class="updated">Last updated: August 25, 2026</p>
+  <p class="updated">Last updated: August 28, 2026</p>
 
   <div class="highlight">
-    <p><strong>Muesli is local-first.</strong> By default, speech-to-text processing runs on your Mac and audio never leaves your device. If you explicitly select the optional OpenAI dictation provider, Muesli sends that dictation audio directly to OpenAI for transcription. We do not operate servers that receive, store, or process your data.</p>
+    <p><strong>Muesli is local-first.</strong> By default, speech-to-text processing runs on your Mac and audio never leaves your device. If you explicitly select an optional hosted dictation provider, Muesli sends that dictation audio to OpenAI or through OpenRouter to your selected upstream model for transcription. We do not operate servers that receive, store, or process your data.</p>
   </div>
 
   <h2>What Muesli Does</h2>
-  <p>Muesli is a macOS application for dictation and meeting transcription. It uses on-device machine learning models (CoreML / Apple Neural Engine) to convert speech to text entirely on your Mac by default. An optional OpenAI dictation provider is available when you choose to use your own OpenAI API key.</p>
+  <p>Muesli is a macOS application for dictation and meeting transcription. It uses on-device machine learning models (CoreML / Apple Neural Engine) to convert speech to text entirely on your Mac by default. Optional OpenAI and OpenRouter dictation providers are available only when you choose and configure them.</p>
 
   <h2>Data That Stays on Your Device</h2>
   <p>The following data is created and stored locally on your Mac. It is not transmitted to any external server unless you explicitly enable an optional cloud service described below:</p>
   <ul>
-    <li><strong>Audio recordings</strong> &mdash; microphone and system audio captured during dictation and meetings; microphone audio is streamed directly to OpenAI only while the optional OpenAI dictation provider is selected</li>
+    <li><strong>Audio recordings</strong> &mdash; microphone and system audio captured during dictation and meetings; dictation audio is sent to a hosted service only while you have explicitly selected OpenAI or OpenRouter as the dictation provider</li>
     <li><strong>Transcripts and meeting notes</strong> &mdash; stored in a local SQLite database</li>
     <li><strong>Configuration and preferences</strong> &mdash; stored in a local JSON file</li>
     <li><strong>Speech-to-text models</strong> &mdash; downloaded once from public model repositories (HuggingFace) and cached locally</li>
@@ -138,6 +138,7 @@
   <p>Muesli offers optional integrations that connect to external services. These are opt-in and require explicit user action:</p>
   <ul>
     <li><strong>OpenAI dictation (OpenAI API)</strong> &mdash; if you select OpenAI as your dictation provider and add your own API key, microphone audio is streamed directly to OpenAI's Realtime transcription API. OpenAI's API data controls explain how API data is used, retained, and excluded from model training by default; see <a href="https://platform.openai.com/docs/models/default-usage-policies-by-endpoint">OpenAI's API data-controls documentation</a> for the current retention and data-sharing settings.</li>
+    <li><strong>OpenRouter dictation</strong> &mdash; if you select OpenRouter as your dictation provider, connect an account or key, and choose a transcription model, the completed dictation recording is sent through OpenRouter to that selected upstream model. Processing is governed by OpenRouter's and the selected model provider's policies.</li>
     <li><strong>Meeting summarization (OpenAI API / OpenRouter)</strong> &mdash; if configured, meeting transcripts are sent to the selected API provider to generate summaries. This is governed by the respective provider's privacy policy.</li>
     <li><strong>Meeting summarization (ChatGPT subscription)</strong> &mdash; if you sign in with your ChatGPT account, transcripts are sent to OpenAI's API for summarization using your existing subscription.</li>
     <li><strong>Sparkle update checks</strong> &mdash; Muesli checks for new versions via an appcast feed hosted on GitHub. No personal data is transmitted.</li>
@@ -167,7 +168,7 @@
   <p>Muesli uses <a href="https://telemetrydeck.com">TelemetryDeck</a> to collect minimal, anonymized usage signals (e.g., which features are used and app launch counts). When Muesli detects a hard failure, it may also send an allowlisted diagnostic category, workflow stage, selected on-device transcription backend/model, app version and build, operating system and device model, and a random incident ID. These diagnostics never include raw error messages, audio, transcripts, meeting or calendar titles, clipboard or screen contents, API keys, auth tokens, local file paths, raw logs, database contents, or other personal content. TelemetryDeck does not store IP addresses, and identifiers used for anonymous user and session counts cannot be traced back to a person. You can learn more about TelemetryDeck's privacy practices on their <a href="https://telemetrydeck.com/privacy">privacy page</a>.</p>
 
   <h2>No Personal Data Collection</h2>
-  <p><strong>Muesli does not collect, transmit, or store personal data on external servers that we operate.</strong> Apart from the anonymous usage signals described above, data remains on your device unless you choose an optional cloud provider such as OpenAI dictation, hosted cleanup or meeting summaries, or Google Calendar sync. The application remains functional without an internet connection when you use its local features.</p>
+  <p><strong>Muesli does not collect, transmit, or store personal data on external servers that we operate.</strong> Apart from the anonymous usage signals described above, data remains on your device unless you choose an optional cloud provider such as OpenAI or OpenRouter dictation, hosted cleanup or meeting summaries, or Google Calendar sync. The application remains functional without an internet connection when you use its local features.</p>
 
   <h2>Open Source</h2>
   <p>Muesli's source code is publicly available on <a href="https://github.com/Muesli-HQ/muesli">GitHub</a> under the MIT license. You can inspect exactly what the application does with your data.</p>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -116,7 +116,7 @@
   <a href="./" class="back">&larr; freedspeech.xyz</a>
 
   <h1>Terms of Service</h1>
-  <p class="updated">Last updated: August 25, 2026</p>
+  <p class="updated">Last updated: August 28, 2026</p>
 
   <div class="highlight">
     <p><strong>Muesli is free, open-source software.</strong> You may use, modify, and distribute it under the MIT license. These terms cover your use of the application and optional connected services.</p>
@@ -126,7 +126,7 @@
   <p>By downloading, installing, or using Muesli, you agree to these Terms of Service. If you do not agree, do not use the application.</p>
 
   <h2>Description of Service</h2>
-  <p>Muesli is a macOS application for on-device dictation and meeting transcription. It uses local machine learning models to convert speech to text entirely on your Mac by default. Muesli also offers optional integrations with third-party services (OpenAI, OpenRouter, ChatGPT, Google Calendar) that you may choose to enable. When you select the optional OpenAI dictation provider, your microphone audio is streamed directly to OpenAI for transcription using your own API key.</p>
+  <p>Muesli is a macOS application for on-device dictation and meeting transcription. It uses local machine learning models to convert speech to text entirely on your Mac by default. Muesli also offers optional integrations with third-party services (OpenAI, OpenRouter, ChatGPT, Google Calendar) that you may choose to enable. When you select OpenAI dictation, microphone audio is streamed directly to OpenAI using your own API key. When you select OpenRouter dictation, the completed recording is sent through OpenRouter to the upstream transcription model you selected.</p>
 
   <h2>License</h2>
   <p>Muesli is distributed under the <a href="https://opensource.org/licenses/MIT">MIT License</a>. The full source code is available on <a href="https://github.com/Muesli-HQ/muesli">GitHub</a>. You are free to use, copy, modify, merge, publish, distribute, sublicense, and sell copies of the software, subject to the conditions of the MIT License.</p>

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -147,6 +147,13 @@ struct ActiveMeetingAudioWarning: Equatable {
     let message: String
 }
 
+enum OpenRouterModelCatalogLoadState: Equatable {
+    case idle
+    case loading
+    case loaded
+    case failed(String)
+}
+
 @MainActor
 @Observable
 final class AppState {
@@ -203,6 +210,10 @@ final class AppState {
     var isOpenRouterAuthenticated: Bool = false
     var isOpenRouterEnvironmentManaged: Bool = false
     var hasStoredOpenRouterCredential: Bool = false
+    var openRouterSummaryModels: [SummaryModelPreset] = []
+    var openRouterSummaryCatalogState: OpenRouterModelCatalogLoadState = .idle
+    var openRouterTranscriptionModels: [SummaryModelPreset] = []
+    var openRouterTranscriptionCatalogState: OpenRouterModelCatalogLoadState = .idle
     var isGoogleCalendarAvailable: Bool = false
     var isGoogleCalendarVerified: Bool = false
     var isGoogleCalendarAuthenticated: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationProvider.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationProvider.swift
@@ -1,12 +1,13 @@
 import Foundation
 
 /// Selects which transcription engine handles dictation. Local models run on
-/// device via CoreML; OpenAI runs the user's own API key through the OpenAI
-/// Realtime transcription WebSocket. The local model selection (`sttBackend` /
-/// `sttModel`) is preserved so users can switch back and fall back at any time.
+/// device via CoreML; hosted providers use the user's own provider credential.
+/// The local model selection (`sttBackend` / `sttModel`) is preserved so users
+/// can switch back and fall back at any time.
 enum DictationProvider: String, CaseIterable, Codable, Sendable {
     case local
     case openAI
+    case openRouter
 
     static let defaultProvider: Self = .local
 
@@ -16,8 +17,12 @@ enum DictationProvider: String, CaseIterable, Codable, Sendable {
             return "Local"
         case .openAI:
             return "OpenAI"
+        case .openRouter:
+            return "OpenRouter"
         }
     }
+
+    var isHosted: Bool { self != .local }
 
     static func resolved(_ rawValue: String?) -> Self {
         guard let rawValue, let provider = Self(rawValue: rawValue) else {
@@ -31,5 +36,12 @@ enum DictationProvider: String, CaseIterable, Codable, Sendable {
     /// lifecycle and final paste behavior.
     func usesStreamingBackend(_ backend: BackendOption) -> Bool {
         self == .local && backend.isStreamingDictationBackend
+    }
+}
+
+enum OpenRouterDictationModelSelection {
+    static func applyStatusMenuSelection(_ model: String, to config: inout AppConfig) {
+        config.dictationProvider = DictationProvider.openRouter.rawValue
+        config.openRouterDictationModel = OpenRouterTranscriptionClient.normalizedModel(model)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationProvider.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationProvider.swift
@@ -51,13 +51,13 @@ struct HostedDictationModelVisibility: Equatable {
 
     static func resolve(
         openAIAPIKey: String,
-        isOpenRouterAuthenticated: Bool
+        openRouterAPIKey: String
     ) -> Self {
         var providers: [DictationProvider] = []
         if !openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             providers.append(.openAI)
         }
-        if isOpenRouterAuthenticated {
+        if !openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             providers.append(.openRouter)
         }
         return Self(visibleProviders: providers)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationProvider.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationProvider.swift
@@ -45,3 +45,25 @@ enum OpenRouterDictationModelSelection {
         config.openRouterDictationModel = OpenRouterTranscriptionClient.normalizedModel(model)
     }
 }
+
+struct HostedDictationModelVisibility: Equatable {
+    let visibleProviders: [DictationProvider]
+
+    static func resolve(
+        openAIAPIKey: String,
+        isOpenRouterAuthenticated: Bool
+    ) -> Self {
+        var providers: [DictationProvider] = []
+        if !openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            providers.append(.openAI)
+        }
+        if isOpenRouterAuthenticated {
+            providers.append(.openRouter)
+        }
+        return Self(visibleProviders: providers)
+    }
+
+    func shows(_ provider: DictationProvider) -> Bool {
+        visibleProviders.contains(provider)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/HostedDictationSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HostedDictationSession.swift
@@ -73,7 +73,12 @@ final class OpenRouterHostedDictationSession: HostedDictationSession, @unchecked
 }
 
 enum HostedDictationFallbackPolicy {
-    static func shouldFallback(after error: Error) -> Bool {
+    static func shouldFallback(
+        after error: Error,
+        taskIsCancelled: Bool = false,
+        isCurrentSession: Bool = true
+    ) -> Bool {
+        guard !taskIsCancelled, isCurrentSession else { return false }
         if error is CancellationError { return false }
         if let urlError = error as? URLError, urlError.code == .cancelled { return false }
         return true

--- a/native/MuesliNative/Sources/MuesliNativeApp/HostedDictationSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HostedDictationSession.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+struct HostedDictationResult: Equatable, Sendable {
+    let text: String
+    let backend: String
+}
+
+protocol HostedDictationSession: AnyObject {
+    var acceptsLiveAudio: Bool { get }
+    func append(_ samples: [Float])
+    func finish(recordedWAVURL: URL) async throws -> HostedDictationResult
+    func cancel()
+}
+
+final class OpenAIHostedDictationSession: HostedDictationSession {
+    private let stream: OpenAIRealtimeDictationStream
+
+    let acceptsLiveAudio = true
+
+    init(configuration: OpenAIDictationConfiguration) {
+        stream = OpenAIRealtimeDictationStream(configuration: configuration)
+    }
+
+    func append(_ samples: [Float]) {
+        stream.append(samples)
+    }
+
+    func finish(recordedWAVURL _: URL) async throws -> HostedDictationResult {
+        HostedDictationResult(text: try await stream.finish(), backend: "openai-realtime")
+    }
+
+    func cancel() {
+        stream.cancel()
+    }
+}
+
+final class OpenRouterHostedDictationSession: HostedDictationSession, @unchecked Sendable {
+    private let configuration: OpenRouterDictationConfiguration
+    private let client: OpenRouterTranscriptionClient
+    private let lock = NSLock()
+    private var task: Task<OpenRouterTranscriptionResult, Error>?
+    private var cancelled = false
+
+    let acceptsLiveAudio = false
+
+    init(
+        configuration: OpenRouterDictationConfiguration,
+        client: OpenRouterTranscriptionClient = OpenRouterTranscriptionClient()
+    ) {
+        self.configuration = configuration
+        self.client = client
+    }
+
+    func append(_: [Float]) {}
+
+    func finish(recordedWAVURL: URL) async throws -> HostedDictationResult {
+        let task = Task { try await client.transcribe(wavURL: recordedWAVURL, configuration: configuration) }
+        lock.withLock {
+            self.task = task
+            if cancelled { task.cancel() }
+        }
+        defer { lock.withLock { self.task = nil } }
+        let result = try await task.value
+        return HostedDictationResult(text: result.text, backend: "openrouter-stt")
+    }
+
+    func cancel() {
+        lock.withLock {
+            cancelled = true
+            task?.cancel()
+        }
+    }
+}
+
+enum HostedDictationFallbackPolicy {
+    static func shouldFallback(after error: Error) -> Bool {
+        if error is CancellationError { return false }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return false }
+        return true
+    }
+}
+
+enum HostedDictationActivationPolicy {
+    static func blockingMessage(
+        provider: DictationProvider,
+        openAIAPIKey: String,
+        openRouterAPIKey: String,
+        openRouterModel: String
+    ) -> String? {
+        switch provider {
+        case .local:
+            return nil
+        case .openAI:
+            return openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "OpenAI API key not configured. Add one in Settings → Dictation."
+                : nil
+        case .openRouter:
+            if openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "OpenRouter is not connected. Connect it in Settings → Dictation."
+            }
+            return OpenRouterTranscriptionClient.normalizedModel(openRouterModel).isEmpty
+                ? "Choose an OpenRouter transcription model in Settings → Dictation."
+                : nil
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -278,15 +278,15 @@ struct BackendOption: Equatable {
         Self.streaming.contains(self)
     }
 
-    var supportsOpenAIFallback: Bool {
+    var supportsHostedDictationFallback: Bool {
         !isStreamingDictationBackend
     }
 
-    static func resolveOpenAIFallback(
+    static func resolveHostedDictationFallback(
         selected: BackendOption,
         available: [BackendOption]
     ) -> BackendOption? {
-        let compatible = available.filter(\.supportsOpenAIFallback)
+        let compatible = available.filter(\.supportsHostedDictationFallback)
         return compatible.contains(selected) ? selected : compatible.first
     }
 
@@ -760,6 +760,17 @@ enum OpenRouterModelSelection {
     static func persistedModelID(for selectedID: String) -> String {
         selectedID.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    static func presetsIncludingConfiguredModel(
+        _ presets: [SummaryModelPreset],
+        configuredModel: String
+    ) -> [SummaryModelPreset] {
+        let model = persistedModelID(for: configuredModel)
+        guard !model.isEmpty, !presets.contains(where: { $0.id == model }) else {
+            return presets
+        }
+        return presets + [SummaryModelPreset(id: model, label: "Custom: \(model)")]
+    }
 }
 
 struct OpenRouterModel: Decodable {
@@ -816,12 +827,18 @@ extension OpenRouterModel {
         return outputModalities == ["text"]
     }
 
+    var producesTranscription: Bool {
+        architecture?.outputModalities?.contains("transcription") == true
+    }
+
     var summaryPresetLabel: String {
         if let contextLength, contextLength > 0 {
             return "\(name) (\(Self.formatContextLength(contextLength)) ctx)"
         }
         return name
     }
+
+    var transcriptionPresetLabel: String { name }
 
     private static func formatContextLength(_ value: Int) -> String {
         if value >= 1000 {
@@ -848,6 +865,18 @@ enum OpenRouterModelCatalogFilter {
                 return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
             }
             .map { SummaryModelPreset(id: $0.id, label: $0.summaryPresetLabel) }
+    }
+
+    static func transcriptionPresets(from models: [OpenRouterModel]) -> [SummaryModelPreset] {
+        models
+            .filter(\.producesTranscription)
+            .sorted {
+                if $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedSame {
+                    return $0.id < $1.id
+                }
+                return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            .map { SummaryModelPreset(id: $0.id, label: $0.transcriptionPresetLabel) }
     }
 }
 
@@ -1425,6 +1454,7 @@ struct AppConfig: Codable {
     var sttModel: String = BackendOption.parakeetUnified.model
     var dictationProvider: String = DictationProvider.defaultProvider.rawValue
     var openaiDictationModel: String = OpenAITranscriptionClient.defaultModel
+    var openRouterDictationModel: String = ""
     var dictationInputDeviceUID: String? = nil
     var meetingInputDeviceUID: String? = nil
     var cohereLanguage: String = CohereTranscribeLanguage.defaultLanguage.rawValue
@@ -1562,6 +1592,7 @@ struct AppConfig: Codable {
         case sttModel = "stt_model"
         case dictationProvider = "dictation_provider"
         case openaiDictationModel = "openai_dictation_model"
+        case openRouterDictationModel = "openrouter_dictation_model"
         case dictationInputDeviceUID = "dictation_input_device_uid"
         case meetingInputDeviceUID = "meeting_input_device_uid"
         case cohereLanguage = "cohere_language"
@@ -1705,6 +1736,8 @@ struct AppConfig: Codable {
         sttModel = (try? c.decode(String.self, forKey: .sttModel)) ?? defaults.sttModel
         dictationProvider = DictationProvider.resolved(try? c.decode(String.self, forKey: .dictationProvider)).rawValue
         openaiDictationModel = (try? c.decode(String.self, forKey: .openaiDictationModel)) ?? defaults.openaiDictationModel
+        openRouterDictationModel = (try? c.decode(String.self, forKey: .openRouterDictationModel))
+            ?? defaults.openRouterDictationModel
         dictationInputDeviceUID = try? c.decode(String.self, forKey: .dictationInputDeviceUID)
         meetingInputDeviceUID = try? c.decode(String.self, forKey: .meetingInputDeviceUID)
         cohereLanguage = CohereTranscribeLanguage.resolvedCode(try? c.decode(String.self, forKey: .cohereLanguage))

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3453,6 +3453,11 @@ public final class MuesliController: NSObject {
             }
         }
         if selectedDictationProvider == .openRouter {
+            // Disconnect is an explicit withdrawal of permission to send audio
+            // through OpenRouter. Stop both a live recording session and any
+            // upload already finalizing with the credential snapshot.
+            cancelHostedDictation()
+            cancelInFlightDictationTranscription()
             // Keep the selected OpenRouter model for a future reconnect, but
             // never leave dictation pointed at an unauthenticated provider.
             updateConfig { $0.dictationProvider = DictationProvider.local.rawValue }
@@ -10046,6 +10051,16 @@ public final class MuesliController: NSObject {
         dictationTranscriptionTask?.id == id
     }
 
+    #if DEBUG
+    func installHostedDictationSessionsForTesting(
+        recording: (any HostedDictationSession)? = nil,
+        finalizing: (any HostedDictationSession)? = nil
+    ) {
+        hostedDictationSession = recording
+        finalizingHostedDictationSession = finalizing.map { (UUID(), $0) }
+    }
+    #endif
+
     private func captureDictationCorrectionTargetApp() {
         capturedDictationCorrectionTargetApp = currentExternalDictationTargetApp()
     }
@@ -10632,7 +10647,12 @@ public final class MuesliController: NSObject {
                         rawText = result.text
                         completionBackend = result.backend
                     } catch {
-                        guard HostedDictationFallbackPolicy.shouldFallback(after: error),
+                        guard HostedDictationFallbackPolicy.shouldFallback(
+                            after: error,
+                            taskIsCancelled: Task.isCancelled,
+                            isCurrentSession: isTestMode
+                                || self.isCurrentDictationTranscription(id: transcriptionTaskID)
+                        ),
                               let fallbackBackend = hostedFallbackBackend else { throw error }
                         fputs("[hosted-dictation] transcription failed; falling back locally: \(error)\n", stderr)
                         try await self.transcriptionCoordinator.preloadRequired(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2853,7 +2853,8 @@ public final class MuesliController: NSObject {
         updateConfig { $0.dictationProvider = provider.rawValue }
         if provider.isHosted {
             dictationBackendReadiness = .ready
-            if provider == .openRouter {
+            if provider == .openRouter,
+               hostedDictationModelVisibility.shows(.openRouter) {
                 loadOpenRouterModels(.transcription)
             }
             statusBarController?.refresh()
@@ -2914,6 +2915,13 @@ public final class MuesliController: NSObject {
         let environmentKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"]?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return environmentKey
+    }
+
+    var hostedDictationModelVisibility: HostedDictationModelVisibility {
+        HostedDictationModelVisibility.resolve(
+            openAIAPIKey: resolvedOpenAIAPIKey(),
+            isOpenRouterAuthenticated: openRouterAuth.isAuthenticated
+        )
     }
 
     private func prepareDictationBackend(_ backend: BackendOption) async -> Bool {
@@ -3437,6 +3445,8 @@ public final class MuesliController: NSObject {
             return nil
         }
 
+        clearOpenRouterTranscriptionCatalog()
+
         if selectedMeetingSummaryBackend == .openRouter {
             // Match ChatGPT sign-out: move summaries to the existing API-key fallback.
             selectMeetingSummaryBackend(.openAI)
@@ -3497,6 +3507,10 @@ public final class MuesliController: NSObject {
                 }
             }
         case .transcription:
+            guard hostedDictationModelVisibility.shows(.openRouter) else {
+                clearOpenRouterTranscriptionCatalog()
+                return
+            }
             guard force || (
                 appState.openRouterTranscriptionModels.isEmpty
                     && appState.openRouterTranscriptionCatalogState == .idle
@@ -3508,6 +3522,7 @@ public final class MuesliController: NSObject {
                 defer { self.openRouterTranscriptionCatalogTask = nil }
                 do {
                     let models = try await self.openRouterModelCatalogClient.load(.transcription)
+                    guard self.hostedDictationModelVisibility.shows(.openRouter) else { return }
                     self.appState.openRouterTranscriptionModels = models
                     self.appState.openRouterTranscriptionCatalogState = models.isEmpty
                         ? .failed("No transcription models found")
@@ -3520,6 +3535,13 @@ public final class MuesliController: NSObject {
                 self.statusBarController?.refresh()
             }
         }
+    }
+
+    private func clearOpenRouterTranscriptionCatalog() {
+        openRouterTranscriptionCatalogTask?.cancel()
+        openRouterTranscriptionCatalogTask = nil
+        appState.openRouterTranscriptionModels = []
+        appState.openRouterTranscriptionCatalogState = .idle
     }
 
     // MARK: - Google Calendar

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -415,6 +415,7 @@ public final class MuesliController: NSObject {
     private var onboardingModelPreparationTask: Task<Void, Never>?
     private var openRouterSummaryCatalogTask: Task<Void, Never>?
     private var openRouterTranscriptionCatalogTask: Task<Void, Never>?
+    private var openRouterTranscriptionCatalogGeneration = 0
     private var maraudersMapCountdown: MaraudersMapCountdownController?
 
     private var statusBarController: StatusBarController?
@@ -2920,7 +2921,9 @@ public final class MuesliController: NSObject {
     var hostedDictationModelVisibility: HostedDictationModelVisibility {
         HostedDictationModelVisibility.resolve(
             openAIAPIKey: resolvedOpenAIAPIKey(),
-            isOpenRouterAuthenticated: openRouterAuth.isAuthenticated
+            openRouterAPIKey: openRouterAuth.resolvedAPIKey(
+                legacyAPIKey: config.openRouterAPIKey
+            )
         )
     }
 
@@ -3516,28 +3519,39 @@ public final class MuesliController: NSObject {
                     && appState.openRouterTranscriptionCatalogState == .idle
             ) else { return }
             guard openRouterTranscriptionCatalogTask == nil else { return }
+            openRouterTranscriptionCatalogGeneration &+= 1
+            let catalogGeneration = openRouterTranscriptionCatalogGeneration
             appState.openRouterTranscriptionCatalogState = .loading
             openRouterTranscriptionCatalogTask = Task { [weak self] in
                 guard let self else { return }
-                defer { self.openRouterTranscriptionCatalogTask = nil }
+                defer {
+                    if self.openRouterTranscriptionCatalogGeneration == catalogGeneration {
+                        self.openRouterTranscriptionCatalogTask = nil
+                    }
+                }
                 do {
                     let models = try await self.openRouterModelCatalogClient.load(.transcription)
-                    guard self.hostedDictationModelVisibility.shows(.openRouter) else { return }
+                    guard self.openRouterTranscriptionCatalogGeneration == catalogGeneration,
+                          self.hostedDictationModelVisibility.shows(.openRouter) else { return }
                     self.appState.openRouterTranscriptionModels = models
                     self.appState.openRouterTranscriptionCatalogState = models.isEmpty
                         ? .failed("No transcription models found")
                         : .loaded
                 } catch is CancellationError {
+                    guard self.openRouterTranscriptionCatalogGeneration == catalogGeneration else { return }
                     self.appState.openRouterTranscriptionCatalogState = .idle
                 } catch {
+                    guard self.openRouterTranscriptionCatalogGeneration == catalogGeneration else { return }
                     self.appState.openRouterTranscriptionCatalogState = .failed("Could not load")
                 }
+                guard self.openRouterTranscriptionCatalogGeneration == catalogGeneration else { return }
                 self.statusBarController?.refresh()
             }
         }
     }
 
     private func clearOpenRouterTranscriptionCatalog() {
+        openRouterTranscriptionCatalogGeneration &+= 1
         openRouterTranscriptionCatalogTask?.cancel()
         openRouterTranscriptionCatalogTask = nil
         appState.openRouterTranscriptionModels = []

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -454,9 +454,14 @@ public final class MuesliController: NSObject {
     private let liveManualNotesPersistInterval: TimeInterval = 0.75
     private var staleLiveMeetingRecoveryFailures = Set<Int64>()
     private var dictationState: DictationState = .idle
-    private var dictationBackendReadiness: DictationBackendReadiness = .preparing
+    private(set) var dictationBackendReadiness: DictationBackendReadiness = .preparing
     private var dictationStartedAt: Date?
     private var hostedDictationSession: (any HostedDictationSession)?
+    private var finalizingHostedDictationSession: (
+        id: UUID,
+        session: any HostedDictationSession
+    )?
+    private var dictationTranscriptionTask: (id: UUID, task: Task<Void, Never>)?
     private var dictationLatencyTraceID: UUID?
     private var dictationLatencyTraceStartedAt: Date?
     private var currentDictationOutputMode: DictationOutputMode = .paste
@@ -964,6 +969,8 @@ public final class MuesliController: NSObject {
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
         computerUseCommandTaskID = nil
+        cancelHostedDictation()
+        cancelInFlightDictationTranscription()
         clearQuilSession(cancelAudioReason: "shutdown")
         activeComputerUseAudioSessionID = nil
         pendingComputerUseStopSessionID = nil
@@ -2853,6 +2860,10 @@ public final class MuesliController: NSObject {
             return
         }
 
+        prepareSelectedLocalDictationBackend()
+    }
+
+    private func prepareSelectedLocalDictationBackend() {
         dictationBackendReadiness = .preparing
         let option = selectedBackend
         Task { [weak self] in
@@ -3445,6 +3456,7 @@ public final class MuesliController: NSObject {
             // Keep the selected OpenRouter model for a future reconnect, but
             // never leave dictation pointed at an unauthenticated provider.
             updateConfig { $0.dictationProvider = DictationProvider.local.rawValue }
+            prepareSelectedLocalDictationBackend()
         }
         syncAppState()
         return nil
@@ -10012,6 +10024,28 @@ public final class MuesliController: NSObject {
         detachHostedDictation()?.cancel()
     }
 
+    private func cancelInFlightDictationTranscription() {
+        let hostedSession = finalizingHostedDictationSession?.session
+        let transcriptionTask = dictationTranscriptionTask?.task
+        finalizingHostedDictationSession = nil
+        dictationTranscriptionTask = nil
+        hostedSession?.cancel()
+        transcriptionTask?.cancel()
+    }
+
+    private func clearInFlightDictationTranscription(id: UUID) {
+        if finalizingHostedDictationSession?.id == id {
+            finalizingHostedDictationSession = nil
+        }
+        if dictationTranscriptionTask?.id == id {
+            dictationTranscriptionTask = nil
+        }
+    }
+
+    private func isCurrentDictationTranscription(id: UUID) -> Bool {
+        dictationTranscriptionTask?.id == id
+    }
+
     private func captureDictationCorrectionTargetApp() {
         capturedDictationCorrectionTargetApp = currentExternalDictationTargetApp()
     }
@@ -10168,12 +10202,15 @@ public final class MuesliController: NSObject {
     private func handleCancel() {
         if isMeetingRecording() { return }
         if shouldIgnoreDictationCleanupForComputerUseActivity() { return }
-        if shouldIgnoreCleanupAfterBlockedDictationStart {
+        let isCancellingTranscription = dictationState == .transcribing
+            && dictationTranscriptionTask != nil
+        if shouldIgnoreCleanupAfterBlockedDictationStart && !isCancellingTranscription {
             fputs("[muesli-native] ignoring dictation cancel because start was blocked\n", stderr)
             return
         }
         fputs("[muesli-native] cancel\n", stderr)
         cancelHostedDictation()
+        cancelInFlightDictationTranscription()
         resetDictationOutputMode()
 
         if isNemotron35Streaming {
@@ -10571,10 +10608,17 @@ public final class MuesliController: NSObject {
         let storageContext = capturedContext.map { DictationContextCapture.formatForStorage($0) }
             ?? startingTargetApp?.appContext
             ?? ""
+        let transcriptionTaskID = UUID()
+        if !isTestMode, let hostedSession {
+            finalizingHostedDictationSession = (transcriptionTaskID, hostedSession)
+        }
         let task = Task { [weak self] in
             guard let self else { return }
             defer {
                 try? FileManager.default.removeItem(at: wavURL)
+                if !isTestMode {
+                    self.clearInFlightDictationTranscription(id: transcriptionTaskID)
+                }
             }
 
             do {
@@ -10636,6 +10680,9 @@ public final class MuesliController: NSObject {
                 }
                 // Drop result if test was cancelled (user navigated away)
                 try Task.checkCancellation()
+                guard isTestMode || self.isCurrentDictationTranscription(id: transcriptionTaskID) else {
+                    return
+                }
                 let text = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
                 await MainActor.run {
                     self.markDictationLatency("transcription_completed", trace: completionLatencyTrace)
@@ -10740,6 +10787,9 @@ public final class MuesliController: NSObject {
                 }
             } catch is CancellationError {
                 fputs("[muesli-native] test dictation cancelled\n", stderr)
+                guard isTestMode || self.isCurrentDictationTranscription(id: transcriptionTaskID) else {
+                    return
+                }
                 await MainActor.run {
                     self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
@@ -10750,6 +10800,9 @@ public final class MuesliController: NSObject {
                 }
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
+                guard isTestMode || self.isCurrentDictationTranscription(id: transcriptionTaskID) else {
+                    return
+                }
                 await MainActor.run {
                     if self.isDictationTestMode {
                         self.dictationTestFailureCallback?(self.userFacingDictationTestError(error))
@@ -10770,7 +10823,11 @@ public final class MuesliController: NSObject {
                 }
             }
         }
-        if isTestMode { dictationTestTask = task }
+        if isTestMode {
+            dictationTestTask = task
+        } else {
+            dictationTranscriptionTask = (transcriptionTaskID, task)
+        }
     }
 
     private func userFacingDictationTestError(_ error: Error) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -400,6 +400,7 @@ public final class MuesliController: NSObject {
 
     private let chatGPTAuth = ChatGPTAuthManager.shared
     private let openRouterAuth: OpenRouterAuthManager
+    private let openRouterModelCatalogClient: OpenRouterModelCatalogClient
     private let googleCalAuth = GoogleCalendarAuthManager.shared
     private let googleCalClient = GoogleCalendarClient()
     private var calendarCheckTimer: Timer?
@@ -412,6 +413,8 @@ public final class MuesliController: NSObject {
 
     private var searchTask: Task<Void, Never>?
     private var onboardingModelPreparationTask: Task<Void, Never>?
+    private var openRouterSummaryCatalogTask: Task<Void, Never>?
+    private var openRouterTranscriptionCatalogTask: Task<Void, Never>?
     private var maraudersMapCountdown: MaraudersMapCountdownController?
 
     private var statusBarController: StatusBarController?
@@ -453,7 +456,7 @@ public final class MuesliController: NSObject {
     private var dictationState: DictationState = .idle
     private var dictationBackendReadiness: DictationBackendReadiness = .preparing
     private var dictationStartedAt: Date?
-    private var openAIRealtimeStream: OpenAIRealtimeDictationStream?
+    private var hostedDictationSession: (any HostedDictationSession)?
     private var dictationLatencyTraceID: UUID?
     private var dictationLatencyTraceStartedAt: Date?
     private var currentDictationOutputMode: DictationOutputMode = .paste
@@ -549,10 +552,12 @@ public final class MuesliController: NSObject {
         launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager(),
         audioDuckingController: AudioDuckingManaging = AudioDuckingController(),
         dictationAudioRoutingController: DictationAudioRouting = DictationAudioRouteController(),
-        openRouterAuth: OpenRouterAuthManager? = nil
+        openRouterAuth: OpenRouterAuthManager? = nil,
+        openRouterModelCatalogClient: OpenRouterModelCatalogClient = OpenRouterModelCatalogClient()
     ) {
         self.configStore = configStore
         self.openRouterAuth = openRouterAuth ?? .shared
+        self.openRouterModelCatalogClient = openRouterModelCatalogClient
         var loadedConfig = configStore.load()
         let loadedBackend = BackendOption.all.first(where: {
             $0.backend == loadedConfig.sttBackend && $0.model == loadedConfig.sttModel
@@ -879,7 +884,7 @@ public final class MuesliController: NSObject {
                     )
                 }
                 let dictationBackend = self.selectedBackend
-                if self.selectedDictationProvider == .openAI {
+                if self.selectedDictationProvider.isHosted {
                     self.dictationBackendReadiness = .ready
                 } else {
                     guard await self.prepareDictationBackend(dictationBackend) else { return }
@@ -2825,7 +2830,7 @@ public final class MuesliController: NSObject {
         }
     }
 
-    // MARK: - Dictation Provider (Local / OpenAI)
+    // MARK: - Dictation Provider
 
     private func canChangePrimaryDictationModel() -> Bool {
         guard !dictationAudioSessionManager.hasActiveSession, dictationStartedAt == nil else {
@@ -2839,8 +2844,11 @@ public final class MuesliController: NSObject {
         guard provider != selectedDictationProvider else { return }
         guard canChangePrimaryDictationModel() else { return }
         updateConfig { $0.dictationProvider = provider.rawValue }
-        if provider == .openAI {
+        if provider.isHosted {
             dictationBackendReadiness = .ready
+            if provider == .openRouter {
+                loadOpenRouterModels(.transcription)
+            }
             statusBarController?.refresh()
             return
         }
@@ -2875,6 +2883,11 @@ public final class MuesliController: NSObject {
 
     func selectOpenAIDictationModel(_ model: String) {
         updateConfig { $0.openaiDictationModel = OpenAITranscriptionClient.normalizeModel(model) }
+    }
+
+    func selectOpenRouterDictationModel(_ model: String) {
+        let normalizedModel = OpenRouterTranscriptionClient.normalizedModel(model)
+        updateConfig { $0.openRouterDictationModel = normalizedModel }
     }
 
     func testOpenAIConnection() async throws {
@@ -3428,6 +3441,11 @@ public final class MuesliController: NSObject {
                 $0.quilModel = PostProcessorOption.defaultQuilOption.id
             }
         }
+        if selectedDictationProvider == .openRouter {
+            // Keep the selected OpenRouter model for a future reconnect, but
+            // never leave dictation pointed at an unauthenticated provider.
+            updateConfig { $0.dictationProvider = DictationProvider.local.rawValue }
+        }
         syncAppState()
         return nil
     }
@@ -3435,6 +3453,56 @@ public final class MuesliController: NSObject {
     func manageOpenRouterKey() {
         guard let url = openRouterAuth.manageKeyURL else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    func loadOpenRouterModels(_ scope: OpenRouterModelCatalogScope, force: Bool = false) {
+        switch scope {
+        case .text:
+            guard force || (
+                appState.openRouterSummaryModels.isEmpty
+                    && appState.openRouterSummaryCatalogState == .idle
+            ) else { return }
+            guard openRouterSummaryCatalogTask == nil else { return }
+            appState.openRouterSummaryCatalogState = .loading
+            openRouterSummaryCatalogTask = Task { [weak self] in
+                guard let self else { return }
+                defer { self.openRouterSummaryCatalogTask = nil }
+                do {
+                    let models = try await self.openRouterModelCatalogClient.load(.text)
+                    self.appState.openRouterSummaryModels = models
+                    self.appState.openRouterSummaryCatalogState = models.isEmpty
+                        ? .failed("No free text models found")
+                        : .loaded
+                } catch is CancellationError {
+                    self.appState.openRouterSummaryCatalogState = .idle
+                } catch {
+                    self.appState.openRouterSummaryCatalogState = .failed("Could not load")
+                }
+            }
+        case .transcription:
+            guard force || (
+                appState.openRouterTranscriptionModels.isEmpty
+                    && appState.openRouterTranscriptionCatalogState == .idle
+            ) else { return }
+            guard openRouterTranscriptionCatalogTask == nil else { return }
+            appState.openRouterTranscriptionCatalogState = .loading
+            openRouterTranscriptionCatalogTask = Task { [weak self] in
+                guard let self else { return }
+                defer { self.openRouterTranscriptionCatalogTask = nil }
+                do {
+                    let models = try await self.openRouterModelCatalogClient.load(.transcription)
+                    self.appState.openRouterTranscriptionModels = models
+                    self.appState.openRouterTranscriptionCatalogState = models.isEmpty
+                        ? .failed("No transcription models found")
+                        : .loaded
+                } catch is CancellationError {
+                    self.appState.openRouterTranscriptionCatalogState = .idle
+                } catch {
+                    self.appState.openRouterTranscriptionCatalogState = .failed("Could not load")
+                }
+                self.statusBarController?.refresh()
+            }
+        }
     }
 
     // MARK: - Google Calendar
@@ -5011,6 +5079,20 @@ public final class MuesliController: NSObject {
         updateConfig {
             $0.dictationProvider = DictationProvider.openAI.rawValue
             $0.openaiDictationModel = normalizedModel
+        }
+        dictationBackendReadiness = .ready
+        statusBarController?.refresh()
+    }
+
+    @objc func selectOpenRouterDictationModelFromMenu(_ sender: NSMenuItem) {
+        guard let model = sender.representedObject as? String else { return }
+        let normalizedModel = OpenRouterTranscriptionClient.normalizedModel(model)
+        guard !normalizedModel.isEmpty else { return }
+        guard selectedDictationProvider != .openRouter
+            || config.openRouterDictationModel != normalizedModel else { return }
+        guard canChangePrimaryDictationModel() else { return }
+        updateConfig {
+            OpenRouterDictationModelSelection.applyStatusMenuSelection(normalizedModel, to: &$0)
         }
         dictationBackendReadiness = .ready
         statusBarController?.refresh()
@@ -9394,6 +9476,19 @@ public final class MuesliController: NSObject {
 
     private func ensureDictationBackendReady() -> Bool {
         guard !isDictationTestMode else { return true }
+        if let message = HostedDictationActivationPolicy.blockingMessage(
+            provider: selectedDictationProvider,
+            openAIAPIKey: resolvedOpenAIAPIKey(),
+            openRouterAPIKey: openRouterAuth.resolvedAPIKey(legacyAPIKey: config.openRouterAPIKey),
+            openRouterModel: config.openRouterDictationModel
+        ) {
+            return blockHostedDictationStart(
+                status: message,
+                warning: selectedDictationProvider == .openRouter
+                    ? "OpenRouter not ready"
+                    : "OpenAI not configured"
+            )
+        }
         guard !dictationBackendReadiness.allowsDictation else { return true }
         guard let message = dictationBackendReadiness.blockingMessage(
             backendLabel: selectedBackend.label
@@ -9409,6 +9504,13 @@ public final class MuesliController: NSObject {
         case .ready:
             break
         }
+        return false
+    }
+
+    private func blockHostedDictationStart(status: String, warning: String) -> Bool {
+        statusBarController?.setStatus(status)
+        statusBarController?.refresh()
+        indicator.showWarning(warning, icon: "!", duration: 3)
         return false
     }
 
@@ -9714,8 +9816,8 @@ public final class MuesliController: NSObject {
             let startedAt = pendingDictationStopStartedAt ?? dictationStartedAt ?? Date()
             pendingDictationStopSessionID = nil
             pendingDictationStopStartedAt = nil
-            let openAIStream = detachOpenAIRealtimeDictation()
-            finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt, openAIStream: openAIStream)
+            let hostedSession = detachHostedDictation()
+            finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt, hostedSession: hostedSession)
         case .audioRestored(let eventSessionID):
             guard pendingReleaseSoundSessionID == eventSessionID else { break }
             pendingReleaseSoundSessionID = nil
@@ -9727,7 +9829,7 @@ public final class MuesliController: NSObject {
             break
         case .failed(_, let error):
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
-            cancelOpenAIRealtimeDictation()
+            cancelHostedDictation()
             if !isDictationTestMode {
                 recordDiagnosticIncident(
                     kind: .dictationAudioFailed,
@@ -9869,39 +9971,45 @@ public final class MuesliController: NSObject {
         externalDictationTargetApp(from: NSWorkspace.shared.frontmostApplication)
     }
 
-    /// Starts the hosted connection before microphone capture and forwards the
-    /// authoritative route-aware recorder buffers through a bounded serial pump.
+    /// Snapshots the hosted provider configuration before microphone capture and,
+    /// when supported, forwards authoritative route-aware recorder buffers live.
     /// The recorder still writes its WAV so a network failure can fall back locally.
-    private func beginOpenAIRealtimeDictationIfNeeded() -> Bool {
-        guard !isDictationTestMode, selectedDictationProvider == .openAI else { return true }
-        let apiKey = resolvedOpenAIAPIKey()
-        guard !apiKey.isEmpty else {
-            let message = "OpenAI API key not configured. Add one in Settings → Dictation."
-            statusBarController?.setStatus(message)
-            indicator.showWarning("OpenAI not configured", icon: "!", duration: 3)
-            return false
-        }
+    private func beginHostedDictationIfNeeded() -> Bool {
+        guard !isDictationTestMode, selectedDictationProvider.isHosted else { return true }
+        cancelHostedDictation()
 
-        cancelOpenAIRealtimeDictation()
-        let stream = OpenAIRealtimeDictationStream(configuration: OpenAIDictationConfiguration(
-            apiKey: apiKey,
-            model: config.openaiDictationModel
-        ))
-        openAIRealtimeStream = stream
-        dictationAudioSessionManager.onAudioBuffer = { [weak stream] samples in
-            stream?.append(samples)
+        let session: any HostedDictationSession
+        switch selectedDictationProvider {
+        case .local:
+            return true
+        case .openAI:
+            session = OpenAIHostedDictationSession(configuration: OpenAIDictationConfiguration(
+                apiKey: resolvedOpenAIAPIKey(),
+                model: config.openaiDictationModel
+            ))
+        case .openRouter:
+            session = OpenRouterHostedDictationSession(configuration: OpenRouterDictationConfiguration(
+                apiKey: openRouterAuth.resolvedAPIKey(legacyAPIKey: config.openRouterAPIKey),
+                model: config.openRouterDictationModel
+            ))
+        }
+        hostedDictationSession = session
+        if session.acceptsLiveAudio {
+            dictationAudioSessionManager.onAudioBuffer = { [weak session] samples in
+                session?.append(samples)
+            }
         }
         return true
     }
 
-    private func detachOpenAIRealtimeDictation() -> OpenAIRealtimeDictationStream? {
+    private func detachHostedDictation() -> (any HostedDictationSession)? {
         dictationAudioSessionManager.onAudioBuffer = nil
-        defer { openAIRealtimeStream = nil }
-        return openAIRealtimeStream
+        defer { hostedDictationSession = nil }
+        return hostedDictationSession
     }
 
-    private func cancelOpenAIRealtimeDictation() {
-        detachOpenAIRealtimeDictation()?.cancel()
+    private func cancelHostedDictation() {
+        detachHostedDictation()?.cancel()
     }
 
     private func captureDictationCorrectionTargetApp() {
@@ -9914,7 +10022,7 @@ public final class MuesliController: NSObject {
         guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
-        guard beginOpenAIRealtimeDictationIfNeeded() else { return }
+        guard beginHostedDictationIfNeeded() else { return }
 
         // Nemotron backends support hold-to-talk (record → transcribe on release) in
         // addition to double-tap handsfree streaming. The hold path uses the normal
@@ -10065,7 +10173,7 @@ public final class MuesliController: NSObject {
             return
         }
         fputs("[muesli-native] cancel\n", stderr)
-        cancelOpenAIRealtimeDictation()
+        cancelHostedDictation()
         resetDictationOutputMode()
 
         if isNemotron35Streaming {
@@ -10098,7 +10206,7 @@ public final class MuesliController: NSObject {
         guard ensureDictationBackendReady() else { return false }
         if isMeetingRecording() { return false }
         if blockDictationForMeetingActivityIfNeeded() { return false }
-        guard beginOpenAIRealtimeDictationIfNeeded() else { return false }
+        guard beginHostedDictationIfNeeded() else { return false }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "toggle")
@@ -10265,7 +10373,7 @@ public final class MuesliController: NSObject {
             || hasComputerUseActivity
             || hasQuilActivity else { return }
         fputs("[muesli-native] cancelling dictation audio session because meeting is active\n", stderr)
-        cancelOpenAIRealtimeDictation()
+        cancelHostedDictation()
 
         if hasComputerUseActivity {
             handleComputerUseCancel()
@@ -10407,11 +10515,11 @@ public final class MuesliController: NSObject {
     private func finishStandardDictationStop(
         wavURL stoppedWavURL: URL?,
         startedAt: Date,
-        openAIStream: OpenAIRealtimeDictationStream?
+        hostedSession: (any HostedDictationSession)?
     ) {
         markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
-            openAIStream?.cancel()
+            hostedSession?.cancel()
             fputs("[muesli-native] stop without wav\n", stderr)
             clearCapturedDictationSessionContext()
             resetDictationOutputMode()
@@ -10423,7 +10531,7 @@ public final class MuesliController: NSObject {
         }
         let duration = max(Date().timeIntervalSince(startedAt), 0)
         if duration < 0.3 {
-            openAIStream?.cancel()
+            hostedSession?.cancel()
             fputs("[muesli-native] discarded short recording\n", stderr)
             try? FileManager.default.removeItem(at: wavURL)
             if isDictationTestMode {
@@ -10448,9 +10556,9 @@ public final class MuesliController: NSObject {
         // uses the configured provider while retaining the local selection for
         // an instant switch back.
         let transcriptionBackend = isTestMode ? (dictationTestBackend ?? selectedBackend) : selectedBackend
-        let openAIFallbackBackend = isTestMode || openAIStream == nil
+        let hostedFallbackBackend = isTestMode || hostedSession == nil
             ? nil
-            : BackendOption.resolveOpenAIFallback(
+            : BackendOption.resolveHostedDictationFallback(
                 selected: selectedBackend,
                 available: BackendOption.downloaded
             )
@@ -10472,15 +10580,17 @@ public final class MuesliController: NSObject {
             do {
                 let rawText: String
                 let completionBackend: String
-                if let openAIStream {
+                if let hostedSession {
                     do {
-                        // OpenAI transcription models already produce normalized
+                        // Hosted transcription models already produce normalized
                         // prose, so hosted success intentionally bypasses cleanup.
-                        rawText = try await openAIStream.finish()
-                        completionBackend = "openai-realtime"
+                        let result = try await hostedSession.finish(recordedWAVURL: wavURL)
+                        rawText = result.text
+                        completionBackend = result.backend
                     } catch {
-                        guard let fallbackBackend = openAIFallbackBackend else { throw error }
-                        fputs("[openai-realtime] stream failed; falling back locally: \(error)\n", stderr)
+                        guard HostedDictationFallbackPolicy.shouldFallback(after: error),
+                              let fallbackBackend = hostedFallbackBackend else { throw error }
+                        fputs("[hosted-dictation] transcription failed; falling back locally: \(error)\n", stderr)
                         try await self.transcriptionCoordinator.preloadRequired(
                             backend: fallbackBackend,
                             enablePostProcessor: false,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3463,13 +3463,13 @@ public final class MuesliController: NSObject {
             }
         }
         if selectedDictationProvider == .openRouter {
-            // Disconnect is an explicit withdrawal of permission to send audio
-            // through OpenRouter. Stop both a live recording session and any
-            // upload already finalizing with the credential snapshot.
-            cancelHostedDictation()
-            cancelInFlightDictationTranscription()
+            // The active dictation already captured its provider, model, and
+            // credential when recording began. Preserve that session just like
+            // any other mid-dictation provider change; disconnect applies to
+            // subsequent dictations only.
+            //
             // Keep the selected OpenRouter model for a future reconnect, but
-            // never leave dictation pointed at an unauthenticated provider.
+            // never leave future dictation pointed at an unauthenticated provider.
             updateConfig { $0.dictationProvider = DictationProvider.local.rawValue }
             prepareSelectedLocalDictationBackend()
         }
@@ -10080,6 +10080,10 @@ public final class MuesliController: NSObject {
     ) {
         hostedDictationSession = recording
         finalizingHostedDictationSession = finalizing.map { (UUID(), $0) }
+    }
+
+    var hostedDictationSessionPresenceForTesting: (recording: Bool, finalizing: Bool) {
+        (hostedDictationSession != nil, finalizingHostedDictationSession != nil)
     }
     #endif
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterAuthManager.swift
@@ -217,9 +217,11 @@ final class OpenRouterAuthManager {
     }
 
     func resolvedAPIKey(
+        legacyAPIKey: String = "",
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
         OpenRouterCredentialResolver.resolvedAPIKey(
+            legacyAPIKey: legacyAPIKey,
             environment: environment,
             credentialStore: credentialStore
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterTranscriptionClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OpenRouterTranscriptionClient.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+struct OpenRouterDictationConfiguration: Sendable {
+    let apiKey: String
+    let model: String
+}
+
+struct OpenRouterTranscriptionResult: Equatable, Sendable {
+    let text: String
+    let generationID: String?
+}
+
+enum OpenRouterTranscriptionError: LocalizedError, @unchecked Sendable {
+    case missingAPIKey
+    case missingModel
+    case emptyTranscript
+    case server(statusCode: Int, message: String?)
+    case network(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "OpenRouter is not connected. Connect it in Settings → Dictation."
+        case .missingModel:
+            return "Choose an OpenRouter transcription model in Settings → Dictation."
+        case .emptyTranscript:
+            return "OpenRouter returned an empty transcript."
+        case .server(let statusCode, let message):
+            if let message, !message.isEmpty {
+                return "OpenRouter transcription failed (HTTP \(statusCode)): \(message)"
+            }
+            return "OpenRouter transcription failed (HTTP \(statusCode))."
+        case .network(let underlying):
+            return "Could not reach OpenRouter: \(underlying.localizedDescription)"
+        }
+    }
+}
+
+struct OpenRouterTranscriptionClient: Sendable {
+    typealias LoadData = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    static let endpoint = URL(string: "https://openrouter.ai/api/v1/audio/transcriptions")!
+    static let requestTimeout: TimeInterval = 65
+
+    private let loadData: LoadData
+
+    init(loadData: @escaping LoadData = { try await URLSession.shared.data(for: $0) }) {
+        self.loadData = loadData
+    }
+
+    func transcribe(
+        wavURL: URL,
+        configuration: OpenRouterDictationConfiguration
+    ) async throws -> OpenRouterTranscriptionResult {
+        try Task.checkCancellation()
+        let audioData: Data
+        do {
+            audioData = try await Task.detached(priority: .userInitiated) {
+                try Data(contentsOf: wavURL)
+            }.value
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw OpenRouterTranscriptionError.network(underlying: error)
+        }
+
+        try Task.checkCancellation()
+        let request = try Self.request(audioData: audioData, configuration: configuration)
+        do {
+            let (data, response) = try await loadData(request)
+            try Task.checkCancellation()
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw OpenRouterTranscriptionError.network(
+                    underlying: URLError(.badServerResponse)
+                )
+            }
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                throw OpenRouterTranscriptionError.server(
+                    statusCode: httpResponse.statusCode,
+                    message: Self.serverMessage(from: data)
+                )
+            }
+
+            let payload = try JSONDecoder().decode(ResponsePayload.self, from: data)
+            let text = payload.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { throw OpenRouterTranscriptionError.emptyTranscript }
+            return OpenRouterTranscriptionResult(
+                text: text,
+                generationID: httpResponse.value(forHTTPHeaderField: "X-Generation-Id")
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as OpenRouterTranscriptionError {
+            throw error
+        } catch let error as URLError where error.code == .cancelled {
+            throw CancellationError()
+        } catch {
+            throw OpenRouterTranscriptionError.network(underlying: error)
+        }
+    }
+
+    static func request(
+        audioData: Data,
+        configuration: OpenRouterDictationConfiguration
+    ) throws -> URLRequest {
+        let apiKey = configuration.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else { throw OpenRouterTranscriptionError.missingAPIKey }
+        let model = normalizedModel(configuration.model)
+        guard !model.isEmpty else { throw OpenRouterTranscriptionError.missingModel }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = requestTimeout
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(AppIdentity.displayName, forHTTPHeaderField: "X-OpenRouter-Title")
+        request.httpBody = try JSONEncoder().encode(RequestPayload(
+            model: model,
+            inputAudio: InputAudio(data: audioData.base64EncodedString(), format: "wav")
+        ))
+        return request
+    }
+
+    static func normalizedModel(_ model: String) -> String {
+        model.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func serverMessage(from data: Data) -> String? {
+        guard let payload = try? JSONDecoder().decode(ErrorEnvelope.self, from: data) else {
+            return nil
+        }
+        let raw = payload.error?.message ?? payload.message
+        guard let raw else { return nil }
+        let collapsed = raw
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        return String(collapsed.prefix(240))
+    }
+
+    private struct RequestPayload: Encodable {
+        let model: String
+        let inputAudio: InputAudio
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case inputAudio = "input_audio"
+        }
+    }
+
+    private struct InputAudio: Encodable {
+        let data: String
+        let format: String
+    }
+
+    private struct ResponsePayload: Decodable {
+        let text: String
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        let error: ErrorPayload?
+        let message: String?
+    }
+
+    private struct ErrorPayload: Decodable {
+        let message: String?
+    }
+}
+
+enum OpenRouterModelCatalogScope: String, Sendable {
+    case text
+    case transcription
+}
+
+enum OpenRouterModelCatalogError: LocalizedError {
+    case invalidResponse
+
+    var errorDescription: String? { "Could not load OpenRouter models." }
+}
+
+struct OpenRouterModelCatalogClient: Sendable {
+    typealias LoadData = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    private let loadData: LoadData
+
+    init(loadData: @escaping LoadData = { try await URLSession.shared.data(for: $0) }) {
+        self.loadData = loadData
+    }
+
+    func load(_ scope: OpenRouterModelCatalogScope) async throws -> [SummaryModelPreset] {
+        let (data, response) = try await loadData(Self.request(scope))
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw OpenRouterModelCatalogError.invalidResponse
+        }
+        let catalog = try JSONDecoder().decode(OpenRouterModelCatalog.self, from: data)
+        switch scope {
+        case .text:
+            return OpenRouterModelCatalogFilter.freeTextSummaryPresets(from: catalog.data)
+        case .transcription:
+            return OpenRouterModelCatalogFilter.transcriptionPresets(from: catalog.data)
+        }
+    }
+
+    static func request(_ scope: OpenRouterModelCatalogScope) -> URLRequest {
+        var components = URLComponents(string: "https://openrouter.ai/api/v1/models")!
+        components.queryItems = [URLQueryItem(name: "output_modalities", value: scope.rawValue)]
+        var request = URLRequest(url: components.url!)
+        request.timeoutInterval = 30
+        request.setValue(AppIdentity.displayName, forHTTPHeaderField: "X-OpenRouter-Title")
+        return request
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -463,7 +463,8 @@ struct SettingsView: View {
                 if appState.selectedMeetingSummaryBackend == .openRouter {
                     loadOpenRouterFreeModelsIfNeeded()
                 }
-                if appState.dictationProvider == .openRouter {
+                if appState.dictationProvider == .openRouter,
+                   controller.hostedDictationModelVisibility.shows(.openRouter) {
                     loadOpenRouterTranscriptionModelsIfNeeded()
                 }
                 scrollToFeatureTourTarget(activeFeatureTourTarget, using: scrollProxy)
@@ -1087,16 +1088,18 @@ struct SettingsView: View {
             )
             .frame(height: 22)
         }
-        Divider().background(MuesliTheme.surfaceBorder)
-        settingsRow("Model", controlWidth: meetingControlWidth) {
-            settingsModelMenu(
-                currentModel: appState.config.openaiDictationModel,
-                presets: openAIDictationModelPresets
-            ) { controller.selectOpenAIDictationModel($0) }
-        }
-        Divider().background(MuesliTheme.surfaceBorder)
-        settingsRow("Connection", controlWidth: meetingControlWidth) {
-            openAITestControl
+        if controller.hostedDictationModelVisibility.shows(.openAI) {
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Model", controlWidth: meetingControlWidth) {
+                settingsModelMenu(
+                    currentModel: appState.config.openaiDictationModel,
+                    presets: openAIDictationModelPresets
+                ) { controller.selectOpenAIDictationModel($0) }
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Connection", controlWidth: meetingControlWidth) {
+                openAITestControl
+            }
         }
     }
 
@@ -1109,17 +1112,19 @@ struct SettingsView: View {
         settingsRow("Account", controlWidth: meetingControlWidth) {
             openRouterAccountControl(selectMeetingSummaryBackend: false)
         }
-        Divider().background(MuesliTheme.surfaceBorder)
-        settingsRow("Model", controlWidth: meetingControlWidth) {
-            openRouterTranscriptionModelMenu
-        }
-        Divider().background(MuesliTheme.surfaceBorder)
-        settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
-            settingsModelTextField(
-                currentModel: appState.config.openRouterDictationModel,
-                placeholder: "provider/model",
-                onBeginEditing: { isUsingCustomOpenRouterDictationModel = true }
-            ) { controller.selectOpenRouterDictationModel($0) }
+        if controller.hostedDictationModelVisibility.shows(.openRouter) {
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Model", controlWidth: meetingControlWidth) {
+                openRouterTranscriptionModelMenu
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
+                settingsModelTextField(
+                    currentModel: appState.config.openRouterDictationModel,
+                    placeholder: "provider/model",
+                    onBeginEditing: { isUsingCustomOpenRouterDictationModel = true }
+                ) { controller.selectOpenRouterDictationModel($0) }
+            }
         }
     }
 
@@ -2454,6 +2459,9 @@ struct SettingsView: View {
                         )
                         isSigningInOpenRouter = false
                         openRouterSignInError = error
+                        if error == nil, appState.dictationProvider == .openRouter {
+                            loadOpenRouterTranscriptionModelsIfNeeded()
+                        }
                     }
                 } label: {
                     HStack(spacing: 5) {
@@ -2498,6 +2506,9 @@ struct SettingsView: View {
                             if openRouterSignInError == nil {
                                 manualOpenRouterAPIKey = ""
                                 isEnteringOpenRouterAPIKey = false
+                                if appState.dictationProvider == .openRouter {
+                                    loadOpenRouterTranscriptionModelsIfNeeded()
+                                }
                             }
                         }
                         .disabled(manualOpenRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -211,10 +211,8 @@ struct SettingsView: View {
     @AppStorage("settings.pendingScreenContextRequestedAt") private var pendingScreenContextRequestedAt = 0.0
     @State private var systemAudioGranted = false
     @State private var isCheckingSystemAudioPermission = false
-    @State private var openRouterFreeModels: [SummaryModelPreset] = []
-    @State private var isLoadingOpenRouterFreeModels = false
-    @State private var openRouterFreeModelsError: String?
     @State private var isUsingCustomOpenRouterModel = false
+    @State private var isUsingCustomOpenRouterDictationModel = false
     @State private var hasRefreshedMeetingCalendarSources = false
     @State private var isShowingICloudSyncReconnectConfirmation = false
     @State private var isShowingICloudSyncResetConfirmation = false
@@ -247,15 +245,15 @@ struct SettingsView: View {
     ]
 
     private var dictationBackendOptions: [BackendOption] {
-        guard appState.dictationProvider == .openAI else {
+        guard appState.dictationProvider.isHosted else {
             return backendOptions(including: appState.selectedBackend)
         }
-        return downloadedBackendOptions.filter(\.supportsOpenAIFallback)
+        return downloadedBackendOptions.filter(\.supportsHostedDictationFallback)
     }
 
     private var displayedDictationBackend: BackendOption? {
-        guard appState.dictationProvider == .openAI else { return appState.selectedBackend }
-        return BackendOption.resolveOpenAIFallback(
+        guard appState.dictationProvider.isHosted else { return appState.selectedBackend }
+        return BackendOption.resolveHostedDictationFallback(
             selected: appState.selectedBackend,
             available: dictationBackendOptions
         )
@@ -464,6 +462,9 @@ struct SettingsView: View {
                 startPermissionPolling()
                 if appState.selectedMeetingSummaryBackend == .openRouter {
                     loadOpenRouterFreeModelsIfNeeded()
+                }
+                if appState.dictationProvider == .openRouter {
+                    loadOpenRouterTranscriptionModelsIfNeeded()
                 }
                 scrollToFeatureTourTarget(activeFeatureTourTarget, using: scrollProxy)
             }
@@ -1022,8 +1023,11 @@ struct SettingsView: View {
             if appState.dictationProvider == .openAI {
                 openAIDictationSettingsRows
                 Divider().background(MuesliTheme.surfaceBorder)
+            } else if appState.dictationProvider == .openRouter {
+                openRouterDictationSettingsRows
+                Divider().background(MuesliTheme.surfaceBorder)
             }
-            settingsRow(appState.dictationProvider == .openAI ? "Fallback model" : "Dictation model", controlWidth: meetingControlWidth) {
+            settingsRow(appState.dictationProvider.isHosted ? "Fallback model" : "Dictation model", controlWidth: meetingControlWidth) {
                 if let displayedDictationBackend {
                     settingsMenu(
                         selection: displayedDictationBackend.label,
@@ -1039,11 +1043,11 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            if appState.dictationProvider == .openAI {
+            if appState.dictationProvider.isHosted {
                 settingsDescription(
                     displayedDictationBackend == nil
                         ? "Download a non-streaming local model to enable automatic fallback."
-                        : "Used automatically if the Realtime connection fails."
+                        : "Used automatically if \(appState.dictationProvider.label) transcription fails."
                 )
             }
             if !disabledDictationBackendLabels.isEmpty {
@@ -1098,6 +1102,25 @@ struct SettingsView: View {
 
     private var openAIDictationModelPresets: [SummaryModelPreset] {
         OpenAITranscriptionClient.modelPresets.map { SummaryModelPreset(id: $0, label: $0) }
+    }
+
+    @ViewBuilder
+    private var openRouterDictationSettingsRows: some View {
+        settingsRow("Account", controlWidth: meetingControlWidth) {
+            openRouterAccountControl(selectMeetingSummaryBackend: false)
+        }
+        Divider().background(MuesliTheme.surfaceBorder)
+        settingsRow("Model", controlWidth: meetingControlWidth) {
+            openRouterTranscriptionModelMenu
+        }
+        Divider().background(MuesliTheme.surfaceBorder)
+        settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
+            settingsModelTextField(
+                currentModel: appState.config.openRouterDictationModel,
+                placeholder: "provider/model",
+                onBeginEditing: { isUsingCustomOpenRouterDictationModel = true }
+            ) { controller.selectOpenRouterDictationModel($0) }
+        }
     }
 
     @ViewBuilder
@@ -2377,6 +2400,7 @@ struct SettingsView: View {
                             openRouterSignInError = controller.signOutOpenRouter()
                             if openRouterSignInError == nil && !appState.isOpenRouterAuthenticated {
                                 isUsingCustomOpenRouterModel = false
+                                isUsingCustomOpenRouterDictationModel = false
                             }
                         } label: {
                             Text(appState.isOpenRouterEnvironmentManaged ? "Forget local" : "Disconnect")
@@ -3706,7 +3730,8 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var openRouterFreeModelMenu: some View {
-        if isLoadingOpenRouterFreeModels {
+        if appState.openRouterSummaryCatalogState == .loading,
+           appState.openRouterSummaryModels.isEmpty {
             HStack(spacing: 8) {
                 ProgressView()
                     .controlSize(.small)
@@ -3715,7 +3740,8 @@ struct SettingsView: View {
                     .foregroundStyle(MuesliTheme.textTertiary)
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
-        } else if !openRouterFreeModels.isEmpty {
+        } else if !appState.openRouterSummaryModels.isEmpty {
+            let openRouterFreeModels = appState.openRouterSummaryModels
             let configuredModel = appState.config.openRouterModel.trimmingCharacters(in: .whitespacesAndNewlines)
             let configuredPreset = openRouterFreeModels.first { $0.id == configuredModel }
             let showsCustomSelection = isUsingCustomOpenRouterModel
@@ -3730,33 +3756,41 @@ struct SettingsView: View {
                 ? customLabel
                 : (configuredPreset?.label ?? openRouterFreeModels[0].label)
 
-            FixedWidthPopUp(
-                selection: selectedLabel,
-                options: menuPresets.map(\.label),
-                onSelectIndex: { index in
-                    guard index >= 0 && index < menuPresets.count else { return }
-                    if showsCustomSelection && index == openRouterFreeModels.count {
-                        isUsingCustomOpenRouterModel = true
-                        return
+            HStack(spacing: 8) {
+                FixedWidthPopUp(
+                    selection: selectedLabel,
+                    options: menuPresets.map(\.label),
+                    onSelectIndex: { index in
+                        guard index >= 0 && index < menuPresets.count else { return }
+                        if showsCustomSelection && index == openRouterFreeModels.count {
+                            isUsingCustomOpenRouterModel = true
+                            return
+                        }
+                        isUsingCustomOpenRouterModel = false
+                        let selectedID = openRouterFreeModels[index].id
+                        controller.updateConfig {
+                            $0.openRouterModel = OpenRouterModelSelection.persistedModelID(for: selectedID)
+                        }
                     }
-                    isUsingCustomOpenRouterModel = false
-                    let selectedID = openRouterFreeModels[index].id
-                    controller.updateConfig {
-                        $0.openRouterModel = OpenRouterModelSelection.persistedModelID(for: selectedID)
+                )
+                .frame(height: 24)
+                if case .failed = appState.openRouterSummaryCatalogState {
+                    Button("Retry") {
+                        controller.loadOpenRouterModels(.text, force: true)
                     }
+                    .font(.system(size: 11, weight: .medium))
                 }
-            )
-            .frame(height: 24)
+            }
         } else {
             HStack(spacing: 8) {
-                if let openRouterFreeModelsError {
-                    Text(openRouterFreeModelsError)
+                if case .failed(let message) = appState.openRouterSummaryCatalogState {
+                    Text(message)
                         .font(.system(size: 11))
                         .foregroundStyle(MuesliTheme.textTertiary)
                         .lineLimit(1)
                 }
-                Button("Load") {
-                    loadOpenRouterFreeModels(force: true)
+                Button(appState.openRouterSummaryCatalogState == .idle ? "Load" : "Retry") {
+                    controller.loadOpenRouterModels(.text, force: true)
                 }
                 .font(.system(size: 12, weight: .medium))
             }
@@ -3765,39 +3799,54 @@ struct SettingsView: View {
     }
 
     private func loadOpenRouterFreeModelsIfNeeded() {
-        guard openRouterFreeModels.isEmpty, !isLoadingOpenRouterFreeModels else { return }
-        loadOpenRouterFreeModels(force: false)
+        controller.loadOpenRouterModels(.text)
     }
 
-    private func loadOpenRouterFreeModels(force: Bool) {
-        guard force || openRouterFreeModels.isEmpty else { return }
-        isLoadingOpenRouterFreeModels = true
-        openRouterFreeModelsError = nil
+    @ViewBuilder
+    private var openRouterTranscriptionModelMenu: some View {
+        let placeholder = "Choose a model…"
+        let customOption = "Custom model ID"
+        let configured = OpenRouterTranscriptionClient.normalizedModel(
+            appState.config.openRouterDictationModel
+        )
+        let presets = appState.openRouterTranscriptionModels
+        let configuredPreset = presets.first(where: { $0.id == configured })
+        let options = [placeholder] + presets.map(\.label) + [customOption]
+        let selected = isUsingCustomOpenRouterDictationModel
+            ? customOption
+            : (configured.isEmpty ? placeholder : (configuredPreset?.label ?? customOption))
 
-        Task {
-            do {
-                let url = URL(string: "https://openrouter.ai/api/v1/models?output_modalities=text")!
-                let (data, response) = try await URLSession.shared.data(from: url)
-                if let httpResponse = response as? HTTPURLResponse,
-                   !(200..<300).contains(httpResponse.statusCode) {
-                    throw URLError(.badServerResponse)
+        HStack(spacing: 8) {
+            if appState.openRouterTranscriptionCatalogState == .loading, presets.isEmpty {
+                ProgressView().controlSize(.small)
+            }
+            FixedWidthPopUp(
+                selection: selected,
+                options: options,
+                disabledOptions: [placeholder],
+                onSelectIndex: { index in
+                    guard index > 0 else { return }
+                    if index == options.count - 1 {
+                        isUsingCustomOpenRouterDictationModel = true
+                        return
+                    }
+                    isUsingCustomOpenRouterDictationModel = false
+                    controller.selectOpenRouterDictationModel(presets[index - 1].id)
                 }
-                let catalog = try JSONDecoder().decode(OpenRouterModelCatalog.self, from: data)
-                let presets = OpenRouterModelCatalogFilter.freeTextSummaryPresets(from: catalog.data)
+            )
+            .frame(height: 24)
 
-                await MainActor.run {
-                    openRouterFreeModels = presets
-                    openRouterFreeModelsError = presets.isEmpty ? "No free text models found" : nil
-                    isLoadingOpenRouterFreeModels = false
+            if case .failed = appState.openRouterTranscriptionCatalogState {
+                Button("Retry") {
+                    controller.loadOpenRouterModels(.transcription, force: true)
                 }
-            } catch {
-                await MainActor.run {
-                    openRouterFreeModels = []
-                    openRouterFreeModelsError = "Could not load"
-                    isLoadingOpenRouterFreeModels = false
-                }
+                .font(.system(size: 11, weight: .medium))
             }
         }
+    }
+
+    private func loadOpenRouterTranscriptionModelsIfNeeded() {
+        controller.loadOpenRouterModels(.transcription)
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -176,6 +176,33 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             item.representedObject = model
             dictationModelMenu.addItem(item)
         }
+
+        controller.loadOpenRouterModels(.transcription)
+        dictationModelMenu.addItem(.separator())
+        dictationModelMenu.addItem(.sectionHeader(title: "OpenRouter"))
+        let openRouterModels = OpenRouterModelSelection.presetsIncludingConfiguredModel(
+            controller.appState.openRouterTranscriptionModels,
+            configuredModel: controller.config.openRouterDictationModel
+        )
+        if openRouterModels.isEmpty {
+            let item = NSMenuItem(title: "Choose a model in Settings…", action: nil, keyEquivalent: "")
+            item.isEnabled = false
+            dictationModelMenu.addItem(item)
+        } else {
+            for preset in openRouterModels {
+                let isSelected = controller.selectedDictationProvider == .openRouter
+                    && controller.config.openRouterDictationModel == preset.id
+                let prefix = isSelected ? "✓ " : ""
+                let item = NSMenuItem(
+                    title: "\(prefix)\(preset.label)",
+                    action: #selector(MuesliController.selectOpenRouterDictationModelFromMenu(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = controller
+                item.representedObject = preset.id
+                dictationModelMenu.addItem(item)
+            }
+        }
         menu.setSubmenu(dictationModelMenu, for: dictationModelItem)
         menu.addItem(dictationModelItem)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -156,51 +156,56 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             dictationModelMenu.addItem(item)
         }
 
-        dictationModelMenu.addItem(.separator())
-        dictationModelMenu.addItem(.sectionHeader(title: "OpenAI"))
-        var openAIModels = OpenAITranscriptionClient.modelPresets
-        let configuredOpenAIModel = controller.config.openaiDictationModel
-        if !openAIModels.contains(configuredOpenAIModel) {
-            openAIModels.append(configuredOpenAIModel)
-        }
-        for model in openAIModels {
-            let isSelected = controller.selectedDictationProvider == .openAI
-                && configuredOpenAIModel == model
-            let prefix = isSelected ? "✓ " : ""
-            let item = NSMenuItem(
-                title: "\(prefix)\(model)",
-                action: #selector(MuesliController.selectOpenAIDictationModelFromMenu(_:)),
-                keyEquivalent: ""
-            )
-            item.target = controller
-            item.representedObject = model
-            dictationModelMenu.addItem(item)
-        }
-
-        controller.loadOpenRouterModels(.transcription)
-        dictationModelMenu.addItem(.separator())
-        dictationModelMenu.addItem(.sectionHeader(title: "OpenRouter"))
-        let openRouterModels = OpenRouterModelSelection.presetsIncludingConfiguredModel(
-            controller.appState.openRouterTranscriptionModels,
-            configuredModel: controller.config.openRouterDictationModel
-        )
-        if openRouterModels.isEmpty {
-            let item = NSMenuItem(title: "Choose a model in Settings…", action: nil, keyEquivalent: "")
-            item.isEnabled = false
-            dictationModelMenu.addItem(item)
-        } else {
-            for preset in openRouterModels {
-                let isSelected = controller.selectedDictationProvider == .openRouter
-                    && controller.config.openRouterDictationModel == preset.id
+        let hostedVisibility = controller.hostedDictationModelVisibility
+        if hostedVisibility.shows(.openAI) {
+            dictationModelMenu.addItem(.separator())
+            dictationModelMenu.addItem(.sectionHeader(title: "OpenAI"))
+            var openAIModels = OpenAITranscriptionClient.modelPresets
+            let configuredOpenAIModel = controller.config.openaiDictationModel
+            if !openAIModels.contains(configuredOpenAIModel) {
+                openAIModels.append(configuredOpenAIModel)
+            }
+            for model in openAIModels {
+                let isSelected = controller.selectedDictationProvider == .openAI
+                    && configuredOpenAIModel == model
                 let prefix = isSelected ? "✓ " : ""
                 let item = NSMenuItem(
-                    title: "\(prefix)\(preset.label)",
-                    action: #selector(MuesliController.selectOpenRouterDictationModelFromMenu(_:)),
+                    title: "\(prefix)\(model)",
+                    action: #selector(MuesliController.selectOpenAIDictationModelFromMenu(_:)),
                     keyEquivalent: ""
                 )
                 item.target = controller
-                item.representedObject = preset.id
+                item.representedObject = model
                 dictationModelMenu.addItem(item)
+            }
+        }
+
+        if hostedVisibility.shows(.openRouter) {
+            controller.loadOpenRouterModels(.transcription)
+            dictationModelMenu.addItem(.separator())
+            dictationModelMenu.addItem(.sectionHeader(title: "OpenRouter"))
+            let openRouterModels = OpenRouterModelSelection.presetsIncludingConfiguredModel(
+                controller.appState.openRouterTranscriptionModels,
+                configuredModel: controller.config.openRouterDictationModel
+            )
+            if openRouterModels.isEmpty {
+                let item = NSMenuItem(title: "Choose a model in Settings…", action: nil, keyEquivalent: "")
+                item.isEnabled = false
+                dictationModelMenu.addItem(item)
+            } else {
+                for preset in openRouterModels {
+                    let isSelected = controller.selectedDictationProvider == .openRouter
+                        && controller.config.openRouterDictationModel == preset.id
+                    let prefix = isSelected ? "✓ " : ""
+                    let item = NSMenuItem(
+                        title: "\(prefix)\(preset.label)",
+                        action: #selector(MuesliController.selectOpenRouterDictationModelFromMenu(_:)),
+                        keyEquivalent: ""
+                    )
+                    item.target = controller
+                    item.representedObject = preset.id
+                    dictationModelMenu.addItem(item)
+                }
             }
         }
         menu.setSubmenu(dictationModelMenu, for: dictationModelItem)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -8,6 +8,23 @@ private enum OpenRouterDisconnectTestError: Error {
     case expected
 }
 
+private final class DisconnectHostedDictationSessionSpy: HostedDictationSession {
+    let acceptsLiveAudio = false
+    private(set) var cancelCount = 0
+    private(set) var finishCount = 0
+
+    func append(_: [Float]) {}
+
+    func finish(recordedWAVURL _: URL) async throws -> HostedDictationResult {
+        finishCount += 1
+        return HostedDictationResult(text: "unexpected", backend: "test")
+    }
+
+    func cancel() {
+        cancelCount += 1
+    }
+}
+
 @MainActor
 @Suite("Meetings navigation")
 struct MeetingsNavigationTests {
@@ -1309,10 +1326,20 @@ struct MeetingsNavigationTests {
             $0.dictationProvider = DictationProvider.openRouter.rawValue
             $0.openRouterDictationModel = "provider/transcribe"
         }
+        let recordingSession = DisconnectHostedDictationSessionSpy()
+        let finalizingSession = DisconnectHostedDictationSessionSpy()
+        controller.installHostedDictationSessionsForTesting(
+            recording: recordingSession,
+            finalizing: finalizingSession
+        )
 
         #expect(controller.signOutOpenRouter() == nil)
 
         #expect(!openRouterAuth.isAuthenticated)
+        #expect(recordingSession.cancelCount == 1)
+        #expect(recordingSession.finishCount == 0)
+        #expect(finalizingSession.cancelCount == 1)
+        #expect(finalizingSession.finishCount == 0)
         #expect(controller.selectedDictationProvider == .local)
         #expect(controller.dictationBackendReadiness == .preparing)
         #expect(controller.selectedMeetingSummaryBackend == .openAI)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -25,6 +25,20 @@ private final class DisconnectHostedDictationSessionSpy: HostedDictationSession 
     }
 }
 
+private actor OpenRouterCatalogVisibilityProbe {
+    private(set) var requestCount = 0
+
+    func recordRequest() {
+        requestCount += 1
+    }
+
+    func waitForRequest() async {
+        for _ in 0..<100 where requestCount == 0 {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
 @MainActor
 @Suite("Meetings navigation")
 struct MeetingsNavigationTests {
@@ -1355,6 +1369,65 @@ struct MeetingsNavigationTests {
         #expect(persisted.quilBackend == TranscriptCleanupBackendOption.local.backend)
         #expect(persisted.resolvedDictationProvider == .local)
         #expect(persisted.openRouterDictationModel == "provider/transcribe")
+    }
+
+    @Test("OpenRouter transcription catalog stays hidden until authentication")
+    func openRouterCatalogRequiresAuthentication() async throws {
+        let supportDirectory = makeSupportDirectory()
+        let openRouterAuth = OpenRouterAuthManager(
+            credentialStore: OpenRouterCredentialStore(supportDirectory: supportDirectory),
+            loadData: { _ in throw URLError(.unsupportedURL) },
+            openURL: { _ in false },
+            environment: { [:] }
+        )
+        let probe = OpenRouterCatalogVisibilityProbe()
+        let catalogClient = OpenRouterModelCatalogClient { request in
+            await probe.recordRequest()
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            let data = Data("""
+            {"data":[
+              {"id":"provider/asr","name":"Provider ASR","pricing":{},"architecture":{"output_modalities":["transcription"]}}
+            ]}
+            """.utf8)
+            return (data, response)
+        }
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            configStore: ConfigStore(supportDirectory: supportDirectory),
+            openRouterAuth: openRouterAuth,
+            openRouterModelCatalogClient: catalogClient
+        )
+        controller.appState.openRouterTranscriptionModels = [
+            SummaryModelPreset(id: "stale/model", label: "Stale")
+        ]
+        controller.appState.openRouterTranscriptionCatalogState = .loaded
+
+        controller.loadOpenRouterModels(.transcription, force: true)
+        await Task.yield()
+
+        let unauthenticatedRequestCount = await probe.requestCount
+        #expect(unauthenticatedRequestCount == 0)
+        #expect(controller.appState.openRouterTranscriptionModels.isEmpty)
+        #expect(controller.appState.openRouterTranscriptionCatalogState == .idle)
+
+        try openRouterAuth.storeManualAPIKey("sk-or-v1-test")
+        controller.loadOpenRouterModels(.transcription, force: true)
+        await probe.waitForRequest()
+        for _ in 0..<100 where controller.appState.openRouterTranscriptionCatalogState != .loaded {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        let authenticatedRequestCount = await probe.requestCount
+        #expect(authenticatedRequestCount == 1)
+        #expect(controller.appState.openRouterTranscriptionModels.map(\.id) == ["provider/asr"])
+        #expect(controller.appState.openRouterTranscriptionCatalogState == .loaded)
     }
 
     @Test("failed OpenRouter credential deletion preserves provider selections")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1310,7 +1310,7 @@ struct MeetingsNavigationTests {
         #expect(!controller.appState.config.enablePostProcessor)
     }
 
-    @Test("disconnecting OpenRouter replaces every active OpenRouter provider")
+    @Test("disconnecting OpenRouter updates future providers without interrupting active dictation")
     func disconnectingOpenRouterFallsBackSafely() throws {
         let supportDirectory = makeSupportDirectory()
         let configStore = ConfigStore(supportDirectory: supportDirectory)
@@ -1350,10 +1350,12 @@ struct MeetingsNavigationTests {
         #expect(controller.signOutOpenRouter() == nil)
 
         #expect(!openRouterAuth.isAuthenticated)
-        #expect(recordingSession.cancelCount == 1)
+        #expect(recordingSession.cancelCount == 0)
         #expect(recordingSession.finishCount == 0)
-        #expect(finalizingSession.cancelCount == 1)
+        #expect(finalizingSession.cancelCount == 0)
         #expect(finalizingSession.finishCount == 0)
+        #expect(controller.hostedDictationSessionPresenceForTesting.recording)
+        #expect(controller.hostedDictationSessionPresenceForTesting.finalizing)
         #expect(controller.selectedDictationProvider == .local)
         #expect(controller.dictationBackendReadiness == .preparing)
         #expect(controller.selectedMeetingSummaryBackend == .openAI)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -39,6 +39,58 @@ private actor OpenRouterCatalogVisibilityProbe {
     }
 }
 
+private actor OpenRouterCatalogRaceProbe {
+    private struct PendingResponse {
+        let url: URL
+        let continuation: CheckedContinuation<(Data, URLResponse), Never>
+    }
+
+    private var nextRequestID = 0
+    private var pendingResponses: [Int: PendingResponse] = [:]
+    private var returnedRequestIDs = Set<Int>()
+
+    func load(_ request: URLRequest) async -> (id: Int, data: Data, response: URLResponse) {
+        nextRequestID += 1
+        let requestID = nextRequestID
+        let result = await withCheckedContinuation { continuation in
+            pendingResponses[requestID] = PendingResponse(
+                url: request.url!,
+                continuation: continuation
+            )
+        }
+        returnedRequestIDs.insert(requestID)
+        return (requestID, result.0, result.1)
+    }
+
+    func waitForRequestCount(_ count: Int) async {
+        for _ in 0..<100 where nextRequestID < count {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func waitForReturn(_ requestID: Int) async {
+        for _ in 0..<100 where !returnedRequestIDs.contains(requestID) {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func complete(_ requestID: Int, modelID: String, name: String) {
+        guard let pending = pendingResponses.removeValue(forKey: requestID) else { return }
+        let data = Data("""
+        {"data":[
+          {"id":"\(modelID)","name":"\(name)","pricing":{},"architecture":{"output_modalities":["transcription"]}}
+        ]}
+        """.utf8)
+        let response = HTTPURLResponse(
+            url: pending.url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        pending.continuation.resume(returning: (data, response))
+    }
+}
+
 @MainActor
 @Suite("Meetings navigation")
 struct MeetingsNavigationTests {
@@ -1429,6 +1481,80 @@ struct MeetingsNavigationTests {
         let authenticatedRequestCount = await probe.requestCount
         #expect(authenticatedRequestCount == 1)
         #expect(controller.appState.openRouterTranscriptionModels.map(\.id) == ["provider/asr"])
+        #expect(controller.appState.openRouterTranscriptionCatalogState == .loaded)
+    }
+
+    @Test("legacy OpenRouter credentials expose the same model controls as stored credentials")
+    func legacyOpenRouterCredentialShowsModels() {
+        let configDirectory = makeSupportDirectory()
+        let authDirectory = makeSupportDirectory()
+        let openRouterAuth = OpenRouterAuthManager(
+            credentialStore: OpenRouterCredentialStore(supportDirectory: authDirectory),
+            loadData: { _ in throw URLError(.unsupportedURL) },
+            openURL: { _ in false },
+            environment: { [:] }
+        )
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            configStore: ConfigStore(supportDirectory: configDirectory),
+            openRouterAuth: openRouterAuth
+        )
+        controller.updateConfig { $0.openRouterAPIKey = " sk-or-v1-legacy " }
+
+        #expect(!openRouterAuth.isAuthenticated)
+        #expect(controller.hostedDictationModelVisibility.shows(.openRouter))
+    }
+
+    @Test("an older cancelled catalog request cannot overwrite a newer reload")
+    func staleOpenRouterCatalogLoadCannotReplaceNewerModels() async throws {
+        let supportDirectory = makeSupportDirectory()
+        let openRouterAuth = OpenRouterAuthManager(
+            credentialStore: OpenRouterCredentialStore(supportDirectory: supportDirectory),
+            loadData: { _ in throw URLError(.unsupportedURL) },
+            openURL: { _ in false },
+            environment: { [:] }
+        )
+        try openRouterAuth.storeManualAPIKey("sk-or-v1-first")
+        let probe = OpenRouterCatalogRaceProbe()
+        let catalogClient = OpenRouterModelCatalogClient { request in
+            let result = await probe.load(request)
+            return (result.data, result.response)
+        }
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            configStore: ConfigStore(supportDirectory: supportDirectory),
+            openRouterAuth: openRouterAuth,
+            openRouterModelCatalogClient: catalogClient
+        )
+
+        controller.loadOpenRouterModels(.transcription, force: true)
+        await probe.waitForRequestCount(1)
+        #expect(controller.signOutOpenRouter() == nil)
+
+        try openRouterAuth.storeManualAPIKey("sk-or-v1-second")
+        controller.loadOpenRouterModels(.transcription, force: true)
+        await probe.waitForRequestCount(2)
+        await probe.complete(2, modelID: "new/model", name: "New Model")
+        for _ in 0..<100 where controller.appState.openRouterTranscriptionCatalogState != .loaded {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(controller.appState.openRouterTranscriptionModels.map(\.id) == ["new/model"])
+
+        await probe.complete(1, modelID: "stale/model", name: "Stale Model")
+        await probe.waitForReturn(1)
+        for _ in 0..<20 { await Task.yield() }
+
+        #expect(controller.appState.openRouterTranscriptionModels.map(\.id) == ["new/model"])
         #expect(controller.appState.openRouterTranscriptionCatalogState == .loaded)
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1306,11 +1306,15 @@ struct MeetingsNavigationTests {
             $0.postProcessorBackend = LLMBackendOption.openRouter.backend
             $0.quilBackend = LLMBackendOption.openRouter.backend
             $0.quilModel = "openai/gpt-5.4"
+            $0.dictationProvider = DictationProvider.openRouter.rawValue
+            $0.openRouterDictationModel = "provider/transcribe"
         }
 
         #expect(controller.signOutOpenRouter() == nil)
 
         #expect(!openRouterAuth.isAuthenticated)
+        #expect(controller.selectedDictationProvider == .local)
+        #expect(controller.dictationBackendReadiness == .preparing)
         #expect(controller.selectedMeetingSummaryBackend == .openAI)
         #expect(controller.config.meetingSummaryBackend == MeetingSummaryBackendOption.openAI.backend)
         #expect(controller.selectedPostProcessorBackend == .local)
@@ -1322,6 +1326,8 @@ struct MeetingsNavigationTests {
         #expect(persisted.meetingSummaryBackend == MeetingSummaryBackendOption.openAI.backend)
         #expect(persisted.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
         #expect(persisted.quilBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(persisted.resolvedDictationProvider == .local)
+        #expect(persisted.openRouterDictationModel == "provider/transcribe")
     }
 
     @Test("failed OpenRouter credential deletion preserves provider selections")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -3175,6 +3175,39 @@ struct OpenAIDictationProviderTests {
         #expect(OpenAITranscriptionClient.normalizeModel("  gpt-transcribe  ") == "gpt-transcribe")
     }
 
+    @Test("hosted model menus are hidden without provider credentials")
+    func hostedModelVisibilityWithoutCredentials() {
+        let visibility = HostedDictationModelVisibility.resolve(
+            openAIAPIKey: "  ",
+            isOpenRouterAuthenticated: false
+        )
+
+        #expect(visibility.visibleProviders.isEmpty)
+        #expect(!visibility.shows(.openAI))
+        #expect(!visibility.shows(.openRouter))
+    }
+
+    @Test("hosted model menus show only providers with credentials")
+    func hostedModelVisibilityWithProviderCredentials() {
+        let openAIOnly = HostedDictationModelVisibility.resolve(
+            openAIAPIKey: " sk-openai ",
+            isOpenRouterAuthenticated: false
+        )
+        #expect(openAIOnly.visibleProviders == [.openAI])
+
+        let openRouterOnly = HostedDictationModelVisibility.resolve(
+            openAIAPIKey: "",
+            isOpenRouterAuthenticated: true
+        )
+        #expect(openRouterOnly.visibleProviders == [.openRouter])
+
+        let both = HostedDictationModelVisibility.resolve(
+            openAIAPIKey: "sk-openai",
+            isOpenRouterAuthenticated: true
+        )
+        #expect(both.visibleProviders == [.openAI, .openRouter])
+    }
+
     @Test("Realtime session update uses current transcription schema")
     func realtimeSessionUpdate() throws {
         let data = try #require(OpenAIRealtimeProtocol.sessionUpdate(model: "gpt-live-transcribe").data(using: .utf8))

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -338,22 +338,22 @@ struct BackendOptionTests {
         #expect(!DictationProvider.local.usesStreamingBackend(.parakeetMultilingual))
     }
 
-    @Test("OpenAI fallback excludes streaming backends")
+    @Test("Hosted dictation fallback excludes streaming backends")
     func openAIFallbackResolution() {
         let available: [BackendOption] = [
             .nemotron35Multilingual,
             .parakeetUnified,
             .whisperSmall,
         ]
-        #expect(BackendOption.resolveOpenAIFallback(
+        #expect(BackendOption.resolveHostedDictationFallback(
             selected: .nemotron35Multilingual,
             available: available
         ) == .parakeetUnified)
-        #expect(BackendOption.resolveOpenAIFallback(
+        #expect(BackendOption.resolveHostedDictationFallback(
             selected: .whisperSmall,
             available: available
         ) == .whisperSmall)
-        #expect(BackendOption.resolveOpenAIFallback(
+        #expect(BackendOption.resolveHostedDictationFallback(
             selected: .nemotron35Multilingual,
             available: [.nemotron35Multilingual]
         ) == nil)
@@ -3133,6 +3133,7 @@ struct OpenAIDictationProviderTests {
     func providerResolution() {
         #expect(DictationProvider.resolved("local") == .local)
         #expect(DictationProvider.resolved("openAI") == .openAI)
+        #expect(DictationProvider.resolved("openRouter") == .openRouter)
         #expect(DictationProvider.resolved(nil) == .local)
         #expect(DictationProvider.resolved("bogus") == .local)
     }
@@ -3140,16 +3141,19 @@ struct OpenAIDictationProviderTests {
     @Test("AppConfig persists provider settings")
     func configRoundTrip() throws {
         var config = AppConfig()
-        config.dictationProvider = DictationProvider.openAI.rawValue
+        config.dictationProvider = DictationProvider.openRouter.rawValue
         config.openaiDictationModel = "gpt-transcribe"
+        config.openRouterDictationModel = "provider/transcribe"
         let data = try JSONEncoder().encode(config)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        #expect(json?["dictation_provider"] as? String == "openAI")
+        #expect(json?["dictation_provider"] as? String == "openRouter")
         #expect(json?["openai_dictation_model"] as? String == "gpt-transcribe")
+        #expect(json?["openrouter_dictation_model"] as? String == "provider/transcribe")
 
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
-        #expect(decoded.resolvedDictationProvider == .openAI)
+        #expect(decoded.resolvedDictationProvider == .openRouter)
         #expect(decoded.openaiDictationModel == "gpt-transcribe")
+        #expect(decoded.openRouterDictationModel == "provider/transcribe")
     }
 
     @Test("AppConfig defaults provider settings when keys are missing or invalid")
@@ -3157,6 +3161,7 @@ struct OpenAIDictationProviderTests {
         let missing = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
         #expect(missing.resolvedDictationProvider == .local)
         #expect(missing.openaiDictationModel == OpenAITranscriptionClient.defaultModel)
+        #expect(missing.openRouterDictationModel.isEmpty)
 
         let invalidJSON = Data("{\"dictation_provider\":\"bogus\"}".utf8)
         let invalid = try JSONDecoder().decode(AppConfig.self, from: invalidJSON)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -3179,7 +3179,7 @@ struct OpenAIDictationProviderTests {
     func hostedModelVisibilityWithoutCredentials() {
         let visibility = HostedDictationModelVisibility.resolve(
             openAIAPIKey: "  ",
-            isOpenRouterAuthenticated: false
+            openRouterAPIKey: "  "
         )
 
         #expect(visibility.visibleProviders.isEmpty)
@@ -3191,19 +3191,19 @@ struct OpenAIDictationProviderTests {
     func hostedModelVisibilityWithProviderCredentials() {
         let openAIOnly = HostedDictationModelVisibility.resolve(
             openAIAPIKey: " sk-openai ",
-            isOpenRouterAuthenticated: false
+            openRouterAPIKey: ""
         )
         #expect(openAIOnly.visibleProviders == [.openAI])
 
         let openRouterOnly = HostedDictationModelVisibility.resolve(
             openAIAPIKey: "",
-            isOpenRouterAuthenticated: true
+            openRouterAPIKey: " sk-or-legacy "
         )
         #expect(openRouterOnly.visibleProviders == [.openRouter])
 
         let both = HostedDictationModelVisibility.resolve(
             openAIAPIKey: "sk-openai",
-            isOpenRouterAuthenticated: true
+            openRouterAPIKey: "sk-or-oauth"
         )
         #expect(both.visibleProviders == [.openAI, .openRouter])
     }

--- a/native/MuesliNative/Tests/MuesliTests/OpenRouterAuthTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OpenRouterAuthTests.swift
@@ -237,9 +237,11 @@ struct OpenRouterAuthTests {
         )
 
         #expect(auth.resolvedAPIKey(environment: ["OPENROUTER_API_KEY": " env-key "]) == "env-key")
+        #expect(auth.resolvedAPIKey(legacyAPIKey: " legacy-key ", environment: [:]) == "legacy-key")
         try auth.storeManualAPIKey("  manual-key\n")
         #expect(auth.resolvedAPIKey(environment: ["OPENROUTER_API_KEY": "env-key"]) == "env-key")
         #expect(auth.resolvedAPIKey(environment: [:]) == "manual-key")
+        #expect(auth.resolvedAPIKey(legacyAPIKey: "legacy-key", environment: [:]) == "manual-key")
         #expect(auth.isAuthenticated)
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/OpenRouterTranscriptionClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OpenRouterTranscriptionClientTests.swift
@@ -205,6 +205,22 @@ struct OpenRouterTranscriptionClientTests {
         #expect(!HostedDictationFallbackPolicy.shouldFallback(after: URLError(.cancelled)))
     }
 
+    @Test("cancelled or stale hosted work cannot start local fallback")
+    func staleCompletionDoesNotFallback() {
+        let lateFailure = URLError(.timedOut)
+
+        #expect(!HostedDictationFallbackPolicy.shouldFallback(
+            after: lateFailure,
+            taskIsCancelled: true,
+            isCurrentSession: true
+        ))
+        #expect(!HostedDictationFallbackPolicy.shouldFallback(
+            after: lateFailure,
+            taskIsCancelled: false,
+            isCurrentSession: false
+        ))
+    }
+
     @Test("catalog scopes use separate endpoint queries")
     func catalogScopes() {
         #expect(

--- a/native/MuesliNative/Tests/MuesliTests/OpenRouterTranscriptionClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OpenRouterTranscriptionClientTests.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("OpenRouter dictation")
+struct OpenRouterTranscriptionClientTests {
+    @Test("request contains the documented endpoint, credential, headers, model, and raw WAV")
+    func requestShape() throws {
+        let audio = Data([0x52, 0x49, 0x46, 0x46])
+        let request = try OpenRouterTranscriptionClient.request(
+            audioData: audio,
+            configuration: OpenRouterDictationConfiguration(
+                apiKey: "  sk-or-test  ",
+                model: "  provider/transcribe  "
+            )
+        )
+
+        #expect(request.url == OpenRouterTranscriptionClient.endpoint)
+        #expect(request.httpMethod == "POST")
+        #expect(request.timeoutInterval == 65)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-or-test")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "X-OpenRouter-Title") == AppIdentity.displayName)
+
+        let httpBody = try #require(request.httpBody)
+        let body = try #require(
+            JSONSerialization.jsonObject(with: httpBody) as? [String: Any]
+        )
+        #expect(body["model"] as? String == "provider/transcribe")
+        let inputAudio = try #require(body["input_audio"] as? [String: Any])
+        #expect(inputAudio["format"] as? String == "wav")
+        #expect(inputAudio["data"] as? String == audio.base64EncodedString())
+    }
+
+    @Test("request requires both a credential and an explicit model")
+    func requiredConfiguration() {
+        #expect(throws: OpenRouterTranscriptionError.self) {
+            try OpenRouterTranscriptionClient.request(
+                audioData: Data(),
+                configuration: .init(apiKey: "", model: "provider/model")
+            )
+        }
+        #expect(throws: OpenRouterTranscriptionError.self) {
+            try OpenRouterTranscriptionClient.request(
+                audioData: Data(),
+                configuration: .init(apiKey: "key", model: "  ")
+            )
+        }
+    }
+
+    @Test("successful response decodes final text and generation ID")
+    func success() async throws {
+        let wavURL = try temporaryWAV(Data([1, 2, 3]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let client = OpenRouterTranscriptionClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["X-Generation-Id": "gen-123"]
+            )!
+            return (Data("{\"text\":\"  hello world  \"}".utf8), response)
+        }
+
+        let result = try await client.transcribe(
+            wavURL: wavURL,
+            configuration: .init(apiKey: "key", model: "provider/model")
+        )
+        #expect(result.text == "hello world")
+        #expect(result.generationID == "gen-123")
+    }
+
+    @Test("hosted session snapshots the model before transcription starts")
+    func sessionSnapshot() async throws {
+        let wavURL = try temporaryWAV(Data([1, 2, 3]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let recorder = OpenRouterRequestRecorder()
+        let client = OpenRouterTranscriptionClient { request in
+            await recorder.record(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (Data("{\"text\":\"snapshot\"}".utf8), response)
+        }
+        var configuration = OpenRouterDictationConfiguration(apiKey: "old-key", model: "old/model")
+        let session = OpenRouterHostedDictationSession(configuration: configuration, client: client)
+        configuration = OpenRouterDictationConfiguration(apiKey: "new-key", model: "new/model")
+
+        _ = try await session.finish(recordedWAVURL: wavURL)
+        let recordedRequest = await recorder.request
+        let request = try #require(recordedRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer old-key")
+        let requestBody = try #require(request.httpBody)
+        let body = try #require(
+            JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+        )
+        #expect(body["model"] as? String == "old/model")
+        #expect(configuration.model == "new/model")
+    }
+
+    @Test("empty transcripts fail instead of being treated as successful dictation")
+    func emptyTranscript() async throws {
+        let wavURL = try temporaryWAV(Data([1]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let client = OpenRouterTranscriptionClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (Data("{\"text\":\"  \"}".utf8), response)
+        }
+
+        do {
+            _ = try await client.transcribe(
+                wavURL: wavURL,
+                configuration: .init(apiKey: "key", model: "provider/model")
+            )
+            Issue.record("Expected an empty-transcript error")
+        } catch OpenRouterTranscriptionError.emptyTranscript {
+            // Expected.
+        }
+    }
+
+    @Test("provider errors are sanitized before display")
+    func sanitizedProviderError() async throws {
+        let wavURL = try temporaryWAV(Data([1]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let client = OpenRouterTranscriptionClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 429, httpVersion: nil, headerFields: nil
+            )!
+            return (Data("{\"error\":{\"message\":\"rate\\nlimit\\tplease retry\"}}".utf8), response)
+        }
+
+        do {
+            _ = try await client.transcribe(
+                wavURL: wavURL,
+                configuration: .init(apiKey: "key", model: "provider/model")
+            )
+            Issue.record("Expected an HTTP error")
+        } catch OpenRouterTranscriptionError.server(let code, let message) {
+            #expect(code == 429)
+            #expect(message == "rate limit please retry")
+        }
+    }
+
+    @Test("cancellation remains cancellation and does not qualify for fallback")
+    func cancellation() async throws {
+        let wavURL = try temporaryWAV(Data([1]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let client = OpenRouterTranscriptionClient { _ in
+            try await Task.sleep(for: .seconds(30))
+            throw URLError(.timedOut)
+        }
+        let task = Task {
+            try await client.transcribe(
+                wavURL: wavURL,
+                configuration: .init(apiKey: "key", model: "provider/model")
+            )
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected cancellation")
+        } catch is CancellationError {
+            #expect(!HostedDictationFallbackPolicy.shouldFallback(after: CancellationError()))
+            #expect(HostedDictationFallbackPolicy.shouldFallback(after: URLError(.timedOut)))
+        }
+    }
+
+    @Test("all non-cancellation hosted failures qualify for local fallback")
+    func fallbackPolicy() {
+        #expect(HostedDictationFallbackPolicy.shouldFallback(
+            after: OpenRouterTranscriptionError.server(statusCode: 429, message: "rate limited")
+        ))
+        #expect(HostedDictationFallbackPolicy.shouldFallback(
+            after: OpenRouterTranscriptionError.server(statusCode: 404, message: "unknown model")
+        ))
+        #expect(HostedDictationFallbackPolicy.shouldFallback(after: URLError(.timedOut)))
+        #expect(HostedDictationFallbackPolicy.shouldFallback(after: URLError(.notConnectedToInternet)))
+        #expect(!HostedDictationFallbackPolicy.shouldFallback(after: URLError(.cancelled)))
+    }
+
+    @Test("catalog scopes use separate endpoint queries")
+    func catalogScopes() {
+        #expect(
+            OpenRouterModelCatalogClient.request(.text).url?.query == "output_modalities=text"
+        )
+        #expect(
+            OpenRouterModelCatalogClient.request(.transcription).url?.query
+                == "output_modalities=transcription"
+        )
+    }
+
+    @Test("malformed catalog responses fail without inventing models")
+    func malformedCatalog() async {
+        let client = OpenRouterModelCatalogClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (Data("{not-json".utf8), response)
+        }
+        await #expect(throws: DecodingError.self) {
+            _ = try await client.load(.transcription)
+        }
+    }
+
+    @Test("transport timeouts remain sanitized network errors")
+    func timeout() async throws {
+        let wavURL = try temporaryWAV(Data([1]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let client = OpenRouterTranscriptionClient { _ in throw URLError(.timedOut) }
+
+        do {
+            _ = try await client.transcribe(
+                wavURL: wavURL,
+                configuration: .init(apiKey: "key", model: "provider/model")
+            )
+            Issue.record("Expected a network error")
+        } catch OpenRouterTranscriptionError.network(let underlying) {
+            #expect((underlying as? URLError)?.code == .timedOut)
+        }
+    }
+
+    @Test("transcription catalog filters, sorts, and retains custom selections")
+    func catalogFilteringAndCustomRetention() throws {
+        let data = Data("""
+        {"data":[
+          {"id":"z/model","name":"Zulu","pricing":{},"architecture":{"output_modalities":["transcription"]}},
+          {"id":"a/model","name":"Alpha","pricing":{},"architecture":{"output_modalities":["text","transcription"]}},
+          {"id":"text/model","name":"Text","pricing":{},"architecture":{"output_modalities":["text"]}}
+        ]}
+        """.utf8)
+        let catalog = try JSONDecoder().decode(OpenRouterModelCatalog.self, from: data)
+        let presets = OpenRouterModelCatalogFilter.transcriptionPresets(from: catalog.data)
+        #expect(presets.map(\.id) == ["a/model", "z/model"])
+
+        let retained = OpenRouterModelSelection.presetsIncludingConfiguredModel(
+            presets,
+            configuredModel: "custom/asr"
+        )
+        #expect(retained.map(\.id) == ["a/model", "z/model", "custom/asr"])
+        #expect(retained.last?.label == "Custom: custom/asr")
+        #expect(
+            OpenRouterModelSelection.presetsIncludingConfiguredModel(
+                presets,
+                configuredModel: "a/model"
+            ).count == presets.count
+        )
+    }
+
+    @Test("activation requires OpenRouter authentication and an explicit model")
+    func activationPolicy() {
+        #expect(HostedDictationActivationPolicy.blockingMessage(
+            provider: .local,
+            openAIAPIKey: "",
+            openRouterAPIKey: "",
+            openRouterModel: ""
+        ) == nil)
+        #expect(HostedDictationActivationPolicy.blockingMessage(
+            provider: .openRouter,
+            openAIAPIKey: "",
+            openRouterAPIKey: "",
+            openRouterModel: "provider/model"
+        )?.contains("not connected") == true)
+        #expect(HostedDictationActivationPolicy.blockingMessage(
+            provider: .openRouter,
+            openAIAPIKey: "",
+            openRouterAPIKey: "key",
+            openRouterModel: ""
+        )?.contains("Choose") == true)
+        #expect(HostedDictationActivationPolicy.blockingMessage(
+            provider: .openRouter,
+            openAIAPIKey: "",
+            openRouterAPIKey: "key",
+            openRouterModel: "provider/model"
+        ) == nil)
+    }
+
+    @Test("status menu selection changes provider and model atomically")
+    func atomicStatusMenuSelection() {
+        var config = AppConfig()
+        OpenRouterDictationModelSelection.applyStatusMenuSelection("  provider/model  ", to: &config)
+        #expect(config.resolvedDictationProvider == .openRouter)
+        #expect(config.openRouterDictationModel == "provider/model")
+    }
+
+    private func temporaryWAV(_ data: Data) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-openrouter-\(UUID().uuidString).wav")
+        try data.write(to: url)
+        return url
+    }
+}
+
+private actor OpenRouterRequestRecorder {
+    private(set) var request: URLRequest?
+
+    func record(_ request: URLRequest) {
+        self.request = request
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/OpenRouterTranscriptionClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OpenRouterTranscriptionClientTests.swift
@@ -168,6 +168,30 @@ struct OpenRouterTranscriptionClientTests {
         }
     }
 
+    @Test("a finalizing hosted session can still cancel its in-flight upload")
+    func finalizingSessionCancellation() async throws {
+        let wavURL = try temporaryWAV(Data([1]))
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let probe = OpenRouterCancellationProbe()
+        let client = OpenRouterTranscriptionClient { _ in
+            await probe.markStarted()
+            try await Task.sleep(for: .seconds(30))
+            throw URLError(.timedOut)
+        }
+        let session = OpenRouterHostedDictationSession(
+            configuration: .init(apiKey: "key", model: "provider/model"),
+            client: client
+        )
+        let task = Task { try await session.finish(recordedWAVURL: wavURL) }
+
+        await probe.waitUntilStarted()
+        session.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+    }
+
     @Test("all non-cancellation hosted failures qualify for local fallback")
     func fallbackPolicy() {
         #expect(HostedDictationFallbackPolicy.shouldFallback(
@@ -298,5 +322,24 @@ private actor OpenRouterRequestRecorder {
 
     func record(_ request: URLRequest) {
         self.request = request
+    }
+}
+
+private actor OpenRouterCancellationProbe {
+    private var hasStarted = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func markStarted() {
+        hasStarted = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        pendingWaiters.forEach { $0.resume() }
+    }
+
+    func waitUntilStarted() async {
+        if hasStarted { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
     }
 }

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -71,6 +71,7 @@ case "${shard}" in
       QuilTransformationTests
       BackendOptionTests
       OpenAIDictationProviderTests
+      OpenRouterTranscriptionClientTests
       SummaryModelPresetTests
       HotkeyMonitorTests
       InteractiveAudioSessionOwnershipTests


### PR DESCRIPTION
## Summary

- add OpenRouter as a third dictation provider, reusing the OAuth credential flow from #482 and hosted fallback lifecycle from #478
- submit the completed WAV to the documented OpenRouter transcription endpoint with a snapshotted provider/model session and local fallback on eligible failures
- share separate OpenRouter summary and transcription model catalogs across Settings and the status menu, including custom model retention and retry
- hide hosted model selectors until that provider has a usable credential; keep Local models available and show only OpenAI and/or OpenRouter choices whose credentials are configured
- resolve OpenRouter visibility through the same environment, protected-store, and legacy credential precedence used by transcription
- protect catalog state with load generations so a cancelled pre-disconnect request cannot overwrite a newer reconnect/reload
- block recording when OpenRouter authentication or explicit model selection is missing
- on disconnect, return future dictations to Local and prepare the selected local backend while retaining the OpenRouter model; an already-started dictation keeps its snapshotted OpenRouter session and finishes normally
- update README, privacy, and terms while retaining local-by-default positioning

## Transport

OpenRouter currently documents REST transcription rather than realtime WebSocket STT, so this version sends one WAV after recording stops. The hosted-session seam keeps controller and UI routing transport-independent for a future documented streaming implementation.

Documentation: https://openrouter.ai/docs/guides/overview/multimodal/stt

## Lifecycle decisions

- Provider/model changes and OpenRouter disconnect affect subsequent dictations only. Work already captured keeps its snapshotted provider, model, and credential and is allowed to finish so user information is not discarded.
- Starting a meeting while hosted transcription is finalizing does not cancel that transcription. A later paste is accepted as the least destructive behavior.
- OpenRouter catalogs are cached once per app process. There is no timer or periodic refresh; retry/force reload is explicit.

## Validation

- focused OpenRouter dictation: 16 tests passed
- focused hosted-provider/controller coverage: 84 tests passed
- focused credential visibility and catalog-generation regressions: 4 tests passed
- OpenRouter OAuth: 11 tests passed
- provider/config: 6 tests passed
- full native suite: 1,943 tests across 173 suites passed (one unrelated meeting-mic timing test was green on isolated rerun and on the clean full rerun)
- changed-file classification passed
- CI shard assignment passed
- update-flow verification with DMG skipped passed
- cached Dev lane B build installed and launched with complete source and bundled LocalVQE runtimes
- three consecutive Dev B dictations using `fish-audio/transcribe-1` completed through OpenRouter with HTTP 200 responses and no local fallback
- lifecycle coverage verifies explicit cancellation stops active/finalizing uploads, disconnect preserves already-started snapshotted work while changing future dictations to Local, and stale completions cannot start local fallback or mutate a newer dictation

## Manual acceptance remaining

- verify a second current catalog model and one custom model ID using a real account
- verify invalid-model fallback through the installed UI

No synthetic paid transcription request is included.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None introduced. The implementation integrates the documented OpenRouter API without vendoring third-party code or assets.

### AI assistance

OpenAI Codex assisted with implementation, tests, review triage, and documentation. The resulting changes were reviewed and validated with focused tests, the full native suite, repository CI scripts, and Dev B runtime checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as an optional hosted dictation provider while keeping local dictation as the default.
  * Added transcription model discovery, custom model support, and selection through Settings and the status-bar menu.
  * Added credential-based visibility for hosted provider controls.
  * Added automatic local fallback when hosted transcription is unavailable.
* **Bug Fixes**
  * OpenRouter sign-out now applies to future dictations while active dictations finish with their original settings.
* **Documentation**
  * Updated the README, Privacy Policy, and Terms of Service with OpenRouter dictation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
