### PR TITLE
Add What's New tour for Muesli 0.8.4

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -122,23 +122,29 @@ struct DashboardRootView: View {
                     .frame(width: proxy.size.width, height: proxy.size.height)
                     .zIndex(101)
                 } else if let tour = appState.activeFeatureTour,
-                   tour.steps.indices.contains(appState.featureTourStepIndex),
-                   let globalTargetFrame = featureTourTargetFrames[tour.steps[appState.featureTourStepIndex].target] {
+                          tour.steps.indices.contains(appState.featureTourStepIndex) {
+                    let step = tour.steps[appState.featureTourStepIndex]
                     let globalRootFrame = proxy.frame(in: .global)
-                    let targetFrame = globalTargetFrame.offsetBy(
-                        dx: -globalRootFrame.minX,
-                        dy: -globalRootFrame.minY
-                    )
-                    FeatureTourOverlay(
-                        tour: tour,
-                        stepIndex: appState.featureTourStepIndex,
-                        spotlightRect: targetFrame,
-                        containerSize: proxy.size,
-                        onBack: { controller.showPreviousFeatureTourStep() },
-                        onNext: { controller.showNextFeatureTourStep() },
-                        onDismiss: { controller.dismissFeatureTour() }
-                    )
-                    .zIndex(100)
+                    let targetFrame = step.target
+                        .flatMap { featureTourTargetFrames[$0] }
+                        .map {
+                            $0.offsetBy(
+                                dx: -globalRootFrame.minX,
+                                dy: -globalRootFrame.minY
+                            )
+                        }
+                    if step.target == nil || targetFrame != nil {
+                        FeatureTourOverlay(
+                            tour: tour,
+                            stepIndex: appState.featureTourStepIndex,
+                            spotlightRect: targetFrame,
+                            containerSize: proxy.size,
+                            onBack: { controller.showPreviousFeatureTourStep() },
+                            onNext: { controller.showNextFeatureTourStep() },
+                            onDismiss: { controller.dismissFeatureTour() }
+                        )
+                        .zIndex(100)
+                    }
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -52,18 +52,42 @@ enum FeatureTourTarget: String, Hashable {
     case streamingModels
     case experimentalModels
 
-    var modelsCategory: ModelsCategory? {
+    var navigationRoute: FeatureTourNavigationRoute {
         switch self {
-        case .modelLibrary, .appleSpeechCard, .parakeetFamilyCard:
-            return .dictation
+        case .quillSettings, .dictationProviderSetting, .cloudCleanupSetting:
+            return .settings(.dictation)
+        case .liveCaptionsSetting:
+            return .settings(.meetings)
+        case .timelineSidebar, .timelineFilters, .insightsEntry:
+            return .tab(.timeline)
+        case .timelineApplications:
+            return .timelineApplications
+        case .dictionarySuggestions:
+            return .tab(.dictionary)
+        case .meetingsSidebar:
+            return .meetingsBrowser
+        case .meetingPeople:
+            return .meetingPeople
+        case .modelLibrary, .appleSpeechCard, .parakeetFamilyCard, .experimentalModels:
+            return .models(.dictation)
         case .streamingModels:
-            return .streaming
-        case .experimentalModels:
-            return .dictation
-        case .quillSettings, .dictationProviderSetting, .timelineSidebar, .timelineApplications, .meetingPeople, .timelineFilters, .insightsEntry, .dictionarySuggestions, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
-            return nil
+            return .models(.streaming)
         }
     }
+
+    var modelsCategory: ModelsCategory? {
+        guard case let .models(category) = navigationRoute else { return nil }
+        return category
+    }
+}
+
+enum FeatureTourNavigationRoute: Equatable {
+    case settings(SettingsPane)
+    case tab(DashboardTab)
+    case models(ModelsCategory)
+    case timelineApplications
+    case meetingsBrowser
+    case meetingPeople
 }
 
 struct FeatureTourStep: Identifiable, Equatable {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -35,6 +35,9 @@ struct MarketingVersion: Comparable, Equatable {
 }
 
 enum FeatureTourTarget: String, Hashable {
+    case quillSettings
+    case dictationProviderSetting
+    case parakeetFamilyCard
     case timelineSidebar
     case timelineApplications
     case appleSpeechCard
@@ -51,13 +54,13 @@ enum FeatureTourTarget: String, Hashable {
 
     var modelsCategory: ModelsCategory? {
         switch self {
-        case .modelLibrary, .appleSpeechCard:
+        case .modelLibrary, .appleSpeechCard, .parakeetFamilyCard:
             return .dictation
         case .streamingModels:
             return .streaming
         case .experimentalModels:
             return .dictation
-        case .timelineSidebar, .timelineApplications, .meetingPeople, .timelineFilters, .insightsEntry, .dictionarySuggestions, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
+        case .quillSettings, .dictationProviderSetting, .timelineSidebar, .timelineApplications, .meetingPeople, .timelineFilters, .insightsEntry, .dictionarySuggestions, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
             return nil
         }
     }
@@ -69,7 +72,7 @@ struct FeatureTourStep: Identifiable, Equatable {
     let title: String
     let message: String
     let systemImage: String
-    let target: FeatureTourTarget
+    let target: FeatureTourTarget?
 }
 
 struct FeatureTour: Equatable {
@@ -96,63 +99,40 @@ extension AppState {
 
 enum FeatureTourCatalog {
     static var latest: FeatureTour {
-        latest(
-            includeApplicationFilter: false,
-            includeAppleSpeech: false,
-            includeMeetingPeople: false
-        )
-    }
-
-    static func latest(
-        includeApplicationFilter: Bool,
-        includeAppleSpeech: Bool,
-        includeMeetingPeople: Bool
-    ) -> FeatureTour {
-        var steps = [
+        FeatureTour(version: "0.8.4", steps: [
             FeatureTourStep(
-                id: "timeline",
-                eyebrow: "ONE TIMELINE",
-                title: "Dictations and meetings, together",
-                message: "Timeline puts your recent work in one chronological view. Open it from the sidebar whenever you want to retrace what you dictated or discussed.",
-                systemImage: "clock.arrow.circlepath",
-                target: .timelineSidebar
-            )
-        ]
-
-        if includeApplicationFilter {
-            steps.append(FeatureTourStep(
-                id: "timeline-apps",
-                eyebrow: "FILTER BY APP",
-                title: "Find dictations by destination app",
-                message: "Use Apps to narrow Timeline to dictations sent to a specific destination, such as Mail, Notes, or your browser.",
-                systemImage: "square.grid.2x2",
-                target: .timelineApplications
-            ))
-        }
-
-        if includeAppleSpeech {
-            steps.append(FeatureTourStep(
-                id: "apple-speech",
-                eyebrow: "ON-DEVICE SPEECH",
-                title: "Try Apple's native on-device speech model",
-                message: "On macOS 26, Apple Speech can transcribe without a separate model download. Use your system language or choose another supported language in Models.",
-                systemImage: "apple.logo",
-                target: .appleSpeechCard
-            ))
-        }
-
-        if includeMeetingPeople {
-            steps.append(FeatureTourStep(
-                id: "meeting-people",
-                eyebrow: "MEETING ATTENDEES",
-                title: "Meeting attendees are now available!",
-                message: "See organizers and attendees from calendar events, or add people from Apple Contacts directly to a meeting.",
-                systemImage: "person.2.fill",
-                target: .meetingPeople
-            ))
-        }
-
-        return FeatureTour(version: "0.8.2", steps: steps)
+                id: "quill",
+                eyebrow: "QUILL MODE",
+                title: "Edit text with your voice",
+                message: "Highlight text or place the cursor, activate Quill, and say what you want changed. Use a configured AI provider, or download Gemma 4 for a private, on-device workflow.",
+                systemImage: "pencil.and.scribble",
+                target: .quillSettings
+            ),
+            FeatureTourStep(
+                id: "apple-shortcuts",
+                eyebrow: "APPLE SHORTCUTS",
+                title: "Control Muesli with Command-Space",
+                message: "Press Command-Space, then type Start Dictation, Stop Dictation, Start Meeting, or Stop Meeting.",
+                systemImage: "command",
+                target: nil
+            ),
+            FeatureTourStep(
+                id: "hosted-dictation",
+                eyebrow: "OPTIONAL CLOUD TRANSCRIPTION",
+                title: "Choose OpenAI or OpenRouter for dictation",
+                message: "Use a hosted transcription model when you want one. Local remains the default, and audio is sent only after you choose OpenAI or OpenRouter as your provider.",
+                systemImage: "cloud",
+                target: .dictationProviderSetting
+            ),
+            FeatureTourStep(
+                id: "parakeet-unified",
+                eyebrow: "ON-DEVICE ENGLISH",
+                title: "Meet the best English STT model",
+                message: "Parakeet Unified balances speed and accuracy for fast, reliable English transcription on your Mac. For other languages, choose multilingual Parakeet v3.",
+                systemImage: "waveform",
+                target: .parakeetFamilyCard
+            ),
+        ])
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -84,9 +84,9 @@ struct FeatureTourCalloutLayout {
         switch target {
         case .timelineSidebar, .meetingsSidebar:
             return [.trailing, .leading, .below, .above]
-        case .timelineApplications, .appleSpeechCard, .meetingPeople, .timelineFilters, .modelLibrary, .insightsEntry, .liveCaptionsSetting:
+        case .timelineApplications, .appleSpeechCard, .meetingPeople, .timelineFilters, .modelLibrary, .insightsEntry, .liveCaptionsSetting, .dictationProviderSetting, .parakeetFamilyCard:
             return [.below, .above, .trailing, .leading]
-        case .dictionarySuggestions, .cloudCleanupSetting, .streamingModels, .experimentalModels:
+        case .dictionarySuggestions, .cloudCleanupSetting, .streamingModels, .experimentalModels, .quillSettings:
             return [.above, .below, .trailing, .leading]
         }
     }
@@ -175,7 +175,7 @@ extension View {
 struct FeatureTourOverlay: View {
     let tour: FeatureTour
     let stepIndex: Int
-    let spotlightRect: CGRect
+    let spotlightRect: CGRect?
     let containerSize: CGSize
     let onBack: () -> Void
     let onNext: () -> Void
@@ -188,8 +188,8 @@ struct FeatureTourOverlay: View {
         tour.steps[stepIndex]
     }
 
-    private var expandedSpotlight: CGRect {
-        spotlightRect.insetBy(dx: -8, dy: -8)
+    private var expandedSpotlight: CGRect? {
+        spotlightRect?.insetBy(dx: -8, dy: -8)
     }
 
     var body: some View {
@@ -197,19 +197,24 @@ struct FeatureTourOverlay: View {
             Color.clear
                 .contentShape(Rectangle())
 
-            FeatureTourDimmingShape(spotlight: expandedSpotlight, cornerRadius: 10)
-                .fill(
-                    Color.black.opacity(0.72),
-                    style: FillStyle(eoFill: true, antialiased: true)
-                )
-                .allowsHitTesting(false)
+            if let expandedSpotlight {
+                FeatureTourDimmingShape(spotlight: expandedSpotlight, cornerRadius: 10)
+                    .fill(
+                        Color.black.opacity(0.72),
+                        style: FillStyle(eoFill: true, antialiased: true)
+                    )
+                    .allowsHitTesting(false)
 
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(MuesliTheme.accent, lineWidth: 2)
-                .frame(width: expandedSpotlight.width, height: expandedSpotlight.height)
-                .position(x: expandedSpotlight.midX, y: expandedSpotlight.midY)
-                .shadow(color: MuesliTheme.accent.opacity(0.55), radius: 10)
-                .allowsHitTesting(false)
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(MuesliTheme.accent, lineWidth: 2)
+                    .frame(width: expandedSpotlight.width, height: expandedSpotlight.height)
+                    .position(x: expandedSpotlight.midX, y: expandedSpotlight.midY)
+                    .shadow(color: MuesliTheme.accent.opacity(0.55), radius: 10)
+                    .allowsHitTesting(false)
+            } else {
+                Color.black.opacity(0.72)
+                    .allowsHitTesting(false)
+            }
 
             callout
                 .frame(width: 380)
@@ -310,11 +315,14 @@ struct FeatureTourOverlay: View {
     }
 
     private var calloutPosition: CGPoint {
-        FeatureTourCalloutLayout.position(
+        guard let expandedSpotlight, let target = step.target else {
+            return CGPoint(x: containerSize.width / 2, y: containerSize.height / 2)
+        }
+        return FeatureTourCalloutLayout.position(
             spotlight: expandedSpotlight,
             containerSize: containerSize,
             calloutSize: calloutSize,
-            target: step.target
+            target: target
         )
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -205,6 +205,8 @@ struct ModelsView: View {
                 selection: $selectedParakeetModel,
                 options: BackendOption.parakeetFamily
             )
+            .id(FeatureTourTarget.parakeetFamilyCard.rawValue)
+            .featureTourTarget(.parakeetFamilyCard)
 
             familyCard(
                 title: "Whisper",
@@ -257,6 +259,9 @@ struct ModelsView: View {
             appState.selectedModelsCategory = .dictation
         case .appleSpeechCard:
             target = .appleSpeechCard
+            appState.selectedModelsCategory = .dictation
+        case .parakeetFamilyCard:
+            target = .parakeetFamilyCard
             appState.selectedModelsCategory = .dictation
         case .streamingModels:
             target = .streamingModels

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1206,25 +1206,21 @@ public final class MuesliController: NSObject {
             clearSearch()
         }
         guard let target = step.target else { return }
-        switch target {
-        case .quillSettings, .dictationProviderSetting:
-            appState.selectedSettingsPane = .dictation
+        switch target.navigationRoute {
+        case let .settings(pane):
+            appState.selectedSettingsPane = pane
             appState.selectedTab = .settings
-        case .timelineSidebar, .timelineFilters:
-            appState.selectedTab = .timeline
+        case let .tab(tab):
+            appState.selectedTab = tab
+        case let .models(category):
+            showModels(category: category)
         case .timelineApplications:
             guard (try? dictationStore.dictationTargetApplications().isEmpty) == false else {
                 completeFeatureTour()
                 return
             }
             appState.selectedTab = .timeline
-        case .appleSpeechCard, .modelLibrary:
-            showModels(category: .dictation)
-        case .insightsEntry:
-            appState.selectedTab = .timeline
-        case .dictionarySuggestions:
-            appState.selectedTab = .dictionary
-        case .meetingsSidebar:
+        case .meetingsBrowser:
             appState.selectedTab = .meetings
             appState.meetingsNavigationState = .browser
             appState.selectedMeetingID = nil
@@ -1235,16 +1231,6 @@ public final class MuesliController: NSObject {
                 return
             }
             showMeetingDocument(id: meetingID)
-        case .liveCaptionsSetting:
-            appState.selectedSettingsPane = .meetings
-            appState.selectedTab = .settings
-        case .cloudCleanupSetting:
-            appState.selectedSettingsPane = .dictation
-            appState.selectedTab = .settings
-        case .parakeetFamilyCard, .streamingModels, .experimentalModels:
-            if let category = target.modelsCategory {
-                showModels(category: category)
-            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1081,20 +1081,7 @@ public final class MuesliController: NSObject {
     }
 
     private func latestFeatureTour() -> FeatureTour {
-        let targetApplications = (try? dictationStore.dictationTargetApplications()) ?? []
-        let latestMeetingID = (try? dictationStore.recentMeetings(limit: 1))?.first?.id
-        return FeatureTourCatalog.latest(
-            includeApplicationFilter: !targetApplications.isEmpty,
-            includeAppleSpeech: Self.includesAppleSpeechInFeatureTour,
-            includeMeetingPeople: latestMeetingID != nil
-        )
-    }
-
-    private static var includesAppleSpeechInFeatureTour: Bool {
-        if #available(macOS 26.0, *) {
-            return AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem
-        }
-        return false
+        FeatureTourCatalog.latest
     }
 
     @discardableResult
@@ -1219,7 +1206,13 @@ public final class MuesliController: NSObject {
         if appState.isSearchActive {
             clearSearch()
         }
-        switch step.target {
+        guard let target = step.target else { return }
+        switch target {
+        case .quillSettings, .dictationProviderSetting:
+            appState.selectedSettingsPane = .dictation
+            appState.selectedTab = .settings
+        case .parakeetFamilyCard:
+            showModels(category: .dictation)
         case .timelineSidebar, .timelineFilters:
             appState.selectedTab = .timeline
         case .timelineApplications:
@@ -1252,7 +1245,7 @@ public final class MuesliController: NSObject {
             appState.selectedSettingsPane = .dictation
             appState.selectedTab = .settings
         case .streamingModels, .experimentalModels:
-            if let category = step.target.modelsCategory {
+            if let category = target.modelsCategory {
                 showModels(category: category)
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1103,7 +1103,6 @@ public final class MuesliController: NSObject {
             TelemetryDeck.signal("feature_walkthrough.invitation_shown", parameters: [
                 "version": tour.version,
                 "step_count": "\(tour.steps.count)",
-                "includes_apple_speech": "\(tour.steps.contains { $0.target == .appleSpeechCard })",
             ])
         })
         // The normal startup preload task continues while this invitation and
@@ -1211,8 +1210,6 @@ public final class MuesliController: NSObject {
         case .quillSettings, .dictationProviderSetting:
             appState.selectedSettingsPane = .dictation
             appState.selectedTab = .settings
-        case .parakeetFamilyCard:
-            showModels(category: .dictation)
         case .timelineSidebar, .timelineFilters:
             appState.selectedTab = .timeline
         case .timelineApplications:
@@ -1244,7 +1241,7 @@ public final class MuesliController: NSObject {
         case .cloudCleanupSetting:
             appState.selectedSettingsPane = .dictation
             appState.selectedTab = .settings
-        case .streamingModels, .experimentalModels:
+        case .parakeetFamilyCard, .streamingModels, .experimentalModels:
             if let category = target.modelsCategory {
                 showModels(category: category)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -592,7 +592,10 @@ struct SettingsView: View {
 
     private func scrollToFeatureTourTarget(_ target: FeatureTourTarget?, using proxy: ScrollViewProxy) {
         guard let target,
-              target == .liveCaptionsSetting || target == .cloudCleanupSetting else { return }
+              target == .liveCaptionsSetting
+                || target == .cloudCleanupSetting
+                || target == .dictationProviderSetting
+                || target == .quillSettings else { return }
         DispatchQueue.main.async {
             withAnimation(.easeInOut(duration: 0.2)) {
                 proxy.scrollTo(target.rawValue, anchor: .center)
@@ -1020,6 +1023,8 @@ struct SettingsView: View {
                     }
                 }
             }
+            .id(FeatureTourTarget.dictationProviderSetting.rawValue)
+            .featureTourTarget(.dictationProviderSetting)
             Divider().background(MuesliTheme.surfaceBorder)
             if appState.dictationProvider == .openAI {
                 openAIDictationSettingsRows
@@ -1430,6 +1435,8 @@ struct SettingsView: View {
                 }
             }
         }
+        .id(FeatureTourTarget.quillSettings.rawValue)
+        .featureTourTarget(.quillSettings)
     }
 
     private func selectQuilLocalModel(_ model: OnDeviceCleanupModel?) {

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -8,12 +8,12 @@ struct FeatureTourTests {
 
     @Test("marketing versions compare numeric components and ignore prerelease suffixes")
     func versionComparison() throws {
-        #expect(try #require(MarketingVersion("0.8.1")) < #require(MarketingVersion("0.8.2")))
-        #expect(try #require(MarketingVersion("0.8.2")) == #require(MarketingVersion("0.8.2.0")))
-        #expect(try #require(MarketingVersion("0.8.2-preprod.2")) == #require(MarketingVersion("0.8.2")))
+        #expect(try #require(MarketingVersion("0.8.3")) < #require(MarketingVersion("0.8.4")))
+        #expect(try #require(MarketingVersion("0.8.4")) == #require(MarketingVersion("0.8.4.0")))
+        #expect(try #require(MarketingVersion("0.8.4-preprod.2")) == #require(MarketingVersion("0.8.4")))
         #expect(MarketingVersion("not-a-version") == nil)
         #expect(MarketingVersion("999999999999999999999999.0") == nil)
-        #expect(tour.displayVersion == "0.8.2")
+        #expect(tour.displayVersion == "0.8.4")
         #expect(FeatureTour(version: "0.8.0", steps: []).displayVersion == "0.8")
     }
 
@@ -99,7 +99,7 @@ struct FeatureTourTests {
     @Test("existing users without legacy version markers see the first feature tour")
     func legacyUpgrade() {
         #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             previousVersion: nil,
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: true,
@@ -110,15 +110,15 @@ struct FeatureTourTests {
     @Test("fresh installs and pre-target versions do not see the tour")
     func ineligibleLaunches() {
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             previousVersion: nil,
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: false,
             tour: tour
         ))
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.1",
-            previousVersion: "0.8.0",
+            currentVersion: "0.8.3",
+            previousVersion: "0.8.2",
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: true,
             tour: tour
@@ -128,22 +128,22 @@ struct FeatureTourTests {
     @Test("upgrade crossing the target version presents once")
     func crossingTarget() {
         #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.2-preprod.2",
-            previousVersion: "0.8.1",
-            lastPresentedTourVersion: "0.8.0",
-            hasCompletedOnboarding: true,
-            tour: tour
-        ))
-        #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.2",
-            previousVersion: "0.8.1",
+            currentVersion: "0.8.4-preprod.2",
+            previousVersion: "0.8.3",
             lastPresentedTourVersion: "0.8.2",
             hasCompletedOnboarding: true,
             tour: tour
         ))
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.1",
-            previousVersion: "0.8.0",
+            currentVersion: "0.8.4",
+            previousVersion: "0.8.3",
+            lastPresentedTourVersion: "0.8.4",
+            hasCompletedOnboarding: true,
+            tour: tour
+        ))
+        #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.8.3",
+            previousVersion: "0.8.2",
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: true,
             tour: tour
@@ -153,71 +153,58 @@ struct FeatureTourTests {
     @Test("prerelease upgrade at the target version presents only to established users")
     func prereleaseUpgradeAtTargetVersion() {
         #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.2-preprod.2",
-            previousVersion: "0.8.2-preprod.1",
-            lastPresentedTourVersion: "0.8.0",
+            currentVersion: "0.8.4-preprod.2",
+            previousVersion: "0.8.4-preprod.1",
+            lastPresentedTourVersion: "0.8.2",
             hasCompletedOnboarding: true,
             tour: tour
         ))
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.2-preprod.2",
-            previousVersion: "0.8.2-preprod.2",
+            currentVersion: "0.8.4-preprod.2",
+            previousVersion: "0.8.4-preprod.2",
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: true,
             tour: tour
         ))
     }
 
-    @Test("0.8.2 catalog highlights a small set of unique product locations")
+    @Test("0.8.4 catalog highlights four major product additions")
     func catalogShape() {
-        #expect(tour.version == "0.8.2")
-        #expect(tour.steps.map(\.target) == [.timelineSidebar])
-
-        let fullTour = FeatureTourCatalog.latest(
-            includeApplicationFilter: true,
-            includeAppleSpeech: true,
-            includeMeetingPeople: true
-        )
-        #expect(fullTour.steps.count == 4)
-        #expect(Set(fullTour.steps.map(\.id)).count == fullTour.steps.count)
-        #expect(Set(fullTour.steps.map(\.target)).count == fullTour.steps.count)
-        #expect(fullTour.steps.map(\.target) == [
-            .timelineSidebar,
-            .timelineApplications,
-            .appleSpeechCard,
-            .meetingPeople,
+        #expect(tour.version == "0.8.4")
+        #expect(tour.steps.count == 4)
+        #expect(Set(tour.steps.map(\.id)).count == tour.steps.count)
+        #expect(Set(tour.steps.map(\.target)).count == tour.steps.count)
+        #expect(tour.steps.map(\.target) == [
+            .quillSettings,
+            nil,
+            .dictationProviderSetting,
+            .parakeetFamilyCard,
         ])
 
-        let timelineStep = fullTour.steps.first
-        #expect(timelineStep?.message.contains("sidebar") == true)
+        let quill = tour.steps[0]
+        #expect(quill.message.contains("Gemma 4"))
 
-        let applicationStep = fullTour.steps.first { $0.target == .timelineApplications }
-        #expect(applicationStep?.id == "timeline-apps")
-        #expect(applicationStep?.message.contains("Mail") == true)
+        let shortcuts = tour.steps[1]
+        #expect(shortcuts.target == nil)
+        #expect(shortcuts.message.contains("Command-Space"))
+        #expect(shortcuts.message.contains("Start Dictation"))
+        #expect(shortcuts.message.contains("Stop Dictation"))
+        #expect(shortcuts.message.contains("Start Meeting"))
+        #expect(shortcuts.message.contains("Stop Meeting"))
 
-        let appleSpeechStep = fullTour.steps.first { $0.target == .appleSpeechCard }
-        #expect(appleSpeechStep?.id == "apple-speech")
-        #expect(appleSpeechStep?.title == "Try Apple's native on-device speech model")
-        #expect(appleSpeechStep?.message.contains("macOS 26") == true)
-        #expect(appleSpeechStep?.target.modelsCategory == .dictation)
+        let hostedDictation = tour.steps[2]
+        #expect(hostedDictation.message.contains("Local remains the default"))
+        #expect(hostedDictation.message.contains("OpenAI or OpenRouter"))
+        #expect(!hostedDictation.message.localizedCaseInsensitiveContains("meeting"))
 
-        let peopleStep = fullTour.steps.last
-        #expect(peopleStep?.id == "meeting-people")
-        #expect(peopleStep?.title == "Meeting attendees are now available!")
-        #expect(peopleStep?.message.contains("Apple Contacts") == true)
-    }
-
-    @Test("catalog omits targets that cannot be rendered")
-    func unavailableTargetsAreOmitted() {
-        let tour = FeatureTourCatalog.latest(
-            includeApplicationFilter: false,
-            includeAppleSpeech: false,
-            includeMeetingPeople: false
-        )
-        #expect(tour.steps.map(\.target) == [.timelineSidebar])
-        #expect(!tour.steps.contains { $0.id == "timeline-apps" })
-        #expect(!tour.steps.contains { $0.id == "apple-speech" })
-        #expect(!tour.steps.contains { $0.id == "meeting-people" })
+        let parakeet = tour.steps[3]
+        #expect(parakeet.title == "Meet the best English STT model")
+        #expect(parakeet.message.contains("balances speed and accuracy"))
+        #expect(!parakeet.title.localizedCaseInsensitiveContains("our best"))
+        #expect(!parakeet.message.localizedCaseInsensitiveContains("our best"))
+        #expect(parakeet.message.contains("English"))
+        #expect(parakeet.message.contains("Parakeet v3"))
+        #expect(parakeet.target?.modelsCategory == .dictation)
     }
 
     @Test("store suppresses fresh installs and presents a legacy upgrade only once")
@@ -228,15 +215,15 @@ struct FeatureTourTests {
         let store = FeatureTourStore(defaults: defaults)
 
         #expect(store.automaticTour(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             hasCompletedOnboarding: false,
             canPresent: false
         ) == nil)
 
         // A fresh install that later completes onboarding is already recorded at
-        // 0.8.2 and does not receive a second onboarding-like flow.
+        // 0.8.4 and does not receive a second onboarding-like flow.
         #expect(store.automaticTour(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             hasCompletedOnboarding: true,
             canPresent: true
         ) == nil)
@@ -244,14 +231,14 @@ struct FeatureTourTests {
         defaults.removePersistentDomain(forName: suiteName)
         let legacyStore = FeatureTourStore(defaults: defaults)
         let presented = try #require(legacyStore.automaticTour(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             hasCompletedOnboarding: true,
             canPresent: true
         ))
         legacyStore.markOffered(presented)
 
         #expect(legacyStore.automaticTour(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             hasCompletedOnboarding: true,
             canPresent: true
         ) == nil)
@@ -265,12 +252,12 @@ struct FeatureTourTests {
         let store = FeatureTourStore(defaults: defaults)
 
         #expect(store.automaticTour(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             hasCompletedOnboarding: true,
             canPresent: false
         ) == nil)
         #expect(store.automaticTour(
-            currentVersion: "0.8.2",
+            currentVersion: "0.8.4",
             hasCompletedOnboarding: true,
             canPresent: true
         ) != nil)

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -207,6 +207,13 @@ struct FeatureTourTests {
         #expect(parakeet.target?.modelsCategory == .dictation)
     }
 
+    @Test("model feature-tour targets resolve routes without UI state")
+    func modelNavigationRoutes() {
+        #expect(FeatureTourTarget.parakeetFamilyCard.navigationRoute == .models(.dictation))
+        #expect(FeatureTourTarget.streamingModels.navigationRoute == .models(.streaming))
+        #expect(FeatureTourTarget.experimentalModels.navigationRoute == .models(.dictation))
+    }
+
     @Test("store suppresses fresh installs and presents a legacy upgrade only once")
     func storeLifecycle() throws {
         let suiteName = "FeatureTourTests.storeLifecycle.\(UUID().uuidString)"


### PR DESCRIPTION
## Summary

- Replace the previous feature-tour catalog with four major Muesli 0.8.4 highlights: Quill Mode, Apple Shortcuts, optional OpenAI/OpenRouter dictation, and Parakeet Unified.
- Spotlight relevant Settings and Models controls while presenting Apple Shortcuts as a centered, non-targeted Command-Space callout.
- Update tour eligibility and regression coverage for the 0.8.4 release boundary.

## Product details

- Quill directs users to configured AI providers or the private on-device Gemma 4 path.
- Apple Shortcuts describes Start Dictation, Stop Dictation, Start Meeting, and Stop Meeting without conflating App Intents with Muesli keyboard shortcuts.
- Hosted dictation remains explicitly optional and local-first.
- Parakeet Unified is presented as an English STT model balancing speed and accuracy, with Parakeet v3 retained for multilingual use.

## Validation

- FeatureTourTests: 11 tests passed on the latest head.
- Full native suite: 1,951 tests passed during branch validation.
- Changed-file classifier, CI shard assignment, update-flow verification with DMG skipped, and git diff checks passed.
- MuesliDevA rebuilt from this worktree using the shared build cache, produced App Intents metadata, passed deep signature verification, and launched successfully.

## Scope

- Sparkle appcast and release-note metadata are intentionally deferred to the follow-up release PR.
- Unrelated design-qa.md is not included.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid Signed-off-by trailer from its author under the Developer Certificate of Origin.
- [x] I created this contribution or otherwise have the right to submit it under Muesli's MIT License.
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex was used to analyze the 0.8.4 change set, implement and refine the SwiftUI feature tour, update tests, and address automated review feedback. The resulting changes were reviewed and validated locally on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the feature tour with guidance for Quill mode, Apple Shortcuts, hosted dictation, and Parakeet models.
  - Added guided navigation to dictation settings, cleanup options, and model library sections.
  - Added support for highlighting and scrolling to newly covered settings and model cards.

- **Bug Fixes**
  - Feature-tour steps without a specific screen target now display correctly with a centered informational overlay.
  - Improved spotlight and callout placement for additional tour steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->