### PR TITLE
Fix duplicate sidebar toggle and compact meeting layout

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -24,6 +24,25 @@ extension EnvironmentValues {
     }
 }
 
+struct DashboardContentLayout<SidebarContent: View, DetailContent: View>: View {
+    let usesCompactQuickNotes: Bool
+    @ViewBuilder let sidebar: () -> SidebarContent
+    @ViewBuilder let detail: () -> DetailContent
+
+    var body: some View {
+        HSplitView {
+            if !usesCompactQuickNotes {
+                sidebar()
+            }
+
+            detail()
+                .environment(\.usesCompactQuickNotes, usesCompactQuickNotes)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(MuesliTheme.backgroundBase)
+        }
+    }
+}
+
 struct DashboardRootView: View {
     let appState: AppState
     let controller: MuesliController
@@ -32,36 +51,29 @@ struct DashboardRootView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            if DashboardWindowLayout.usesCompactQuickNotes(
+            let usesCompactQuickNotes = DashboardWindowLayout.usesCompactQuickNotes(
                 width: proxy.size.width,
                 hasOpenMeeting: hasOpenMeeting
-            ) {
-                detailContent
-                    .environment(\.usesCompactQuickNotes, true)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(MuesliTheme.backgroundBase)
-            } else {
-                HSplitView {
-                    SidebarView(
-                        appState: appState,
-                        controller: controller,
-                        isCollapsed: isSidebarCollapsed,
-                        onToggleCollapsed: {
-                            withAnimation(.easeInOut(duration: 0.22)) {
-                                isSidebarCollapsed.toggle()
-                            }
-                        }
-                    )
-                    .frame(
-                        minWidth: isSidebarCollapsed ? 68 : 240,
-                        idealWidth: isSidebarCollapsed ? 68 : 260,
-                        maxWidth: isSidebarCollapsed ? 68 : 300
-                    )
+            )
 
-                    detailContent
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(MuesliTheme.backgroundBase)
-                }
+            DashboardContentLayout(usesCompactQuickNotes: usesCompactQuickNotes) {
+                SidebarView(
+                    appState: appState,
+                    controller: controller,
+                    isCollapsed: isSidebarCollapsed,
+                    onToggleCollapsed: {
+                        withAnimation(.easeInOut(duration: 0.22)) {
+                            isSidebarCollapsed.toggle()
+                        }
+                    }
+                )
+                .frame(
+                    minWidth: isSidebarCollapsed ? 68 : 240,
+                    idealWidth: isSidebarCollapsed ? 68 : 260,
+                    maxWidth: isSidebarCollapsed ? 68 : 300
+                )
+            } detail: {
+                detailContent
             }
         }
         .frame(

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -4,8 +4,24 @@ import MuesliCore
 enum DashboardWindowLayout {
     /// Narrow enough to sit beside a call window while preserving a useful
     /// notes editor when the sidebar is collapsed or hidden.
-    static let minimumContentWidth: CGFloat = 620
+    static let minimumContentWidth: CGFloat = 520
     static let minimumContentHeight: CGFloat = 600
+    static let compactQuickNotesThreshold: CGFloat = 600
+
+    static func usesCompactQuickNotes(width: CGFloat, hasOpenMeeting: Bool) -> Bool {
+        hasOpenMeeting && width < compactQuickNotesThreshold
+    }
+}
+
+private struct CompactQuickNotesEnvironmentKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var usesCompactQuickNotes: Bool {
+        get { self[CompactQuickNotesEnvironmentKey.self] }
+        set { self[CompactQuickNotesEnvironmentKey.self] = newValue }
+    }
 }
 
 struct DashboardRootView: View {
@@ -15,26 +31,38 @@ struct DashboardRootView: View {
     @State private var isSidebarCollapsed = false
 
     var body: some View {
-        HSplitView {
-            SidebarView(
-                appState: appState,
-                controller: controller,
-                isCollapsed: isSidebarCollapsed,
-                onToggleCollapsed: {
-                    withAnimation(.easeInOut(duration: 0.22)) {
-                        isSidebarCollapsed.toggle()
-                    }
-                }
-            )
-            .frame(
-                minWidth: isSidebarCollapsed ? 68 : 240,
-                idealWidth: isSidebarCollapsed ? 68 : 260,
-                maxWidth: isSidebarCollapsed ? 68 : 300
-            )
+        GeometryReader { proxy in
+            if DashboardWindowLayout.usesCompactQuickNotes(
+                width: proxy.size.width,
+                hasOpenMeeting: hasOpenMeeting
+            ) {
+                detailContent
+                    .environment(\.usesCompactQuickNotes, true)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(MuesliTheme.backgroundBase)
+            } else {
+                HSplitView {
+                    SidebarView(
+                        appState: appState,
+                        controller: controller,
+                        isCollapsed: isSidebarCollapsed,
+                        onToggleCollapsed: {
+                            withAnimation(.easeInOut(duration: 0.22)) {
+                                isSidebarCollapsed.toggle()
+                            }
+                        }
+                    )
+                    .frame(
+                        minWidth: isSidebarCollapsed ? 68 : 240,
+                        idealWidth: isSidebarCollapsed ? 68 : 260,
+                        maxWidth: isSidebarCollapsed ? 68 : 300
+                    )
 
-            detailContent
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(MuesliTheme.backgroundBase)
+                    detailContent
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(MuesliTheme.backgroundBase)
+                }
+            }
         }
         .frame(
             minWidth: DashboardWindowLayout.minimumContentWidth,
@@ -130,6 +158,13 @@ struct DashboardRootView: View {
                 onDismiss: { controller.dismissDiagnosticIncidentPrompt() }
             )
         }
+    }
+
+    private var hasOpenMeeting: Bool {
+        if case .document = appState.meetingsNavigationState {
+            return true
+        }
+        return false
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -24,6 +24,15 @@ extension EnvironmentValues {
     }
 }
 
+@Observable
+final class DashboardSidebarPresentation {
+    var isCollapsed = false
+
+    func toggle() {
+        isCollapsed.toggle()
+    }
+}
+
 struct DashboardContentLayout<SidebarContent: View, DetailContent: View>: View {
     let usesCompactQuickNotes: Bool
     @ViewBuilder let sidebar: () -> SidebarContent
@@ -47,7 +56,30 @@ struct DashboardRootView: View {
     let appState: AppState
     let controller: MuesliController
     @State private var featureTourTargetFrames: [FeatureTourTarget: CGRect] = [:]
-    @State private var isSidebarCollapsed = false
+    @State private var sidebarPresentation: DashboardSidebarPresentation
+
+    init(
+        appState: AppState,
+        controller: MuesliController,
+        sidebarPresentation: DashboardSidebarPresentation = DashboardSidebarPresentation()
+    ) {
+        self.appState = appState
+        self.controller = controller
+        _sidebarPresentation = State(initialValue: sidebarPresentation)
+    }
+
+    var sidebarView: SidebarView {
+        SidebarView(
+            appState: appState,
+            controller: controller,
+            isCollapsed: sidebarPresentation.isCollapsed,
+            onToggleCollapsed: {
+                withAnimation(.easeInOut(duration: 0.22)) {
+                    sidebarPresentation.toggle()
+                }
+            }
+        )
+    }
 
     var body: some View {
         GeometryReader { proxy in
@@ -57,20 +89,11 @@ struct DashboardRootView: View {
             )
 
             DashboardContentLayout(usesCompactQuickNotes: usesCompactQuickNotes) {
-                SidebarView(
-                    appState: appState,
-                    controller: controller,
-                    isCollapsed: isSidebarCollapsed,
-                    onToggleCollapsed: {
-                        withAnimation(.easeInOut(duration: 0.22)) {
-                            isSidebarCollapsed.toggle()
-                        }
-                    }
-                )
+                sidebarView
                 .frame(
-                    minWidth: isSidebarCollapsed ? 68 : 240,
-                    idealWidth: isSidebarCollapsed ? 68 : 260,
-                    maxWidth: isSidebarCollapsed ? 68 : 300
+                    minWidth: sidebarPresentation.isCollapsed ? 68 : 240,
+                    idealWidth: sidebarPresentation.isCollapsed ? 68 : 260,
+                    maxWidth: sidebarPresentation.isCollapsed ? 68 : 300
                 )
             } detail: {
                 detailContent

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 import MuesliCore
 
+enum DashboardWindowLayout {
+    /// Narrow enough to sit beside a call window while preserving a useful
+    /// notes editor when the sidebar is collapsed or hidden.
+    static let minimumContentWidth: CGFloat = 620
+    static let minimumContentHeight: CGFloat = 600
+}
+
 struct DashboardRootView: View {
     let appState: AppState
     let controller: MuesliController
@@ -8,7 +15,7 @@ struct DashboardRootView: View {
     @State private var isSidebarCollapsed = false
 
     var body: some View {
-        NavigationSplitView {
+        HSplitView {
             SidebarView(
                 appState: appState,
                 controller: controller,
@@ -19,18 +26,20 @@ struct DashboardRootView: View {
                     }
                 }
             )
-            .navigationSplitViewColumnWidth(
-                min: isSidebarCollapsed ? 68 : 240,
-                ideal: isSidebarCollapsed ? 68 : 260,
-                max: isSidebarCollapsed ? 68 : 300
+            .frame(
+                minWidth: isSidebarCollapsed ? 68 : 240,
+                idealWidth: isSidebarCollapsed ? 68 : 260,
+                maxWidth: isSidebarCollapsed ? 68 : 300
             )
-        } detail: {
+
             detailContent
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(MuesliTheme.backgroundBase)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(MuesliTheme.backgroundBase)
         }
-        .navigationSplitViewStyle(.balanced)
-        .frame(minWidth: 900, minHeight: 600)
+        .frame(
+            minWidth: DashboardWindowLayout.minimumContentWidth,
+            minHeight: DashboardWindowLayout.minimumContentHeight
+        )
         .preferredColorScheme(appState.config.darkMode ? .dark : .light)
         .onPreferenceChange(FeatureTourTargetPreferenceKey.self) { frames in
             guard FeatureTourFrameTracking.hasMeaningfulChange(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -256,6 +256,8 @@ struct MeetingDetailView: View {
         .padding(.horizontal, 40)
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity, alignment: .center)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("meeting.header.standard")
     }
 
     private func compactQuickNotesHeader(_ meeting: MeetingRecord) -> some View {
@@ -313,13 +315,15 @@ struct MeetingDetailView: View {
             HStack(alignment: .center, spacing: MuesliTheme.spacing8) {
                 folderPill(for: meeting)
                     .frame(maxWidth: 150)
-                MeetingParticipantsView(meetingID: meeting.id, controller: controller)
-                    .frame(maxWidth: 150)
+                if meeting.status != .recording || isPreparingThisMeeting(meeting) {
+                    MeetingParticipantsView(meetingID: meeting.id, controller: controller)
+                        .frame(maxWidth: 150)
+                } else if showsManualNotesEditor(for: meeting) {
+                    compactFormattingToolbar
+                        .disabled(!canEditManualNotes(for: meeting))
+                }
                 Spacer(minLength: 0)
                 detailModePicker(for: meeting)
-                if showsManualNotesEditor(for: meeting) {
-                    compactFormattingMenu
-                }
             }
 
             threadBreadcrumb
@@ -329,6 +333,8 @@ struct MeetingDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("meeting.header.compact")
     }
 
     @ViewBuilder
@@ -343,50 +349,35 @@ struct MeetingDetailView: View {
                     .fixedSize()
                 stopRecordingButton
                     .fixedSize()
-                Menu {
-                    Button("Discard meeting", role: .destructive) {
+                MeetingParticipantsView(
+                    meetingID: meeting.id,
+                    controller: controller,
+                    compactDiscardAction: {
                         controller.discardMeetingWithConfirmation()
                     }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.textSecondary)
-                        .frame(width: 28, height: 28)
-                        .background(MuesliTheme.backgroundRaised)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .fixedSize()
-                .help("More recording actions")
+                )
             }
         } else {
             recordingControlGroup(for: meeting)
         }
     }
 
-    private var compactFormattingMenu: some View {
-        Menu {
-            Button("Heading") { manualEditorCommand = MarkdownEditorCommand(kind: .heading) }
-            Button("Bold") { manualEditorCommand = MarkdownEditorCommand(kind: .bold) }
-            Button("Bullet list") { manualEditorCommand = MarkdownEditorCommand(kind: .bullet) }
-            Button("Checklist") { manualEditorCommand = MarkdownEditorCommand(kind: .checkbox) }
-        } label: {
-            Image(systemName: "textformat")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .frame(width: 28, height: 28)
-                .background(MuesliTheme.backgroundRaised)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .overlay {
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                }
+    private var compactFormattingToolbar: some View {
+        HStack(spacing: 4) {
+            markdownToolbarButton(systemImage: "textformat.size", label: "Heading") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .heading)
+            }
+            markdownToolbarButton(systemImage: "bold", label: "Bold") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .bold)
+            }
+            markdownToolbarButton(systemImage: "list.bullet", label: "Bullet") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .bullet)
+            }
+            markdownToolbarButton(systemImage: "checklist", label: "Checkbox") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .checkbox)
+            }
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
         .fixedSize()
-        .help("Formatting")
     }
 
     private func meetingIdentity(for meeting: MeetingRecord) -> some View {
@@ -1052,6 +1043,7 @@ struct MeetingDetailView: View {
         }
         .buttonStyle(.plain)
         .help(label)
+        .accessibilityLabel(label)
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -201,48 +201,9 @@ struct MeetingDetailView: View {
                 .buttonStyle(.plain)
             }
 
-            HStack(alignment: .top, spacing: MuesliTheme.spacing24) {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                    MarqueeTitleTextField(
-                        text: $editableTitle,
-                        onSubmit: {
-                            controller.updateMeetingTitle(id: meeting.id, title: editableTitle)
-                        },
-                        onTextChange: {
-                            debounceSaveTitle(meetingID: meeting.id)
-                        }
-                    )
+            responsiveTitleAndActions(for: meeting, appliedTemplate: appliedTemplate)
 
-                    HStack(spacing: MuesliTheme.spacing8) {
-                        metadataItem(systemImage: "calendar", text: MeetingBrowserLogic.formatStartTime(meeting.startTime))
-                        metadataDivider
-                        metadataItem(systemImage: "clock", text: formatDuration(meeting.durationSeconds))
-                        metadataDivider
-                        metadataItem(systemImage: "doc.text", text: "\(meeting.wordCount) words")
-                        if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: meeting.source) {
-                            SyncOriginBadge(label: label)
-                        }
-                    }
-                }
-
-                Spacer(minLength: MuesliTheme.spacing16)
-
-                VStack(alignment: .trailing, spacing: 10) {
-                    if showsManualNotesEditor(for: meeting) {
-                        recordingControlGroup(for: meeting)
-                    } else {
-                        compactHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
-                    }
-                }
-            }
-
-            HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                meetingContextStrip(for: meeting)
-                    .layoutPriority(1)
-                Spacer(minLength: MuesliTheme.spacing12)
-                detailModePicker(for: meeting)
-                    .fixedSize(horizontal: true, vertical: false)
-            }
+            responsiveContextControls(for: meeting)
             .padding(MuesliTheme.spacing8)
             .background(MuesliTheme.surfacePrimary)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
@@ -268,6 +229,92 @@ struct MeetingDetailView: View {
         .padding(.horizontal, 40)
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func meetingIdentity(for meeting: MeetingRecord) -> some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            MarqueeTitleTextField(
+                text: $editableTitle,
+                onSubmit: {
+                    controller.updateMeetingTitle(id: meeting.id, title: editableTitle)
+                },
+                onTextChange: {
+                    debounceSaveTitle(meetingID: meeting.id)
+                }
+            )
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                metadataItem(systemImage: "calendar", text: MeetingBrowserLogic.formatStartTime(meeting.startTime))
+                metadataDivider
+                metadataItem(systemImage: "clock", text: formatDuration(meeting.durationSeconds))
+                metadataDivider
+                metadataItem(systemImage: "doc.text", text: "\(meeting.wordCount) words")
+                if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: meeting.source) {
+                    SyncOriginBadge(label: label)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func meetingHeaderActions(
+        for meeting: MeetingRecord,
+        appliedTemplate: MeetingTemplateSnapshot
+    ) -> some View {
+        if showsManualNotesEditor(for: meeting) {
+            recordingControlGroup(for: meeting)
+        } else {
+            compactHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
+        }
+    }
+
+    /// The wide dashboard keeps identity and recording actions on one row. In
+    /// a side-by-side call layout, stack the actions below the title instead of
+    /// forcing the window back to its old 900pt minimum.
+    private func responsiveTitleAndActions(
+        for meeting: MeetingRecord,
+        appliedTemplate: MeetingTemplateSnapshot
+    ) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing24) {
+                meetingIdentity(for: meeting)
+                    .frame(minWidth: 260)
+
+                Spacer(minLength: MuesliTheme.spacing16)
+
+                VStack(alignment: .trailing, spacing: 10) {
+                    meetingHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                meetingIdentity(for: meeting)
+                meetingHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    /// Folder/people controls and the Notes/Live picker share a row when space
+    /// permits, then split into two rows for the compact meeting-notes window.
+    private func responsiveContextControls(for meeting: MeetingRecord) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                meetingContextStrip(for: meeting)
+                    .frame(minWidth: 280, alignment: .leading)
+                    .layoutPriority(1)
+                Spacer(minLength: MuesliTheme.spacing12)
+                detailModePicker(for: meeting)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                meetingContextStrip(for: meeting)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                detailModePicker(for: meeting)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+        }
     }
 
     private func meetingContextStrip(for meeting: MeetingRecord) -> some View {
@@ -1211,6 +1258,8 @@ struct MeetingDetailView: View {
                     .font(.system(size: 10))
                 Text(currentFolder?.name ?? "Add to folder")
                     .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
             .foregroundStyle(hasFolder ? MuesliTheme.accent : MuesliTheme.textSecondary)
             .padding(.horizontal, MuesliTheme.spacing8)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -72,6 +72,7 @@ struct MeetingDetailView: View {
     let appState: AppState
     let onBack: (() -> Void)?
     let backLabel: String
+    @Environment(\.usesCompactQuickNotes) private var usesCompactQuickNotes
     @State private var isSummarizing = false
     @State private var isRetranscribing = false
     @State private var isEditingNotes = false
@@ -204,8 +205,16 @@ struct MeetingDetailView: View {
 
     @ViewBuilder
     private func header(_ meeting: MeetingRecord) -> some View {
+        if usesCompactQuickNotes {
+            compactQuickNotesHeader(meeting)
+        } else {
+            standardHeader(meeting)
+        }
+    }
+
+    private func standardHeader(_ meeting: MeetingRecord) -> some View {
         let appliedTemplate = controller.meetingTemplateSnapshot(for: meeting)
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+        return VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
             if let onBack {
                 Button(action: onBack) {
                     HStack(spacing: 6) {
@@ -247,6 +256,137 @@ struct MeetingDetailView: View {
         .padding(.horizontal, 40)
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func compactQuickNotesHeader(_ meeting: MeetingRecord) -> some View {
+        let appliedTemplate = controller.meetingTemplateSnapshot(for: meeting)
+        return VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(alignment: .center, spacing: MuesliTheme.spacing8) {
+                if let onBack {
+                    Button(action: onBack) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .frame(width: 30, height: 30)
+                            .background(MuesliTheme.backgroundRaised)
+                            .clipShape(Circle())
+                            .overlay {
+                                Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    .help(backLabel)
+                    .accessibilityLabel(backLabel)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    MarqueeTitleTextField(
+                        text: $editableTitle,
+                        titleSize: 24,
+                        onSubmit: {
+                            controller.updateMeetingTitle(id: meeting.id, title: editableTitle)
+                        },
+                        onTextChange: {
+                            debounceSaveTitle(meetingID: meeting.id)
+                        }
+                    )
+
+                    HStack(spacing: 6) {
+                        metadataItem(
+                            systemImage: "calendar",
+                            text: MeetingBrowserLogic.formatStartTime(meeting.startTime)
+                        )
+                        metadataDivider
+                        metadataItem(systemImage: "clock", text: formatDuration(meeting.durationSeconds))
+                    }
+                    .lineLimit(1)
+                }
+                .layoutPriority(1)
+
+                if showsManualNotesEditor(for: meeting) {
+                    compactRecordingControls(for: meeting)
+                } else {
+                    compactHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
+                }
+            }
+
+            HStack(alignment: .center, spacing: MuesliTheme.spacing8) {
+                folderPill(for: meeting)
+                    .frame(maxWidth: 150)
+                MeetingParticipantsView(meetingID: meeting.id, controller: controller)
+                    .frame(maxWidth: 150)
+                Spacer(minLength: 0)
+                detailModePicker(for: meeting)
+                if showsManualNotesEditor(for: meeting) {
+                    compactFormattingMenu
+                }
+            }
+
+            threadBreadcrumb
+
+            activeMeetingAudioWarningBanner(for: meeting)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    @ViewBuilder
+    private func compactRecordingControls(for meeting: MeetingRecord) -> some View {
+        if meeting.status == .recording, !isPreparingThisMeeting(meeting) {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(appState.isMeetingRecordingPaused ? MuesliTheme.transcribing : MuesliTheme.recording)
+                    .frame(width: 7, height: 7)
+                    .help(appState.isMeetingRecordingPaused ? "Recording paused" : "Recording")
+                pauseResumeRecordingButton
+                    .fixedSize()
+                stopRecordingButton
+                    .fixedSize()
+                Menu {
+                    Button("Discard meeting", role: .destructive) {
+                        controller.discardMeetingWithConfirmation()
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.backgroundRaised)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("More recording actions")
+            }
+        } else {
+            recordingControlGroup(for: meeting)
+        }
+    }
+
+    private var compactFormattingMenu: some View {
+        Menu {
+            Button("Heading") { manualEditorCommand = MarkdownEditorCommand(kind: .heading) }
+            Button("Bold") { manualEditorCommand = MarkdownEditorCommand(kind: .bold) }
+            Button("Bullet list") { manualEditorCommand = MarkdownEditorCommand(kind: .bullet) }
+            Button("Checklist") { manualEditorCommand = MarkdownEditorCommand(kind: .checkbox) }
+        } label: {
+            Image(systemName: "textformat")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 28, height: 28)
+                .background(MuesliTheme.backgroundRaised)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay {
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Formatting")
     }
 
     private func meetingIdentity(for meeting: MeetingRecord) -> some View {
@@ -400,8 +540,10 @@ struct MeetingDetailView: View {
                         }
 
                         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                            manualNotesToolbar(for: meeting)
-                                .disabled(!isManualNotesEditable)
+                            if !usesCompactQuickNotes {
+                                manualNotesToolbar(for: meeting)
+                                    .disabled(!isManualNotesEditable)
+                            }
                             MarkdownRichTextEditor(
                                 text: $editableManualNotes,
                                 command: $manualEditorCommand,
@@ -413,17 +555,13 @@ struct MeetingDetailView: View {
                                 }
                             )
                             .background(MuesliTheme.backgroundBase)
-                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                            )
+                            .manualNotesEditorChrome(compact: usesCompactQuickNotes)
                             .frame(maxHeight: hasPersistedNotes ? 260 : .infinity)
                         }
                         .frame(maxWidth: 980, maxHeight: hasPersistedNotes ? nil : .infinity, alignment: .topLeading)
                     }
-                    .padding(.horizontal, 40)
-                    .padding(.top, 12)
+                    .padding(.horizontal, usesCompactQuickNotes ? 24 : 40)
+                    .padding(.top, usesCompactQuickNotes ? 0 : 12)
                     .padding(.bottom, 24)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .opacity(recordingMode == .notes ? 1 : 0)
@@ -440,8 +578,10 @@ struct MeetingDetailView: View {
             } else {
                 let isManualNotesEditable = canEditManualNotes(for: meeting)
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                    manualNotesToolbar(for: meeting)
-                        .disabled(!isManualNotesEditable)
+                    if !usesCompactQuickNotes {
+                        manualNotesToolbar(for: meeting)
+                            .disabled(!isManualNotesEditable)
+                    }
 
                     MarkdownRichTextEditor(
                         text: $editableManualNotes,
@@ -455,14 +595,10 @@ struct MeetingDetailView: View {
                     )
                     .frame(maxWidth: 980, maxHeight: .infinity, alignment: .topLeading)
                     .background(MuesliTheme.backgroundBase)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                    )
+                    .manualNotesEditorChrome(compact: usesCompactQuickNotes)
                 }
-                .padding(.horizontal, 40)
-                .padding(.top, 12)
+                .padding(.horizontal, usesCompactQuickNotes ? 24 : 40)
+                .padding(.top, usesCompactQuickNotes ? 0 : 12)
                 .padding(.bottom, 24)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
@@ -547,7 +683,7 @@ struct MeetingDetailView: View {
         }
         .pickerStyle(.segmented)
         .tint(MuesliTheme.accent)
-        .frame(width: 180)
+        .frame(width: usesCompactQuickNotes ? 124 : 180)
     }
 
     private func showsManualNotesEditor(for meeting: MeetingRecord) -> Bool {
@@ -1709,10 +1845,24 @@ private extension View {
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
     }
+
+    @ViewBuilder
+    func manualNotesEditorChrome(compact: Bool) -> some View {
+        if compact {
+            self
+        } else {
+            clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+        }
+    }
 }
 
 private struct MarqueeTitleTextField: View {
     @Binding var text: String
+    var titleSize: CGFloat = 30
     let onSubmit: () -> Void
     let onTextChange: () -> Void
 
@@ -1723,7 +1873,7 @@ private struct MarqueeTitleTextField: View {
     @State private var marqueeRunID = UUID()
     @FocusState private var isTitleFocused: Bool
 
-    private let titleFont = Font.system(size: 30, weight: .bold)
+    private var titleFont: Font { .system(size: titleSize, weight: .bold) }
 
     var body: some View {
         ZStack(alignment: .leading) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -27,6 +27,19 @@ enum MeetingHeaderLayout {
     static let contextControlHeight: CGFloat = 28
 }
 
+enum CompactMeetingFormattingPolicy {
+    static func showsFormattingControls(for status: MeetingStatus, isPreparing: Bool) -> Bool {
+        switch status {
+        case .recording:
+            return !isPreparing
+        case .noteOnly:
+            return true
+        case .processing, .completed, .failed:
+            return false
+        }
+    }
+}
+
 struct ResponsiveHorizontalLayout<Wide: View, Compact: View>: View {
     let wideIdentifier: String
     let compactIdentifier: String
@@ -315,12 +328,15 @@ struct MeetingDetailView: View {
             HStack(alignment: .center, spacing: MuesliTheme.spacing8) {
                 folderPill(for: meeting)
                     .frame(maxWidth: 150)
-                if meeting.status != .recording || isPreparingThisMeeting(meeting) {
-                    MeetingParticipantsView(meetingID: meeting.id, controller: controller)
-                        .frame(maxWidth: 150)
-                } else if showsManualNotesEditor(for: meeting) {
+                if CompactMeetingFormattingPolicy.showsFormattingControls(
+                    for: meeting.status,
+                    isPreparing: isPreparingThisMeeting(meeting)
+                ) {
                     compactFormattingToolbar
                         .disabled(!canEditManualNotes(for: meeting))
+                } else {
+                    MeetingParticipantsView(meetingID: meeting.id, controller: controller)
+                        .frame(maxWidth: 150)
                 }
                 Spacer(minLength: 0)
                 detailModePicker(for: meeting)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -27,6 +27,24 @@ enum MeetingHeaderLayout {
     static let contextControlHeight: CGFloat = 28
 }
 
+struct ResponsiveHorizontalLayout<Wide: View, Compact: View>: View {
+    let wideIdentifier: String
+    let compactIdentifier: String
+    @ViewBuilder let wide: () -> Wide
+    @ViewBuilder let compact: () -> Compact
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            wide()
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier(wideIdentifier)
+            compact()
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier(compactIdentifier)
+        }
+    }
+}
+
 // Wrapper views that isolate observation of liveMeetingTranscript.
 // Without these, MeetingDetailView.body would observe the property and
 // re-evaluate on every chunk (every ~5s), re-rendering the entire detail view.
@@ -275,7 +293,10 @@ struct MeetingDetailView: View {
         for meeting: MeetingRecord,
         appliedTemplate: MeetingTemplateSnapshot
     ) -> some View {
-        ViewThatFits(in: .horizontal) {
+        ResponsiveHorizontalLayout(
+            wideIdentifier: "meeting.header.wide",
+            compactIdentifier: "meeting.header.compact"
+        ) {
             HStack(alignment: .top, spacing: MuesliTheme.spacing24) {
                 meetingIdentity(for: meeting)
                     .frame(minWidth: 260)
@@ -286,7 +307,7 @@ struct MeetingDetailView: View {
                     meetingHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
                 }
             }
-
+        } compact: {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 meetingIdentity(for: meeting)
                 meetingHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
@@ -298,7 +319,10 @@ struct MeetingDetailView: View {
     /// Folder/people controls and the Notes/Live picker share a row when space
     /// permits, then split into two rows for the compact meeting-notes window.
     private func responsiveContextControls(for meeting: MeetingRecord) -> some View {
-        ViewThatFits(in: .horizontal) {
+        ResponsiveHorizontalLayout(
+            wideIdentifier: "meeting.context.wide",
+            compactIdentifier: "meeting.context.compact"
+        ) {
             HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
                 meetingContextStrip(for: meeting)
                     .frame(minWidth: 280, alignment: .leading)
@@ -307,7 +331,7 @@ struct MeetingDetailView: View {
                 detailModePicker(for: meeting)
                     .fixedSize(horizontal: true, vertical: false)
             }
-
+        } compact: {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                 meetingContextStrip(for: meeting)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
@@ -9,12 +9,23 @@ extension Notification.Name {
 struct MeetingParticipantsView: View {
     let meetingID: Int64
     let controller: MuesliController
+    let compactDiscardAction: (() -> Void)?
 
     @State private var participants: [MeetingParticipant] = []
     @State private var isContactPickerPresented = false
     @State private var isNewContactPresented = false
     @State private var isPeoplePopoverPresented = false
     @State private var errorMessage: String?
+
+    init(
+        meetingID: Int64,
+        controller: MuesliController,
+        compactDiscardAction: (() -> Void)? = nil
+    ) {
+        self.meetingID = meetingID
+        self.controller = controller
+        self.compactDiscardAction = compactDiscardAction
+    }
 
     private var peopleDescription: String {
         participants.count == 1 ? "1 person" : "\(participants.count) people"
@@ -30,44 +41,8 @@ struct MeetingParticipantsView: View {
     }
 
     var body: some View {
-        Button {
-            isPeoplePopoverPresented.toggle()
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: participants.isEmpty ? "person.2" : "person.2.fill")
-
-                if let firstParticipantName {
-                    Text(firstParticipantName)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-
-                    if participants.count > 1 {
-                        Text("+\(participants.count - 1)")
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                    }
-                } else {
-                    Text("Add people")
-                }
-            }
-            .font(MuesliTheme.caption())
-            .foregroundStyle(MuesliTheme.textSecondary)
-            .padding(.horizontal, 10)
-            .frame(height: MeetingHeaderLayout.contextControlHeight)
-            .frame(maxWidth: 220)
-            .background(MuesliTheme.backgroundRaised)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .overlay {
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-            }
-        }
-        .buttonStyle(.plain)
-        .fixedSize(horizontal: false, vertical: true)
+        participantControl
         .featureTourTarget(.meetingPeople)
-        .help(participants.isEmpty ? "Add people to this meeting" : "Show \(peopleDescription)")
-        .accessibilityLabel(
-            participants.isEmpty ? "Add people to this meeting" : "\(peopleDescription) in this meeting"
-        )
         .popover(isPresented: $isPeoplePopoverPresented, arrowEdge: .bottom) {
             peoplePopover
         }
@@ -94,6 +69,75 @@ struct MeetingParticipantsView: View {
             }
         } message: {
             Text(errorMessage ?? "The meeting's people could not be updated.")
+        }
+    }
+
+    @ViewBuilder
+    private var participantControl: some View {
+        if let compactDiscardAction {
+            Menu {
+                Button {
+                    presentPeoplePopoverAfterMenuDismisses()
+                } label: {
+                    Label("Add people…", systemImage: "person.2")
+                }
+
+                Divider()
+
+                Button("Discard meeting", role: .destructive) {
+                    compactDiscardAction()
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .background(MuesliTheme.backgroundRaised)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("More recording actions")
+            .accessibilityLabel("More recording actions")
+        } else {
+            Button {
+                isPeoplePopoverPresented.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: participants.isEmpty ? "person.2" : "person.2.fill")
+
+                    if let firstParticipantName {
+                        Text(firstParticipantName)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        if participants.count > 1 {
+                            Text("+\(participants.count - 1)")
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                        }
+                    } else {
+                        Text("Add people")
+                    }
+                }
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .padding(.horizontal, 10)
+                .frame(height: MeetingHeaderLayout.contextControlHeight)
+                .frame(maxWidth: 220)
+                .background(MuesliTheme.backgroundRaised)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay {
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                }
+            }
+            .buttonStyle(.plain)
+            .fixedSize(horizontal: false, vertical: true)
+            .help(participants.isEmpty ? "Add people to this meeting" : "Show \(peopleDescription)")
+            .accessibilityLabel(
+                participants.isEmpty ? "Add people to this meeting" : "\(peopleDescription) in this meeting"
+            )
         }
     }
 
@@ -223,6 +267,13 @@ struct MeetingParticipantsView: View {
         Task { @MainActor in
             await Task.yield()
             isContactPickerPresented = true
+        }
+    }
+
+    private func presentPeoplePopoverAfterMenuDismisses() {
+        Task { @MainActor in
+            await Task.yield()
+            isPeoplePopoverPresented = true
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4864,11 +4864,14 @@ public final class MuesliController: NSObject {
         presentHistoryWindow(tab: tab)
     }
 
-    private func presentHistoryWindow(tab: DashboardTab) {
+    private func presentHistoryWindow(
+        tab: DashboardTab,
+        presentation: DashboardWindowPresentation = .restored
+    ) {
         appState.selectedTab = tab
         syncAppState()
         DispatchQueue.main.async { [weak self] in
-            self?.historyWindowController?.show()
+            self?.historyWindowController?.show(presentation: presentation)
         }
     }
 
@@ -6088,6 +6091,12 @@ public final class MuesliController: NSObject {
         }
     }
 
+    @objc func startMeetingRecordingFromMenuBar() {
+        startMeetingRecordingFromEntryPoint(
+            dashboardWindowPresentation: .compactMeetingTrailing
+        )
+    }
+
     @objc func toggleMeetingRecordingPause() {
         if isMeetingRecordingPaused() {
             resumeMeetingRecording()
@@ -6127,13 +6136,17 @@ public final class MuesliController: NSObject {
                 calendarOccurrence: payload.calendarOccurrence,
                 endDate: payload.endDate,
                 autoStopSource: payload.autoStopSource,
-                startOrigin: .scheduledMeetingPrompt
+                startOrigin: .scheduledMeetingPrompt,
+                dashboardWindowPresentation: .compactMeetingTrailing
             )
             return
         }
 
         guard let title = sender.representedObject as? String else { return }
-        startMeetingRecordingFromEntryPoint(title: title)
+        startMeetingRecordingFromEntryPoint(
+            title: title,
+            dashboardWindowPresentation: .compactMeetingTrailing
+        )
     }
 
     @discardableResult
@@ -6144,12 +6157,16 @@ public final class MuesliController: NSObject {
         endDate: Date? = nil,
         autoStopSource: MeetingAutoStopSource? = nil,
         presentation: MeetingStartPresentation = .foregroundNotes,
-        startOrigin: MeetingRecordingStartOrigin = .manual
+        startOrigin: MeetingRecordingStartOrigin = .manual,
+        dashboardWindowPresentation: DashboardWindowPresentation = .restored
     ) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
         if isMeetingRecording() {
             if presentation.presentsHistoryWindow {
-                presentHistoryWindow(tab: .meetings)
+                presentHistoryWindow(
+                    tab: .meetings,
+                    presentation: dashboardWindowPresentation
+                )
             }
             return false
         }
@@ -6165,7 +6182,10 @@ public final class MuesliController: NSObject {
         )
         guard didStart else { return false }
         if presentation.presentsHistoryWindow {
-            presentHistoryWindow(tab: .meetings)
+            presentHistoryWindow(
+                tab: .meetings,
+                presentation: dashboardWindowPresentation
+            )
         }
         return true
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -129,6 +129,10 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         window.title = AppIdentity.displayName
         window.isReleasedWhenClosed = false
         window.delegate = self
+        window.contentMinSize = NSSize(
+            width: DashboardWindowLayout.minimumContentWidth,
+            height: DashboardWindowLayout.minimumContentHeight
+        )
         // Opaque titlebar: with .fullSizeContentView a transparent titlebar
         // renders the system chrome material over the detail column, and that
         // material follows the OS theme rather than the app's (dark strip with

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -33,6 +33,28 @@ struct DashboardPresentationReadiness<Action> {
     }
 }
 
+enum DashboardWindowPresentation: Equatable {
+    case restored
+    case compactMeetingTrailing
+}
+
+enum DashboardWindowPlacement {
+    static func compactTrailingFrame(
+        currentFrame: NSRect,
+        visibleFrame: NSRect,
+        targetFrameWidth: CGFloat
+    ) -> NSRect {
+        let width = min(targetFrameWidth, visibleFrame.width)
+        let height = min(currentFrame.height, visibleFrame.height)
+        return NSRect(
+            x: visibleFrame.maxX - width,
+            y: visibleFrame.maxY - height,
+            width: width,
+            height: height
+        )
+    }
+}
+
 @MainActor
 final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
     typealias ReadyAction = () -> Void
@@ -52,13 +74,17 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         self.controller = controller
     }
 
-    func show(whenReady readyAction: ReadyAction? = nil) {
+    func show(
+        whenReady readyAction: ReadyAction? = nil,
+        presentation: DashboardWindowPresentation = .restored
+    ) {
         if window == nil {
             buildWindow()
         }
         guard let window else { return }
         applyAppearance(to: window)
         controller.syncAppState()
+        apply(presentation, to: window)
         if !window.isVisible {
             controller.noteWindowOpened()
         }
@@ -70,6 +96,24 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         window.orderFrontRegardless()
         NSApplication.shared.activate(ignoringOtherApps: true)
         scheduleInitialOrderedLayoutIfNeeded(for: window)
+    }
+
+    private func apply(_ presentation: DashboardWindowPresentation, to window: NSWindow) {
+        guard presentation == .compactMeetingTrailing else { return }
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouseLocation) }
+            ?? window.screen
+            ?? NSScreen.main
+        guard let screen else { return }
+
+        let currentContentWidth = window.contentRect(forFrameRect: window.frame).width
+        let frameChromeWidth = max(0, window.frame.width - currentContentWidth)
+        let targetFrame = DashboardWindowPlacement.compactTrailingFrame(
+            currentFrame: window.frame,
+            visibleFrame: screen.visibleFrame,
+            targetFrameWidth: DashboardWindowLayout.minimumContentWidth + frameChromeWidth
+        )
+        window.setFrame(targetFrame, display: true, animate: window.isVisible)
     }
 
     func reload() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import MuesliCore
 
 struct SidebarToggleButton: View {
+    static let accessibilityIdentifier = "dashboard.sidebar.toggle"
+
     let isCollapsed: Bool
     let action: () -> Void
 
@@ -22,6 +24,7 @@ struct SidebarToggleButton: View {
         .buttonStyle(.plain)
         .help(accessibilityTitle)
         .accessibilityLabel(accessibilityTitle)
+        .accessibilityIdentifier(Self.accessibilityIdentifier)
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -1,6 +1,30 @@
 import SwiftUI
 import MuesliCore
 
+struct SidebarToggleButton: View {
+    let isCollapsed: Bool
+    let action: () -> Void
+
+    var accessibilityTitle: String {
+        isCollapsed ? "Expand sidebar" : "Collapse sidebar"
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "sidebar.left")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 36, height: 36)
+                .background(MuesliTheme.backgroundRaised.opacity(0.72))
+                .clipShape(Circle())
+                .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help(accessibilityTitle)
+        .accessibilityLabel(accessibilityTitle)
+    }
+}
+
 struct SidebarView: View {
     private let sidebarIconColumnWidth: CGFloat = 20
     private let meetingsTrailingColumnWidth: CGFloat = 24
@@ -137,18 +161,7 @@ struct SidebarView: View {
     }
 
     private var sidebarToggleButton: some View {
-        Button(action: onToggleCollapsed) {
-            Image(systemName: "sidebar.left")
-                .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .frame(width: 36, height: 36)
-                .background(MuesliTheme.backgroundRaised.opacity(0.72))
-                .clipShape(Circle())
-                .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
-        }
-        .buttonStyle(.plain)
-        .help(isCollapsed ? "Expand sidebar" : "Collapse sidebar")
-        .accessibilityLabel(isCollapsed ? "Expand sidebar" : "Collapse sidebar")
+        SidebarToggleButton(isCollapsed: isCollapsed, action: onToggleCollapsed)
     }
 
     private func collapsedItem(tab: DashboardTab, icon: String, label: String) -> some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -117,7 +117,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             menu.addItem(actionItem(title: "Stop Meeting Recording", action: #selector(MuesliController.toggleMeetingRecording)))
             menu.addItem(actionItem(title: "Discard Meeting Recording...", action: #selector(MuesliController.discardMeetingWithConfirmation)))
         } else {
-            menu.addItem(actionItem(title: "Start Meeting Recording", action: #selector(MuesliController.toggleMeetingRecording)))
+            menu.addItem(actionItem(
+                title: "Start Meeting Recording",
+                action: #selector(MuesliController.startMeetingRecordingFromMenuBar)
+            ))
         }
         menu.addItem(.separator())
 

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -20,9 +20,16 @@ struct WindowAppearanceTests {
 
     @Test("dashboard can shrink beside a call window")
     func dashboardUsesCompactMinimumWidth() {
-        #expect(DashboardWindowLayout.minimumContentWidth == 620)
+        #expect(DashboardWindowLayout.minimumContentWidth == 520)
         #expect(DashboardWindowLayout.minimumContentWidth < 900)
         #expect(DashboardWindowLayout.minimumContentHeight == 600)
+    }
+
+    @Test("compact quick notes hides the sidebar only for an open meeting")
+    func compactQuickNotesPresentationPolicy() {
+        #expect(DashboardWindowLayout.usesCompactQuickNotes(width: 520, hasOpenMeeting: true))
+        #expect(!DashboardWindowLayout.usesCompactQuickNotes(width: 600, hasOpenMeeting: true))
+        #expect(!DashboardWindowLayout.usesCompactQuickNotes(width: 520, hasOpenMeeting: false))
     }
 
     @Test("dashboard renders one working custom sidebar toggle")

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Foundation
 import Testing
 @testable import MuesliNativeApp
 
@@ -13,5 +14,48 @@ struct WindowAppearanceTests {
     @Test("light mode maps to the light AppKit appearance")
     func lightModeMapsToAqua() {
         #expect(RecentHistoryWindowController.appearanceName(for: false) == .aqua)
+    }
+
+    @Test("dashboard can shrink beside a call window")
+    func dashboardUsesCompactMinimumWidth() {
+        #expect(DashboardWindowLayout.minimumContentWidth == 620)
+        #expect(DashboardWindowLayout.minimumContentWidth < 900)
+        #expect(DashboardWindowLayout.minimumContentHeight == 600)
+    }
+
+    @Test("dashboard uses its custom sidebar without a navigation toolbar toggle")
+    func dashboardUsesOnlyCustomSidebarToggle() throws {
+        let source = try dashboardRootViewSource()
+        #expect(source.contains("HSplitView"))
+        #expect(!source.contains("NavigationSplitView"))
+        #expect(!source.contains("navigationSplitViewColumnWidth"))
+    }
+
+    @Test("meeting header has compact fallbacks for narrow notes windows")
+    func meetingHeaderHasCompactFallbacks() throws {
+        let source = try meetingDetailViewSource()
+        #expect(source.contains("private func responsiveTitleAndActions"))
+        #expect(source.contains("private func responsiveContextControls"))
+        #expect(source.components(separatedBy: "ViewThatFits(in: .horizontal)").count >= 5)
+    }
+
+    private func appSource(named name: String) throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let url = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent(name)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func meetingDetailViewSource() throws -> String {
+        try appSource(named: "MeetingDetailView.swift")
+    }
+
+    private func dashboardRootViewSource() throws -> String {
+        try appSource(named: "DashboardRootView.swift")
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -1,9 +1,11 @@
 import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import MuesliNativeApp
 
-@Suite("WindowAppearance")
+@MainActor
+@Suite("WindowAppearance", .serialized)
 struct WindowAppearanceTests {
 
     @Test("dark mode maps to the dark AppKit appearance")
@@ -23,39 +25,68 @@ struct WindowAppearanceTests {
         #expect(DashboardWindowLayout.minimumContentHeight == 600)
     }
 
-    @Test("dashboard uses its custom sidebar without a navigation toolbar toggle")
-    func dashboardUsesOnlyCustomSidebarToggle() throws {
-        let source = try dashboardRootViewSource()
-        #expect(source.contains("HSplitView"))
-        #expect(!source.contains("NavigationSplitView"))
-        #expect(!source.contains("navigationSplitViewColumnWidth"))
+    @Test("dashboard renders one working custom sidebar toggle")
+    func dashboardRendersOneWorkingSidebarToggle() {
+        var actionCount = 0
+        let expandedControl = SidebarToggleButton(isCollapsed: false) {
+            actionCount += 1
+        }
+        let expandedRenderer = ImageRenderer(content: expandedControl)
+        expandedRenderer.proposedSize = ProposedViewSize(width: 36, height: 36)
+
+        #expect(expandedControl.accessibilityTitle == "Collapse sidebar")
+        #expect(expandedRenderer.nsImage != nil)
+
+        expandedControl.action()
+        #expect(actionCount == 1)
+
+        let collapsedControl = SidebarToggleButton(isCollapsed: true) {}
+        let collapsedRenderer = ImageRenderer(content: collapsedControl)
+        collapsedRenderer.proposedSize = ProposedViewSize(width: 36, height: 36)
+
+        #expect(collapsedControl.accessibilityTitle == "Expand sidebar")
+        #expect(collapsedRenderer.nsImage != nil)
     }
 
-    @Test("meeting header has compact fallbacks for narrow notes windows")
-    func meetingHeaderHasCompactFallbacks() throws {
-        let source = try meetingDetailViewSource()
-        #expect(source.contains("private func responsiveTitleAndActions"))
-        #expect(source.contains("private func responsiveContextControls"))
-        #expect(source.components(separatedBy: "ViewThatFits(in: .horizontal)").count >= 5)
+    @Test("meeting header chooses its compact layout at a constrained width")
+    func meetingHeaderRendersCompactControls() {
+        let selection = LayoutSelectionRecorder()
+        let content =
+            ResponsiveHorizontalLayout(
+                wideIdentifier: "meeting.header.wide",
+                compactIdentifier: "meeting.header.compact"
+            ) {
+                LayoutSelectionProbe(name: "wide", width: 600, recorder: selection)
+            } compact: {
+                LayoutSelectionProbe(name: "compact", width: 100, recorder: selection)
+            }
+            .frame(width: 360, height: DashboardWindowLayout.minimumContentHeight)
+        let renderer = ImageRenderer(content: content)
+        renderer.proposedSize = ProposedViewSize(
+            width: 360,
+            height: DashboardWindowLayout.minimumContentHeight
+        )
+
+        #expect(renderer.nsImage != nil)
+
+        #expect(selection.names == ["compact"])
     }
 
-    private func appSource(named name: String) throws -> String {
-        let packageRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let url = packageRoot
-            .appendingPathComponent("Sources")
-            .appendingPathComponent("MuesliNativeApp")
-            .appendingPathComponent(name)
-        return try String(contentsOf: url, encoding: .utf8)
-    }
+}
 
-    private func meetingDetailViewSource() throws -> String {
-        try appSource(named: "MeetingDetailView.swift")
-    }
+@MainActor
+private final class LayoutSelectionRecorder {
+    var names: [String] = []
+}
 
-    private func dashboardRootViewSource() throws -> String {
-        try appSource(named: "DashboardRootView.swift")
+private struct LayoutSelectionProbe: View {
+    let name: String
+    let width: CGFloat
+    let recorder: LayoutSelectionRecorder
+
+    var body: some View {
+        Color.clear
+            .frame(width: width, height: 40)
+            .onAppear { recorder.names.append(name) }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -172,8 +172,8 @@ struct WindowAppearanceTests {
         return lifecycle.appearanceCount > 0
     }
 
-    @Test("dashboard renders the production compact meeting composition")
-    func dashboardRendersProductionCompactMeetingComposition() {
+    @Test("dashboard wires the production sidebar toggle and compact meeting header")
+    func dashboardWiresProductionSidebarAndCompactMeetingComposition() {
         let supportDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-window-test-\(UUID().uuidString)", isDirectory: true)
         let databaseURL = supportDirectory.appendingPathComponent("muesli.db")
@@ -205,12 +205,22 @@ struct WindowAppearanceTests {
         controller.appState.selectedMeetingRecord = meeting
         controller.appState.meetingsNavigationState = .document(meeting.id)
 
+        let sidebarPresentation = DashboardSidebarPresentation()
+        let rootView = DashboardRootView(
+            appState: controller.appState,
+            controller: controller,
+            sidebarPresentation: sidebarPresentation
+        )
+        let productionSidebar = rootView.sidebarView
+        #expect(!productionSidebar.isCollapsed)
+        #expect(SidebarToggleButton.accessibilityIdentifier == "dashboard.sidebar.toggle")
+
+        productionSidebar.onToggleCollapsed()
+        #expect(sidebarPresentation.isCollapsed)
+        #expect(rootView.sidebarView.isCollapsed)
+
         let renderer = ImageRenderer(
-            content: DashboardRootView(
-                appState: controller.appState,
-                controller: controller
-            )
-            .frame(
+            content: rootView.frame(
                 width: DashboardWindowLayout.minimumContentWidth,
                 height: DashboardWindowLayout.minimumContentHeight
             )

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -26,6 +26,33 @@ struct WindowAppearanceTests {
         #expect(DashboardWindowLayout.minimumContentHeight == 600)
     }
 
+    @Test("menu bar meeting placement uses the top-right of the active display")
+    func menuBarMeetingPlacementUsesTopRightOfDisplay() {
+        let visibleFrame = NSRect(x: -1920, y: 23, width: 1920, height: 1057)
+        let frame = DashboardWindowPlacement.compactTrailingFrame(
+            currentFrame: NSRect(x: 180, y: 140, width: 1120, height: 790),
+            visibleFrame: visibleFrame,
+            targetFrameWidth: DashboardWindowLayout.minimumContentWidth
+        )
+
+        #expect(frame.maxX == visibleFrame.maxX)
+        #expect(frame.maxY == visibleFrame.maxY)
+        #expect(frame.width == DashboardWindowLayout.minimumContentWidth)
+        #expect(frame.height == 790)
+    }
+
+    @Test("menu bar meeting placement stays inside a smaller display")
+    func menuBarMeetingPlacementClampsToDisplay() {
+        let visibleFrame = NSRect(x: 0, y: 25, width: 500, height: 575)
+        let frame = DashboardWindowPlacement.compactTrailingFrame(
+            currentFrame: NSRect(x: 100, y: 100, width: 1120, height: 790),
+            visibleFrame: visibleFrame,
+            targetFrameWidth: DashboardWindowLayout.minimumContentWidth
+        )
+
+        #expect(frame == visibleFrame)
+    }
+
     @Test("compact quick notes hides the sidebar only for an open meeting")
     func compactQuickNotesPresentationPolicy() {
         #expect(DashboardWindowLayout.usesCompactQuickNotes(width: 520, hasOpenMeeting: true))

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import MuesliCore
 import SwiftUI
 import Testing
 @testable import MuesliNativeApp
@@ -79,6 +80,97 @@ struct WindowAppearanceTests {
         #expect(selection.names == ["compact"])
     }
 
+    @Test("compact threshold preserves dashboard detail identity")
+    func compactThresholdPreservesDashboardDetailIdentity() async {
+        let presentation = DashboardLayoutPresentation()
+        let lifecycle = DashboardDetailLifecycleRecorder()
+        let hostingView = NSHostingView(
+            rootView: DashboardLayoutIdentityHarness(
+                presentation: presentation,
+                lifecycle: lifecycle
+            )
+        )
+        hostingView.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: 700, height: DashboardWindowLayout.minimumContentHeight)
+        )
+
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        #expect(lifecycle.appearanceCount == 1)
+        #expect(lifecycle.disappearanceCount == 0)
+
+        presentation.usesCompactQuickNotes = true
+        hostingView.frame.size.width = DashboardWindowLayout.minimumContentWidth
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        #expect(lifecycle.appearanceCount == 1)
+        #expect(lifecycle.disappearanceCount == 0)
+
+        presentation.usesCompactQuickNotes = false
+        hostingView.frame.size.width = 700
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        #expect(lifecycle.appearanceCount == 1)
+        #expect(lifecycle.disappearanceCount == 0)
+    }
+
+    @Test("dashboard renders the production compact meeting composition")
+    func dashboardRendersProductionCompactMeetingComposition() {
+        let supportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-window-test-\(UUID().uuidString)", isDirectory: true)
+        let databaseURL = supportDirectory.appendingPathComponent("muesli.db")
+        let store = DictationStore(databaseURL: databaseURL)
+        try? store.migrateIfNeeded()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store,
+            configStore: ConfigStore(supportDirectory: supportDirectory)
+        )
+        let meeting = MeetingRecord(
+            id: 42,
+            title: "Compact Header Test",
+            startTime: ISO8601DateFormatter().string(from: Date()),
+            durationSeconds: 0,
+            rawTranscript: "",
+            formattedNotes: "",
+            wordCount: 0,
+            folderID: nil,
+            status: .recording
+        )
+        controller.appState.selectedTab = .meetings
+        controller.appState.selectedMeetingID = meeting.id
+        controller.appState.selectedMeetingRecord = meeting
+        controller.appState.meetingsNavigationState = .document(meeting.id)
+
+        let renderer = ImageRenderer(
+            content: DashboardRootView(
+                appState: controller.appState,
+                controller: controller
+            )
+            .frame(
+                width: DashboardWindowLayout.minimumContentWidth,
+                height: DashboardWindowLayout.minimumContentHeight
+            )
+        )
+        renderer.proposedSize = ProposedViewSize(
+            width: DashboardWindowLayout.minimumContentWidth,
+            height: DashboardWindowLayout.minimumContentHeight
+        )
+
+        let image = renderer.nsImage
+        #expect(image != nil)
+        #expect(image?.size.width == DashboardWindowLayout.minimumContentWidth)
+        #expect(image?.size.height == DashboardWindowLayout.minimumContentHeight)
+    }
+
 }
 
 @MainActor
@@ -95,5 +187,43 @@ private struct LayoutSelectionProbe: View {
         Color.clear
             .frame(width: width, height: 40)
             .onAppear { recorder.names.append(name) }
+    }
+}
+
+@MainActor
+@Observable
+private final class DashboardLayoutPresentation {
+    var usesCompactQuickNotes = false
+}
+
+@MainActor
+private final class DashboardDetailLifecycleRecorder {
+    var appearanceCount = 0
+    var disappearanceCount = 0
+}
+
+private struct DashboardLayoutIdentityHarness: View {
+    let presentation: DashboardLayoutPresentation
+    let lifecycle: DashboardDetailLifecycleRecorder
+
+    var body: some View {
+        DashboardContentLayout(
+            usesCompactQuickNotes: presentation.usesCompactQuickNotes
+        ) {
+            Color.clear
+                .frame(minWidth: 240, idealWidth: 260, maxWidth: 300)
+        } detail: {
+            DashboardDetailIdentityProbe(lifecycle: lifecycle)
+        }
+    }
+}
+
+private struct DashboardDetailIdentityProbe: View {
+    let lifecycle: DashboardDetailLifecycleRecorder
+
+    var body: some View {
+        Color.clear
+            .onAppear { lifecycle.appearanceCount += 1 }
+            .onDisappear { lifecycle.disappearanceCount += 1 }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -107,6 +107,16 @@ struct WindowAppearanceTests {
         #expect(selection.names == ["compact"])
     }
 
+    @Test("compact formatting follows editable note-taking workflows")
+    func compactFormattingPolicy() {
+        #expect(CompactMeetingFormattingPolicy.showsFormattingControls(for: .recording, isPreparing: false))
+        #expect(!CompactMeetingFormattingPolicy.showsFormattingControls(for: .recording, isPreparing: true))
+        #expect(CompactMeetingFormattingPolicy.showsFormattingControls(for: .noteOnly, isPreparing: false))
+        #expect(!CompactMeetingFormattingPolicy.showsFormattingControls(for: .failed, isPreparing: false))
+        #expect(!CompactMeetingFormattingPolicy.showsFormattingControls(for: .processing, isPreparing: false))
+        #expect(!CompactMeetingFormattingPolicy.showsFormattingControls(for: .completed, isPreparing: false))
+    }
+
     @Test("compact threshold preserves dashboard detail identity")
     func compactThresholdPreservesDashboardDetailIdentity() async {
         let presentation = DashboardLayoutPresentation()
@@ -121,9 +131,16 @@ struct WindowAppearanceTests {
             origin: .zero,
             size: NSSize(width: 700, height: DashboardWindowLayout.minimumContentHeight)
         )
+        let window = NSWindow(
+            contentRect: hostingView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
 
         hostingView.layoutSubtreeIfNeeded()
-        await Task.yield()
+        #expect(await waitForAppearance(lifecycle))
         #expect(lifecycle.appearanceCount == 1)
         #expect(lifecycle.disappearanceCount == 0)
 
@@ -142,6 +159,17 @@ struct WindowAppearanceTests {
 
         #expect(lifecycle.appearanceCount == 1)
         #expect(lifecycle.disappearanceCount == 0)
+    }
+
+    private func waitForAppearance(_ lifecycle: DashboardDetailLifecycleRecorder) async -> Bool {
+        for _ in 0..<50 {
+            if lifecycle.appearanceCount > 0 {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return lifecycle.appearanceCount > 0
     }
 
     @Test("dashboard renders the production compact meeting composition")


### PR DESCRIPTION
## Summary

- replace the dashboard `NavigationSplitView` shell with `HSplitView` so only Muesli's custom sidebar toggle is shown
- reduce the dashboard minimum content width from 900 to 520 points for side-by-side call workflows
- make meeting title, recording actions, context controls, and mode picker adapt at narrow widths
- add production-composition and lifecycle coverage for the sidebar toggle, compact meeting layout, and resize state preservation
- open menu-bar meetings at compact width on the right edge of the active display

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/worktrees/f1d7-muesli/test` (1,951 tests across 173 suites passed)
- `./scripts/dev-test.sh --lane A --local-only` (signed DevA build succeeded; deep signature valid)
- live DevA verification: native titlebar sidebar toggle is absent, custom collapse/expand works, and the window resizes to the compact width

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex assisted with implementation, debugging, regression tests, and PR preparation. The resulting changes were reviewed and validated with the full Swift test suite and live DevA verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard windows now support a smaller minimum size and adapt the sidebar for compact layouts.
  * Meeting details switch to a streamlined quick-notes layout when space is limited.
  * Meeting headers provide clearer formatting, participant, and meeting controls.
  * Added clearer sidebar collapse and expand controls.
  * Meeting controls now provide improved access to participant actions and meeting disposal.

* **Bug Fixes**
  * Improved dashboard and recent-history window behavior at smaller sizes.
  * Prevented meeting header controls from becoming cramped or clipped.
  * Reduced unnecessary editor and toolbar clutter in compact layouts.
  * Improved accessibility labels and navigation for meeting controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
