### PR TITLE
Harden meeting mic recovery and reduce AEC CPU

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -17,37 +17,32 @@ protocol SystemAudioCapturing: AnyObject {
     func resume()
     func stop() -> URL?
 
-    /// Monotonic liveness counter advanced by every IO callback while
-    /// capturing. A stall while recording means the capture graph is dead even
-    /// if every API reports success. Backends without a heartbeat (the SCK
-    /// fallback) return 0 and are exempt from stall monitoring.
-    var captureHeartbeat: UInt64 { get }
-    /// Fired when a route-change rebuild fails permanently (all retries
-    /// exhausted). Capture is dead from this point unless a later route change
-    /// or recovery attempt succeeds.
+    /// Fired when a rebuild fails permanently (all retries exhausted). Capture
+    /// is dead from this point unless a later recovery attempt succeeds.
     var onCaptureFailure: ((Error) -> Void)? { get set }
-    /// True while a route-change/health rebuild (including retries) is in
-    /// flight; the watchdog treats this as a known-transient stall window.
+    /// True while a failure-recovery rebuild (including retries) is in flight.
     var isRebuilding: Bool { get }
-    /// Whether this backend advances captureHeartbeat during capture. Backends
-    /// without a heartbeat (SCK) must be excluded from stall monitoring.
-    var supportsHeartbeatMonitoring: Bool { get }
+    /// Positive recorder state set only after tap rebuild attempts exhaust.
+    /// A flat callback stream is deliberately not equivalent to failure:
+    /// healthy global process taps may quiesce while system output is silent.
+    var captureIsDead: Bool { get }
+    /// Whether this backend can report and recover explicit capture failures.
+    var supportsFailureRecovery: Bool { get }
     /// True while a route transition is still settling (recent notification).
-    /// The watchdog skips stall evaluation in this window: the old tap's
-    /// heartbeat stalling mid-transition is expected, not a dead graph.
+    /// Explicit failure recovery waits for this window to end so it does not
+    /// add more HAL work while the daemon is already reconfiguring routes.
     var isRouteSettling: Bool { get }
-    /// Health-driven rebuild: tear down and recreate the capture graph with
-    /// the same bounded retry policy used for route changes. Returns whether a
-    /// rebuild was actually started. Default no-op (false) for backends without
-    /// a rebuild path.
+    /// Explicit-failure recovery: tear down and recreate the capture graph with
+    /// bounded retries. Returns whether a rebuild was actually started. Default
+    /// no-op (false) for backends without a rebuild path.
     @discardableResult
     func rebuildForHealthRecovery(reason: String) -> Bool
 }
 
 extension SystemAudioCapturing {
-    var captureHeartbeat: UInt64 { 0 }
     var isRebuilding: Bool { false }
-    var supportsHeartbeatMonitoring: Bool { false }
+    var captureIsDead: Bool { false }
+    var supportsFailureRecovery: Bool { false }
     var isRouteSettling: Bool { false }
     var onCaptureFailure: ((Error) -> Void)? {
         get { nil }
@@ -56,12 +51,9 @@ extension SystemAudioCapturing {
     func rebuildForHealthRecovery(reason: String) -> Bool { false }
 }
 
-/// Bounded backoff for tap rebuilds after route-change/health failures.
-/// The observed failure mode (tapCreationFailed mid-route-churn) is transient
-/// but Bluetooth transitions take seconds to settle on the daemon, so the
-/// schedule is deliberately sparse; after the schedule is exhausted the
-/// failure is terminal for this episode (the watchdog's slower cooldown
-/// retries continue past it).
+/// Bounded backoff for tap rebuilds after explicit capture failures. CoreAudio
+/// transitions can take seconds to settle, so the schedule is deliberately
+/// sparse; after it exhausts, the watchdog's slower episode retries continue.
 struct RebuildRetryPolicy: Equatable {
     let delays: [TimeInterval]
 
@@ -98,18 +90,12 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
     private var activeCaptureGeneration: UInt64 = 0
     private let recordingFlag = ManagedAtomic(false)
     private let pausedFlag = ManagedAtomic(false)
-    /// Monotonic liveness counter: advanced by every IO callback while
-    /// capturing. A stall while isRecording && !isPaused means the capture
-    /// graph is dead even when every CoreAudio call reported success.
-    private let heartbeatCounter = ManagedAtomic<UInt64>(0)
-    var captureHeartbeat: UInt64 { heartbeatCounter.load(ordering: .relaxed) }
-    /// Fired when a route-change/health rebuild exhausts its retry budget and
+    /// Fired when a failure-recovery rebuild exhausts its retry budget and
     /// capture is dead. Bridged to episode telemetry by MeetingSession.
     var onCaptureFailure: ((Error) -> Void)?
-    /// True while a route-change/health rebuild (including retries) is in
-    /// flight; the watchdog treats this as a known-transient stall window.
+    /// True while a failure-recovery rebuild (including retries) is in flight.
     private(set) var isRebuilding = false
-    var supportsHeartbeatMonitoring: Bool { true }
+    var supportsFailureRecovery: Bool { true }
     /// Set when a rebuild exhausts its retry budget. The recorder deliberately
     /// keeps isRecording/onPCMSamples alive in that state so the watchdog can
     /// drive a later health-recovery rebuild — flipping them would make the
@@ -129,8 +115,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
     /// Read across queues via atomics; written from processingQueue.
     private let lastRouteChangeAtMs = ManagedAtomic<Int64>(0)
     /// True while a route transition is still settling (recent notification).
-    /// The watchdog skips stall evaluation in this window: the old tap's
-    /// heartbeat stalling mid-transition is expected, not a dead graph.
+    /// Explicit recovery is deferred until CoreAudio route churn settles.
     var isRouteSettling: Bool {
         let lastRoute = lastRouteChangeAtMs.load(ordering: .relaxed)
         guard lastRoute != 0 else { return false }
@@ -222,10 +207,11 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
             try createTapAndAggregateDevice()
             try setupAndStartAudioDevice()
             // The listener is record-only: it timestamps route transitions so
-            // the watchdog and mic recovery can defer stall diagnosis until
-            // the daemon settles. It never rebuilds — the tap is a global
-            // process mix and rides route changes untouched (proven live).
-            installDefaultOutputDeviceListener()
+            // explicit recovery can wait until the daemon settles. It never
+            // rebuilds — the global process tap rides route changes untouched.
+            processingQueue.sync {
+                installDefaultOutputDeviceListener()
+            }
             fputs("[system-audio] CoreAudio tap capture started\n", stderr)
         } catch {
             fputs("[system-audio] CoreAudio tap start failed: \(error)\n", stderr)
@@ -240,13 +226,13 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         isPaused = false
         captureDeadFlag.store(false, ordering: .releasing)
 
-        removeDefaultOutputDeviceListener()
         // A rebuild retry pending on processingQueue must not fire after
         // teardown (attemptTapRebuild also guards on isRecording, belt and
         // suspenders).
-        rebuildRetryWorkItem?.cancel()
-        isRebuilding = false
         processingQueue.sync {
+            removeDefaultOutputDeviceListener()
+            rebuildRetryWorkItem?.cancel()
+            isRebuilding = false
             teardownTapAndAudioDevice()
             onPCMSamples = nil
         }
@@ -381,7 +367,6 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         let generation = activeCaptureGeneration
         let block: AudioDeviceIOBlock = { [weak self] _, inputData, _, _, _ in
             guard let self, self.isRecording, !self.isPaused else { return }
-            self.heartbeatCounter.wrappingIncrement(ordering: .relaxed)
             self.diagnosticsLock.withLock { $0.callbackCount += 1 }
 
             let buffers = Self.copyAudioBuffers(from: inputData)
@@ -826,7 +811,8 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
 
         let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             self?.processingQueue.async { [weak self] in
-                self?.restartTapForDefaultOutputDeviceChange()
+                guard let self, self.isRecording else { return }
+                self.restartTapForDefaultOutputDeviceChange()
             }
         }
         defaultOutputDeviceListenerBlock = block
@@ -836,12 +822,15 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
-        AudioObjectAddPropertyListenerBlock(
+        let status = AudioObjectAddPropertyListenerBlock(
             AudioObjectID(kAudioObjectSystemObject),
             &address,
             nil,
             block
         )
+        if status != noErr {
+            fputs("[system-audio] failed to install default-output listener (status=\(status))\n", stderr)
+        }
     }
 
     private func removeDefaultOutputDeviceListener() {
@@ -887,9 +876,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
     /// mix — upstream of any output device — so route changes need NO rebuild
     /// (proven live: the tap rode an AirPods connect/case cycle untouched).
     /// The listener is retained only to timestamp transitions: the watchdog
-    /// and the mic recovery coordinator use it to defer stall diagnosis until
-    /// the daemon has settled, since the old tap's heartbeat gap during a
-    /// transition is expected, not a dead graph.
+    /// and mic recovery coordinator defer recovery until the daemon settles.
     func restartTapForDefaultOutputDeviceChange() {
         guard isRecording else { return }
         lastRouteChangeAtMs.store(Int64(Date().timeIntervalSince1970 * 1000), ordering: .relaxed)
@@ -946,10 +933,8 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         }
     }
 
-    /// Health-driven rebuild entry point (watchdog: IO heartbeat stalled while
-    /// recording). Shares the route-settle gate with the route-change path:
-    /// during a transition the old tap's stall is expected, so the rebuild
-    /// waits for the churn to settle instead of piling onto the daemon.
+    /// Explicit-failure recovery entry point. A confirmed failure waits for
+    /// route churn to settle instead of piling more work onto the daemon.
     @discardableResult
     func rebuildForHealthRecovery(reason: String) -> Bool {
         guard isRecording, !isPaused else { return false }
@@ -1044,8 +1029,10 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         isPaused = false
         onPCMSamples = nil
 
-        removeDefaultOutputDeviceListener()
-        teardownTapAndAudioDevice()
+        processingQueue.sync {
+            removeDefaultOutputDeviceListener()
+            teardownTapAndAudioDevice()
+        }
 
         if let file = outputFile {
             file.closeFile()

--- a/native/MuesliNative/Sources/MuesliNativeApp/LocalVQEProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/LocalVQEProcessor.swift
@@ -146,6 +146,8 @@ enum LocalVQELibraryLocator {
 }
 
 final class LocalVQEAudioProcessor: MeetingAecProcessor {
+    static let defaultThreadCount = 1
+
     let name = "localvqe"
     let modelPath: String
     let libraryPath: String
@@ -154,7 +156,10 @@ final class LocalVQEAudioProcessor: MeetingAecProcessor {
     private(set) var frameSize = 256
     private(set) var sampleRate = 16_000
 
-    static func load(downloadModelIfMissing: Bool = true, threads: Int = 2) async throws -> LocalVQEAudioProcessor {
+    static func load(
+        downloadModelIfMissing: Bool = true,
+        threads: Int = defaultThreadCount
+    ) async throws -> LocalVQEAudioProcessor {
         let modelURL = try await LocalVQEModelStore.resolveModelURL(downloadIfMissing: downloadModelIfMissing)
         let libraryURL = try LocalVQELibraryLocator.resolve()
         return try LocalVQEAudioProcessor(modelURL: modelURL, libraryURL: libraryURL, threads: threads)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecording.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecording.swift
@@ -58,19 +58,17 @@ protocol MeetingMicRecording: AnyObject {
     /// worker. Default no-op for recorders without retained worker state.
     func invalidateForTeardown()
 
-    /// Request a serialized same-route recovery: prepare a replacement capture
+    /// Request serialized health recovery: prepare an independent capture
     /// graph for the current input while the active graph keeps running, and
-    /// promote it only after it produces a non-empty buffer. Used when the
-    /// health tracker confirms a semantically dead graph (missing/zero
-    /// callbacks) that never raises an explicit CoreAudio error. Recorders
-    /// without a recovery primitive keep the default no-op (.unavailable).
+    /// promote it only after it satisfies the trigger's signal requirement.
+    /// Recorders without a recovery primitive keep the default no-op.
     @discardableResult
-    func requestSameRouteRecovery(reason: String) -> MeetingMicRecoveryRequestResult
+    func requestHealthRecovery(_ trigger: MeetingMicRecoveryTrigger) -> MeetingMicRecoveryRequestResult
 }
 
 extension MeetingMicRecording {
     func invalidateForTeardown() {}
-    func requestSameRouteRecovery(reason: String) -> MeetingMicRecoveryRequestResult { .unavailable }
+    func requestHealthRecovery(_ trigger: MeetingMicRecoveryTrigger) -> MeetingMicRecoveryRequestResult { .unavailable }
 }
 
 final class StreamingMeetingMicRecorderAdapter: MeetingMicRecording {
@@ -164,6 +162,10 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         let recorder: MeetingMicRecording
         let deviceID: AudioObjectID?
     }
+    private enum CandidateSignalRequirement {
+        case callback
+        case nonZeroSamples
+    }
     typealias RecorderFactory = () -> MeetingMicRecording
     typealias HandoffTimeoutScheduler = (TimeInterval, DispatchWorkItem) -> Void
 
@@ -215,6 +217,7 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         var lifecycleState: LifecycleState = .idle
         var active: Child?
         var pending: Child?
+        var pendingSignalRequirement: CandidateSignalRequirement = .callback
         var generation: UInt64 = 0
         var shouldRecoverOnResume = false
         var onRawPCMSamplesStorage: (([Int16]) -> Void)?
@@ -406,15 +409,15 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         return snapshot
     }
 
-    /// Health-driven recovery entry point: the current graph is confirmed
-    /// degraded (missing/zero mic callbacks while system audio is active) but
-    /// never threw, so force a same-route candidate through the existing
-    /// serialized handoff. Reports .busy when a handoff is already pending
+    /// Health-driven recovery entry point. For the system-default route, use
+    /// the other capture backend so a semantically dead AVAudioEngine graph is
+    /// not replaced by an identical graph. Explicitly selected devices stay
+    /// app-scoped. Reports .busy when a handoff is already pending
     /// (back-pressure: the in-flight handoff covers this episode), and
     /// .unavailable when the lifecycle is not in a recoverable state.
     @discardableResult
-    func requestSameRouteRecovery(reason: String) -> MeetingMicRecoveryRequestResult {
-        fputs("[meeting-mic] health-triggered same-route recovery requested: \(reason)\n", stderr)
+    func requestHealthRecovery(_ trigger: MeetingMicRecoveryTrigger) -> MeetingMicRecoveryRequestResult {
+        fputs("[meeting-mic] health-triggered recovery requested: \(trigger.reason)\n", stderr)
         return lifecycleQueue.sync { [weak self] in
             guard let self else { return .unavailable }
             if let availability = self.lock.withLock({ state -> MeetingMicRecoveryRequestResult? in
@@ -424,7 +427,11 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
             }) {
                 return availability
             }
-            return self.beginHandoffIfNeeded(force: true) ? .initiated : .unavailable
+            return self.beginHandoffIfNeeded(
+                force: true,
+                alternateDefaultBackend: true,
+                signalRequirement: trigger.requiresNonZeroSamples ? .nonZeroSamples : .callback
+            ) ? .initiated : .unavailable
         }
     }
 
@@ -454,16 +461,28 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
 
     /// Returns true when a candidate handoff was actually started.
     @discardableResult
-    private func beginHandoffIfNeeded(force: Bool = false) -> Bool {
-        let request = lock.withLock { state -> (AudioObjectID, UInt64)? in
+    private func beginHandoffIfNeeded(
+        force: Bool = false,
+        alternateDefaultBackend: Bool = false,
+        signalRequirement: CandidateSignalRequirement = .callback
+    ) -> Bool {
+        let request = lock.withLock { state -> (AudioObjectID, UInt64, ActiveRecorderKind)? in
             guard state.lifecycleState == .running || state.lifecycleState == .failed,
                   state.pending == nil,
                   force || state.active?.deviceID != state.preferredInputDeviceIDStorage else { return nil }
-            return (state.preferredInputDeviceIDStorage ?? kAudioObjectUnknown, state.generation)
+            let deviceID = state.preferredInputDeviceIDStorage
+            let candidateKind: ActiveRecorderKind
+            if alternateDefaultBackend, deviceID == nil {
+                candidateKind = state.active?.kind == .appScoped ? .systemDefault : .appScoped
+            } else {
+                candidateKind = Self.kind(for: deviceID)
+            }
+            state.pendingSignalRequirement = signalRequirement
+            return (deviceID ?? kAudioObjectUnknown, state.generation, candidateKind)
         }
-        guard let (encodedDeviceID, generation) = request else { return false }
+        guard let (encodedDeviceID, generation, candidateKind) = request else { return false }
         let deviceID = encodedDeviceID == kAudioObjectUnknown ? nil : encodedDeviceID
-        let candidate = makeChild(deviceID: deviceID, generation: generation)
+        let candidate = makeChild(deviceID: deviceID, generation: generation, kind: candidateKind)
         lock.withLock { $0.pending = candidate }
 
         // Schedule the wall-clock deadline before starting the graph. CoreAudio
@@ -515,8 +534,12 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         }
     }
 
-    private func makeChild(deviceID: AudioObjectID?, generation: UInt64) -> Child {
-        let kind = Self.kind(for: deviceID)
+    private func makeChild(
+        deviceID: AudioObjectID?,
+        generation: UInt64,
+        kind: ActiveRecorderKind? = nil
+    ) -> Child {
+        let kind = kind ?? Self.kind(for: deviceID)
         let recorder: MeetingMicRecording
         switch kind {
         case .systemDefault:
@@ -591,6 +614,10 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
 
     private func completePendingHandoff(childID: UUID, generation: UInt64, firstSamples: [Int16]) {
         guard !firstSamples.isEmpty else { return }
+        let signalRequirement = lock.withLock { $0.pendingSignalRequirement }
+        if signalRequirement == .nonZeroSamples, !firstSamples.contains(where: { $0 != 0 }) {
+            return
+        }
         let transition = lock.withLock { state -> (completed: Bool, old: Child?) in
             guard state.generation == generation,
                   state.lifecycleState == .running || state.lifecycleState == .failed,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
@@ -17,6 +17,11 @@ enum MeetingMicHandoffOutcome: String, Equatable {
     case failed = "failed"
 }
 
+struct MeetingMicRecoveryTrigger: Equatable {
+    let reason: String
+    let requiresNonZeroSamples: Bool
+}
+
 /// Privacy-safe coarse context attached to episode telemetry: no audio, device
 /// names, or user content — only enum/classification-level fields.
 struct MeetingMicEpisodeContext: Equatable {
@@ -117,7 +122,7 @@ final class MeetingMicRecoveryCoordinator {
     /// the attempt is refunded but the cooldown timestamp is retained so
     /// refusal cannot churn per-snapshot. `.unavailable` keeps the attempt
     /// counted so the episode cap bounds total requests.
-    var recoveryRequest: (String) -> MeetingMicRecoveryRequestResult = { _ in .unavailable }
+    var recoveryRequest: (MeetingMicRecoveryTrigger) -> MeetingMicRecoveryRequestResult = { _ in .unavailable }
     /// Called after the coordinator's lock is released.
     var onEpisodeEvent: ((MeetingMicHealthEpisodeEvent) -> Void)?
     /// Coarse, privacy-safe context for telemetry; evaluated at event time.
@@ -452,7 +457,10 @@ final class MeetingMicRecoveryCoordinator {
         }
         lock.unlock()
 
-        let result = recoveryRequest(reservation.reason)
+        let result = recoveryRequest(MeetingMicRecoveryTrigger(
+            reason: reservation.reason,
+            requiresNonZeroSamples: active.initialState == .micAllZeroWhileSystemActive
+        ))
 
         lock.lock()
         if var active = episode, active.pendingRecoveryToken == reservation.token {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
@@ -117,6 +117,16 @@ final class MeetingMicRecoveryCoordinator {
         var healthySince: Date?
     }
 
+    /// Recovery policy captured from the live degradation state at the moment
+    /// an attempt is reserved. An episode may flap between missing callbacks
+    /// and all-zero samples, so its initial state is not authoritative for a
+    /// later retry.
+    private struct RecoveryReservation {
+        let token: UUID
+        let reason: String
+        let requiresNonZeroSamples: Bool
+    }
+
     /// Called after the coordinator's lock is released when a recovery attempt
     /// should start. `.busy` (a handoff is already pending) is back-pressure:
     /// the attempt is refunded but the cooldown timestamp is retained so
@@ -176,7 +186,7 @@ final class MeetingMicRecoveryCoordinator {
             let duration: TimeInterval
         }
         var pendingEvent: PendingEvent?
-        var recoveryToDispatch: (token: UUID, reason: String)?
+        var recoveryToDispatch: RecoveryReservation?
 
         // The mute read (HAL, can block) runs outside the lock, and only when
         // it can change behavior: an open episode never consults it, and
@@ -220,7 +230,11 @@ final class MeetingMicRecoveryCoordinator {
                     active.flapCount += 1
                 }
                 active.healthySince = nil
-                if let reservation = reserveRecoveryIfDueLocked(&active, at: timestamp) {
+                if let reservation = reserveRecoveryIfDueLocked(
+                    &active,
+                    at: timestamp,
+                    requiresNonZeroSamples: currentState == .micAllZeroWhileSystemActive
+                ) {
                     recoveryToDispatch = reservation
                 }
                 episode = active
@@ -262,7 +276,11 @@ final class MeetingMicRecoveryCoordinator {
                     pendingEvent = PendingEvent(kind: .degraded, episode: newEpisode, duration: 0)
                     // The tracker already confirmed degradation for ~3s;
                     // attempt recovery immediately at episode start.
-                    recoveryToDispatch = reserveRecoveryLocked(&newEpisode, at: timestamp)
+                    recoveryToDispatch = reserveRecoveryLocked(
+                        &newEpisode,
+                        at: timestamp,
+                        requiresNonZeroSamples: currentState == .micAllZeroWhileSystemActive
+                    )
                     episode = newEpisode
                 }
             case (false, true):
@@ -313,7 +331,7 @@ final class MeetingMicRecoveryCoordinator {
     /// meeting has finished.
     func noteExternalDegradation(reason: String) {
         var pendingEpisode: Episode?
-        var recoveryToDispatch: (token: UUID, reason: String)?
+        var recoveryToDispatch: RecoveryReservation?
 
         lock.lock()
         if !finished, episode == nil {
@@ -332,7 +350,11 @@ final class MeetingMicRecoveryCoordinator {
                 healthySince: nil
             )
             pendingEpisode = newEpisode
-            recoveryToDispatch = reserveRecoveryLocked(&newEpisode, at: timestamp)
+            recoveryToDispatch = reserveRecoveryLocked(
+                &newEpisode,
+                at: timestamp,
+                requiresNonZeroSamples: false
+            )
             episode = newEpisode
         }
         let dispatch = recoveryToDispatch
@@ -415,33 +437,43 @@ final class MeetingMicRecoveryCoordinator {
     /// token stored on the episode; the token is revalidated at dispatch.
     private func reserveRecoveryIfDueLocked(
         _ active: inout Episode,
-        at timestamp: Date
-    ) -> (token: UUID, reason: String)? {
+        at timestamp: Date,
+        requiresNonZeroSamples: Bool
+    ) -> RecoveryReservation? {
         if let lastAttemptAt = active.lastAttemptAt,
            timestamp.timeIntervalSince(lastAttemptAt) < policy.attemptCooldown {
             return nil
         }
-        return reserveRecoveryLocked(&active, at: timestamp)
+        return reserveRecoveryLocked(
+            &active,
+            at: timestamp,
+            requiresNonZeroSamples: requiresNonZeroSamples
+        )
     }
 
     private func reserveRecoveryLocked(
         _ active: inout Episode,
-        at timestamp: Date
-    ) -> (token: UUID, reason: String)? {
+        at timestamp: Date,
+        requiresNonZeroSamples: Bool
+    ) -> RecoveryReservation? {
         guard active.recoveryAttempts < policy.maxAttemptsPerEpisode,
               active.pendingRecoveryToken == nil else { return nil }
         let token = UUID()
         active.recoveryAttempts += 1
         active.lastAttemptAt = timestamp
         active.pendingRecoveryToken = token
-        return (token, active.initialReason)
+        return RecoveryReservation(
+            token: token,
+            reason: active.initialReason,
+            requiresNonZeroSamples: requiresNonZeroSamples
+        )
     }
 
     /// Runs outside the lock. Revalidates the reservation token immediately
     /// before dispatch: an episode that closed or moved on invalidates it.
     /// Defers while a route transition is settling — a handoff mid-churn
     /// reliably fails its first-buffer window.
-    private func dispatchRecovery(_ reservation: (token: UUID, reason: String)) {
+    private func dispatchRecovery(_ reservation: RecoveryReservation) {
         if isRouteSettling() {
             scheduleAfter(1) { [weak self] in
                 self?.dispatchRecovery(reservation)
@@ -459,7 +491,7 @@ final class MeetingMicRecoveryCoordinator {
 
         let result = recoveryRequest(MeetingMicRecoveryTrigger(
             reason: reservation.reason,
-            requiresNonZeroSamples: active.initialState == .micAllZeroWhileSystemActive
+            requiresNonZeroSamples: reservation.requiresNonZeroSamples
         ))
 
         lock.lock()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -379,10 +379,10 @@ private actor MeetingDetectionService {
     private var resetTask: Task<Void, Never>?
     private var latestLifecycleGeneration = 0
     private var isStarted = false
-    // Manual recordings may need one or more discovery passes before a real
-    // media session is found. Once associated, continuing to enumerate every
-    // CoreAudio process only adds daemon load while capture is already owned.
-    private var hasAssociatedActiveRecording = false
+    // Once Muesli owns an active meeting capture, continuing to enumerate every
+    // CoreAudio process only adds daemon load. Browser discovery remains active,
+    // so manual recordings can still be associated without polling CoreAudio.
+    private var recordingAttributionGate = MeetingRecordingAttributionGate()
 
     init(
         contextProvider: @escaping @MainActor (Date) -> MeetingDetectionEvaluationContext,
@@ -425,7 +425,7 @@ private actor MeetingDetectionService {
         pendingEvaluationTrigger = nil
         currentFallbackInterval = nil
         signalRefreshState = MeetingSignalRefreshState()
-        hasAssociatedActiveRecording = false
+        recordingAttributionGate.reset()
         let resetTask = Task { [audioAttributionService, mediaSessionTracker] in
             await audioAttributionService.reset()
             await mediaSessionTracker.reset()
@@ -459,10 +459,14 @@ private actor MeetingDetectionService {
 
     func suppressWhileActive() {
         globalSuppressUntil = .distantFuture
+        if recordingAttributionGate.markCaptureOwned() {
+            log("audio_attribution_suppressed reason=muesli_recording_active")
+        }
         dismissVisiblePromptForSuppression()
     }
 
     func resumeAfterCooldown() {
+        recordingAttributionGate.reset()
         globalSuppressUntil = Date().addingTimeInterval(15)
         scheduleEvaluation(.promptStateChanged)
     }
@@ -530,9 +534,10 @@ private actor MeetingDetectionService {
         let now = Date()
         let context = await contextProvider(now)
         guard isStarted else { return }
-        if !context.isRecording && !context.isStartingRecording {
-            hasAssociatedActiveRecording = false
-        }
+        recordingAttributionGate.synchronize(
+            isRecording: context.isRecording,
+            isStartingRecording: context.isStartingRecording
+        )
         guard context.detectionEnabled else {
             dismissVisiblePromptForSuppression()
             return
@@ -551,7 +556,9 @@ private actor MeetingDetectionService {
         let refreshDecision = refreshPolicy.decision(
             trigger: trigger,
             state: signalRefreshState,
-            suppressAudioAttribution: context.isRecording && hasAssociatedActiveRecording,
+            suppressAudioAttribution: recordingAttributionGate.shouldSuppress(
+                isRecording: context.isRecording
+            ),
             now: now
         )
         async let audioAttributionResult = audioAttributionService.activeInputProcesses(
@@ -836,7 +843,7 @@ private actor MeetingDetectionService {
     private func associateActiveRecording(with candidate: MeetingCandidate) {
         let inserted = promptState.markRecordingStarted(candidate)
         guard inserted || promptState.isRecordingStartedSuppressed(candidate) else { return }
-        hasAssociatedActiveRecording = true
+        recordingAttributionGate.markCaptureOwned()
         if inserted {
             log("recording_session_consumed id=\(candidate.id)")
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -379,6 +379,10 @@ private actor MeetingDetectionService {
     private var resetTask: Task<Void, Never>?
     private var latestLifecycleGeneration = 0
     private var isStarted = false
+    // Manual recordings may need one or more discovery passes before a real
+    // media session is found. Once associated, continuing to enumerate every
+    // CoreAudio process only adds daemon load while capture is already owned.
+    private var hasAssociatedActiveRecording = false
 
     init(
         contextProvider: @escaping @MainActor (Date) -> MeetingDetectionEvaluationContext,
@@ -421,6 +425,7 @@ private actor MeetingDetectionService {
         pendingEvaluationTrigger = nil
         currentFallbackInterval = nil
         signalRefreshState = MeetingSignalRefreshState()
+        hasAssociatedActiveRecording = false
         let resetTask = Task { [audioAttributionService, mediaSessionTracker] in
             await audioAttributionService.reset()
             await mediaSessionTracker.reset()
@@ -487,6 +492,7 @@ private actor MeetingDetectionService {
     func markRecordingStarted(_ candidate: MeetingCandidate?) {
         if let candidate {
             log("recording_started id=\(candidate.id)")
+            associateActiveRecording(with: candidate)
         } else {
             log("recording_started")
         }
@@ -524,6 +530,9 @@ private actor MeetingDetectionService {
         let now = Date()
         let context = await contextProvider(now)
         guard isStarted else { return }
+        if !context.isRecording && !context.isStartingRecording {
+            hasAssociatedActiveRecording = false
+        }
         guard context.detectionEnabled else {
             dismissVisiblePromptForSuppression()
             return
@@ -539,7 +548,12 @@ private actor MeetingDetectionService {
         signalRefreshState.hasCalendarEvent = context.calendarEvent != nil
         signalRefreshState.hasPromptVisible = context.promptVisibility.isVisible
 
-        let refreshDecision = refreshPolicy.decision(trigger: trigger, state: signalRefreshState, now: now)
+        let refreshDecision = refreshPolicy.decision(
+            trigger: trigger,
+            state: signalRefreshState,
+            suppressAudioAttribution: context.isRecording && hasAssociatedActiveRecording,
+            now: now
+        )
         async let audioAttributionResult = audioAttributionService.activeInputProcesses(
             refresh: refreshDecision.refreshAudioAttribution
         )
@@ -605,9 +619,7 @@ private actor MeetingDetectionService {
             // Consume a media-backed session only after capture has really started,
             // so failed startups remain retryable and recurring URL-only candidates
             // are not suppressed for the lifetime of the app.
-            if promptState.markRecordingStarted(unmutedActivityCandidate) {
-                log("recording_session_consumed id=\(unmutedActivityCandidate.id)")
-            }
+            associateActiveRecording(with: unmutedActivityCandidate)
         }
         emitActivityUpdate(unmutedActivityCandidate)
         let candidate = isGloballySuppressed(now: now) ? nil : unmutedActivityCandidate
@@ -819,6 +831,15 @@ private actor MeetingDetectionService {
             now: now,
             resolvedCandidate: candidate
         )
+    }
+
+    private func associateActiveRecording(with candidate: MeetingCandidate) {
+        let inserted = promptState.markRecordingStarted(candidate)
+        guard inserted || promptState.isRecordingStartedSuppressed(candidate) else { return }
+        hasAssociatedActiveRecording = true
+        if inserted {
+            log("recording_session_consumed id=\(candidate.id)")
+        }
     }
 
     private func logEvaluation(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
@@ -157,6 +157,10 @@ final class MeetingPromptStateMachine {
         return inserted
     }
 
+    func isRecordingStartedSuppressed(_ candidate: MeetingCandidate) -> Bool {
+        recordingStartedSuppressionIDs.contains(candidate.suppressionID)
+    }
+
     func markClosed(_ candidate: MeetingCandidate) {
         if visiblePromptID == candidate.id { visiblePromptID = nil }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -269,9 +269,9 @@ final class MeetingSession {
         } else {
             self.systemAudioRecorder = SystemAudioRecorder()
         }
-        micRecoveryCoordinator.recoveryRequest = { [weak meetingMicRecorder] reason in
+        micRecoveryCoordinator.recoveryRequest = { [weak meetingMicRecorder] trigger in
             guard let meetingMicRecorder else { return .unavailable }
-            return meetingMicRecorder.requestSameRouteRecovery(reason: reason)
+            return meetingMicRecorder.requestHealthRecovery(trigger)
         }
         // Recovery handoffs mid-transition reliably fail their first-buffer
         // window; defer them until the daemon settles (same signal the tap

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -204,9 +204,9 @@ final class MeetingSession {
     /// Fired at most once per meeting when confirmed degradation is classified
     /// as user-muted input (no recovery episode is opened in that case).
     var onMicHealthUserMuted: (() -> Void)?
-    /// Episode-level system-audio (tap) health events: degraded when the IO
-    /// heartbeat stalls or a rebuild fails terminally, recovered when capture
-    /// resumes, unrecovered if the meeting ends dead.
+    /// Episode-level system-audio (tap) health events: degraded after positive
+    /// recorder failure evidence, recovered when capture resumes, unrecovered
+    /// if the meeting ends dead.
     var onSystemAudioHealthEpisode: ((MeetingSystemAudioHealthEvent) -> Void)?
     var manualNotesProvider: (() async -> String?)?
     var liveTitleProvider: (() async -> String?)?
@@ -301,12 +301,12 @@ final class MeetingSession {
         meetingMicRecorder.onHandoffOutcome = { [weak micRecoveryCoordinator] outcome in
             micRecoveryCoordinator?.noteHandoffOutcome(outcome)
         }
-        systemAudioWatchdog.captureHeartbeat = { [weak systemAudioRecorder] in
-            systemAudioRecorder?.captureHeartbeat ?? 0
-        }
         systemAudioWatchdog.isCaptureActive = { [weak systemAudioRecorder] in
             guard let recorder = systemAudioRecorder else { return false }
-            return recorder.isRecording && !recorder.isPaused && !recorder.isRebuilding
+            return recorder.isRecording
+                && !recorder.isPaused
+                && !recorder.isRebuilding
+                && !recorder.captureIsDead
         }
         systemAudioWatchdog.isPaused = { [weak systemAudioRecorder] in
             systemAudioRecorder?.isPaused ?? false
@@ -1143,10 +1143,9 @@ final class MeetingSession {
     }
 
     private func startSystemAudioWatchdog() {
-        // Only heartbeat-capable backends can be stall-monitored: the SCK
-        // fallback reports heartbeat 0 permanently and would false-fire
-        // degraded episodes every meeting.
-        guard systemAudioRecorder.supportsHeartbeatMonitoring else { return }
+        // The timer is inert until the recorder reports explicit failure. It
+        // never probes CoreAudio process state or interprets silence as death.
+        guard systemAudioRecorder.supportsFailureRecovery else { return }
         stopSystemAudioWatchdogTimer()
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue(label: "MuesliNative.MeetingSession.systemAudioWatchdog"))
         timer.schedule(deadline: .now() + 1, repeating: 1)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
@@ -73,6 +73,7 @@ struct MeetingSignalRefreshPolicy {
     func decision(
         trigger: MeetingDetectionTrigger,
         state: MeetingSignalRefreshState,
+        suppressAudioAttribution: Bool = false,
         now: Date
     ) -> MeetingSignalRefreshDecision {
         let suspicious = isSuspicious(trigger: trigger, state: state, now: now)
@@ -81,7 +82,8 @@ struct MeetingSignalRefreshPolicy {
 
         return MeetingSignalRefreshDecision(
             mode: mode,
-            refreshAudioAttribution: shouldRefreshAudioAttribution(trigger: trigger, state: state, mode: mode, now: now),
+            refreshAudioAttribution: !suppressAudioAttribution
+                && shouldRefreshAudioAttribution(trigger: trigger, state: state, mode: mode, now: now),
             refreshBrowserMeetings: shouldRefreshBrowserMeetings(trigger: trigger, state: state, mode: mode, now: now),
             fallbackInterval: fallbackInterval
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
@@ -37,6 +37,31 @@ struct MeetingSignalRefreshDecision: Equatable {
     let fallbackInterval: TimeInterval
 }
 
+struct MeetingRecordingAttributionGate: Equatable {
+    private(set) var ownsActiveCapture = false
+
+    @discardableResult
+    mutating func markCaptureOwned() -> Bool {
+        guard !ownsActiveCapture else { return false }
+        ownsActiveCapture = true
+        return true
+    }
+
+    mutating func synchronize(isRecording: Bool, isStartingRecording: Bool) {
+        if !isRecording && !isStartingRecording {
+            reset()
+        }
+    }
+
+    mutating func reset() {
+        ownsActiveCapture = false
+    }
+
+    func shouldSuppress(isRecording: Bool) -> Bool {
+        isRecording && ownsActiveCapture
+    }
+}
+
 struct MeetingSignalRefreshPolicy {
     let idleFallbackInterval: TimeInterval
     let suspiciousFallbackInterval: TimeInterval

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSystemAudioWatchdog.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSystemAudioWatchdog.swift
@@ -13,24 +13,17 @@ struct MeetingSystemAudioHealthEvent: Equatable {
     let recoveryAttempts: Int
 }
 
-/// Watches the system-audio tap's IO heartbeat while a meeting records and
-/// drives bounded rebuilds when capture dies without an error — the observed
-/// production failure was a route-change rebuild that failed once and stayed
-/// dead for the rest of the meeting, silently losing the remote side.
-///
-/// Liveness is callback delivery, not content: the tap's IO callback fires
-/// continuously while the graph runs, even when the room is quiet, so a stall
-/// means a dead pipeline. Same role as MeetingMicRecoveryCoordinator, but the
-/// tap has binary health and no mute classification (output volume does not
-/// affect process-tap content).
+/// Manages explicit system-audio capture failure episodes and bounded recovery.
+/// A flat IO callback stream is intentionally not treated as failure: healthy
+/// global process taps may quiesce while system output is silent, and querying
+/// every CoreAudio process to disambiguate that state can itself contend with
+/// the daemon. Recovery therefore begins only after the recorder reports
+/// positive failure evidence (for example, exhausted HAL rebuild attempts).
 ///
 /// All callbacks fire after internal state commits; injected closures run on
 /// the caller's tick context. Time and cadence are injected for tests.
 final class MeetingSystemAudioWatchdog {
     struct Policy: Equatable {
-        /// Seconds without an IO callback (while recording and not paused)
-        /// before the tap is declared dead.
-        var stallThreshold: TimeInterval = 2
         /// Sustained alive ticks required to close an episode as recovered.
         var recoveredAfterTicks: Int = 2
         /// Minimum gap between recovery rebuild attempts.
@@ -50,16 +43,14 @@ final class MeetingSystemAudioWatchdog {
         var micBridgeFired: Bool
     }
 
-    /// Evaluated per tick: the recorder's monotonic IO heartbeat and whether
-    /// capture is active (recording, no rebuild in flight).
-    var captureHeartbeat: () -> UInt64 = { 0 }
+    /// Evaluated per tick after an explicit failure episode opens. True means
+    /// the recorder is running, not rebuilding, and has not marked its capture
+    /// graph dead.
     var isCaptureActive: () -> Bool = { false }
     /// While true (meeting paused), ticks are ignored entirely.
     var isPaused: () -> Bool = { false }
-    /// While true (a route transition is still settling), ticks are ignored:
-    /// the old tap's heartbeat stalling mid-transition is expected, and firing
-    /// a recovery rebuild into daemon churn reliably fails and amplifies it
-    /// (measured live on macOS 26.5.2).
+    /// While true (a route transition is still settling), retries are paused
+    /// so confirmed recovery does not add HAL work during daemon churn.
     var isRouteSettling: () -> Bool = { false }
     /// The mic tracker's last raw-mic callback time, for the blindness bridge.
     var lastMicCallbackAt: () -> Date? = { nil }
@@ -77,8 +68,6 @@ final class MeetingSystemAudioWatchdog {
     private let lock = NSLock()
     private var episode: Episode?
     private var finished = false
-    private var lastObservedHeartbeat: UInt64 = 0
-    private var lastHeartbeatAdvanceAt: Date?
 
     init(policy: Policy = .default, now: @escaping () -> Date = Date.init) {
         self.policy = policy
@@ -86,7 +75,7 @@ final class MeetingSystemAudioWatchdog {
     }
 
     /// Called by the recorder when a rebuild exhausts its retry budget — the
-    /// tap is dead regardless of heartbeat state. Ignored while paused: a
+    /// tap has positively failed. Ignored while paused: a
     /// rejected recovery request must not open an episode or burn budget.
     func noteCaptureFailure(reason: String) {
         var eventToEmit: MeetingSystemAudioHealthEvent?
@@ -137,84 +126,50 @@ final class MeetingSystemAudioWatchdog {
         var micBridgeReason: String?
 
         lock.lock()
-        if !finished {
-            if isPaused() || isRouteSettling() {
-                lock.unlock()
-                return
-            }
-            let timestamp = now()
-            // Alive = capture active AND the IO heartbeat advanced recently.
-            // Content silence still delivers callbacks; a stall means the
-            // pipeline is dead. A rebuild in flight is a known-transient.
-            let heartbeat = captureHeartbeat()
-            if heartbeat != lastObservedHeartbeat {
-                lastObservedHeartbeat = heartbeat
-                lastHeartbeatAdvanceAt = timestamp
-            }
-            let active = isCaptureActive()
-            let stalled: Bool
-            if !active {
-                stalled = true
-            } else if let lastAdvance = lastHeartbeatAdvanceAt {
-                stalled = timestamp.timeIntervalSince(lastAdvance) >= policy.stallThreshold
-            } else {
-                // Capture active but no heartbeat ever observed.
-                stalled = true
-            }
-            let alive = active && !stalled
+        if finished || isPaused() || isRouteSettling() {
+            lock.unlock()
+            return
+        }
+        guard var active = episode else {
+            // No explicit failure evidence: silence, flat callbacks, playback
+            // transitions, and unrelated CoreAudio clients are all no-ops.
+            lock.unlock()
+            return
+        }
 
-            if alive {
-                if var active = episode {
-                    active.healthyTicks += 1
-                    if active.healthyTicks >= policy.recoveredAfterTicks {
-                        episode = nil
-                        eventToEmit = MeetingSystemAudioHealthEvent(
-                            kind: .recovered,
-                            reason: active.initialReason,
-                            durationSeconds: timestamp.timeIntervalSince(active.startedAt),
-                            recoveryAttempts: active.recoveryAttempts
-                        )
-                    } else {
-                        episode = active
-                    }
-                }
-            } else if episode == nil {
-                episode = openEpisodeLocked(reason: "capture_heartbeat_stalled", at: timestamp)
+        let timestamp = now()
+        if isCaptureActive() {
+            active.healthyTicks += 1
+            if active.healthyTicks >= policy.recoveredAfterTicks {
+                episode = nil
                 eventToEmit = MeetingSystemAudioHealthEvent(
-                    kind: .degraded,
-                    reason: "capture_heartbeat_stalled",
-                    durationSeconds: 0,
-                    recoveryAttempts: 0
+                    kind: .recovered,
+                    reason: active.initialReason,
+                    durationSeconds: timestamp.timeIntervalSince(active.startedAt),
+                    recoveryAttempts: active.recoveryAttempts
                 )
-                // The graph is confirmed dead; rebuild immediately.
-                if var active = episode {
-                    active.recoveryAttempts += 1
-                    active.lastAttemptAt = timestamp
-                    episode = active
-                    recoveryReason = "capture_heartbeat_stalled"
-                }
             } else {
-                if var active = episode {
-                    active.healthyTicks = 0
-                    if active.recoveryAttempts < policy.maxAttemptsPerEpisode,
-                       let lastAttemptAt = active.lastAttemptAt,
-                       timestamp.timeIntervalSince(lastAttemptAt) >= policy.attemptCooldown {
-                        active.recoveryAttempts += 1
-                        active.lastAttemptAt = timestamp
-                        recoveryReason = active.initialReason
-                    }
-                    // Blindness bridge: tap dead + mic stale → the mic
-                    // tracker cannot see degradation without active system
-                    // audio, so surface it here (once per episode).
-                    if !active.micBridgeFired,
-                       let lastMic = lastMicCallbackAt(),
-                       timestamp.timeIntervalSince(lastMic) >= 3 {
-                        active.micBridgeFired = true
-                        micBridgeReason = "mic_callbacks_stale_while_system_tap_dead"
-                    }
-                    episode = active
-                }
+                episode = active
             }
+        } else {
+            active.healthyTicks = 0
+            if active.recoveryAttempts < policy.maxAttemptsPerEpisode,
+               let lastAttemptAt = active.lastAttemptAt,
+               timestamp.timeIntervalSince(lastAttemptAt) >= policy.attemptCooldown {
+                active.recoveryAttempts += 1
+                active.lastAttemptAt = timestamp
+                recoveryReason = active.initialReason
+            }
+            // Blindness bridge: confirmed tap failure + mic stale means the mic
+            // tracker may be blind because its system-audio precondition is
+            // unavailable. Surface this once per failure episode.
+            if !active.micBridgeFired,
+               let lastMic = lastMicCallbackAt(),
+               timestamp.timeIntervalSince(lastMic) >= 3 {
+                active.micBridgeFired = true
+                micBridgeReason = "mic_callbacks_stale_while_system_tap_dead"
+            }
+            episode = active
         }
         lock.unlock()
 

--- a/native/MuesliNative/Tests/MuesliTests/CoreAudioSystemRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CoreAudioSystemRecorderTests.swift
@@ -87,10 +87,12 @@ struct CoreAudioSystemRecorderTests {
         #expect(attempts == 1)
     }
 
-    @Test("CoreAudio tap backend supports heartbeat monitoring; SCK fallback does not")
-    func heartbeatCapabilityByBackend() {
-        #expect(CoreAudioSystemRecorder().supportsHeartbeatMonitoring)
-        #expect(!SystemAudioRecorder().supportsHeartbeatMonitoring)
+    @Test("capture-dead state requires positive recorder failure evidence")
+    func captureDeadDefaultsToFalse() {
+        #expect(!CoreAudioSystemRecorder().captureIsDead)
+        #expect(!SystemAudioRecorder().captureIsDead)
+        #expect(CoreAudioSystemRecorder().supportsFailureRecovery)
+        #expect(!SystemAudioRecorder().supportsFailureRecovery)
     }
 
     @Test("failed rebuild retries then succeeds without a terminal failure")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
@@ -108,6 +108,22 @@ struct MeetingMicRecoveryCoordinatorTests {
         #expect(harness.coordinator.hasActiveEpisode)
     }
 
+    @Test("retry adopts the live all-zero requirement after a degradation-mode change")
+    func retryUsesLiveDegradationMode() {
+        // Keep the retry cooldown beyond the tracker's three-second
+        // degradation confirmation window so the mode change is committed
+        // before attempt two is reserved (production uses 15 seconds).
+        let harness = Harness(cooldown: 3.5, maxAttempts: 2)
+        harness.systemActive(seconds: 3)
+        #expect(harness.recoveryTriggers.map(\.requiresNonZeroSamples) == [false])
+
+        harness.systemActiveWithMicSilence(seconds: 4)
+
+        #expect(harness.events.map(\.kind) == [.degraded])
+        #expect(harness.recoveryTriggers.map(\.requiresNonZeroSamples) == [false, true])
+        #expect(harness.coordinator.hasActiveEpisode)
+    }
+
     @Test("recovery retries after cooldown and stops at the attempt cap")
     func recoveryCooldownAndCap() {
         let harness = Harness(cooldown: 0.5, maxAttempts: 2)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
@@ -8,6 +8,7 @@ struct MeetingMicRecoveryCoordinatorTests {
         var coordinator: MeetingMicRecoveryCoordinator!
         var events: [MeetingMicHealthEpisodeEvent] = []
         var recoveryRequests: [String] = []
+        var recoveryTriggers: [MeetingMicRecoveryTrigger] = []
         var now = Date(timeIntervalSince1970: 1_000_000)
 
         init(cooldown: TimeInterval = 15, maxAttempts: Int = 3) {
@@ -15,8 +16,9 @@ struct MeetingMicRecoveryCoordinatorTests {
                 policy: .init(attemptCooldown: cooldown, maxAttemptsPerEpisode: maxAttempts),
                 now: { [weak self] in self?.now ?? Date() }
             )
-            coordinator.recoveryRequest = { [weak self] reason in
-                self?.recoveryRequests.append(reason)
+            coordinator.recoveryRequest = { [weak self] trigger in
+                self?.recoveryRequests.append(trigger.reason)
+                self?.recoveryTriggers.append(trigger)
                 return .initiated
             }
             coordinator.onEpisodeEvent = { [weak self] event in
@@ -30,6 +32,16 @@ struct MeetingMicRecoveryCoordinatorTests {
         func systemActive(seconds: Int) {
             let chunks = seconds * 10
             for _ in 0..<chunks {
+                let snapshot = tracker.noteSystemSamples(Array(repeating: 2000, count: 1600), now: now)
+                coordinator.process(snapshot)
+                now = now.addingTimeInterval(0.1)
+            }
+        }
+
+        func systemActiveWithMicSilence(seconds: Int) {
+            let chunks = seconds * 10
+            for _ in 0..<chunks {
+                _ = tracker.noteRawMicSamples(Array(repeating: 0, count: 1600), now: now)
                 let snapshot = tracker.noteSystemSamples(Array(repeating: 2000, count: 1600), now: now)
                 coordinator.process(snapshot)
                 now = now.addingTimeInterval(0.1)
@@ -61,6 +73,16 @@ struct MeetingMicRecoveryCoordinatorTests {
         #expect(harness.events.first?.reason == "system_audio_active_without_mic_callbacks")
         #expect(harness.events.first?.state == MeetingMicHealthState.micCallbacksMissing.rawValue)
         #expect(harness.recoveryRequests == ["system_audio_active_without_mic_callbacks"])
+        #expect(harness.recoveryTriggers.first?.requiresNonZeroSamples == false)
+    }
+
+    @Test("all-zero degradation requires a non-zero recovery candidate")
+    func allZeroRecoveryRequiresNonZeroCandidate() {
+        let harness = Harness()
+        harness.systemActiveWithMicSilence(seconds: 4)
+
+        #expect(harness.events.first?.state == MeetingMicHealthState.micAllZeroWhileSystemActive.rawValue)
+        #expect(harness.recoveryTriggers.first?.requiresNonZeroSamples == true)
     }
 
     @Test("continued degradation does not emit duplicate events or premature retries")
@@ -378,8 +400,8 @@ struct MeetingMicRecoveryCoordinatorTests {
     @Test("recovery request callback may re-enter process without deadlock")
     func recoveryCallbackReentryDoesNotDeadlock() {
         let harness = Harness()
-        harness.coordinator.recoveryRequest = { [weak harness] reason in
-            harness?.recoveryRequests.append(reason)
+        harness.coordinator.recoveryRequest = { [weak harness] trigger in
+            harness?.recoveryRequests.append(trigger.reason)
             // Synchronous re-entry, as if a recovery drove an audio callback
             // straight back into the coordinator.
             harness?.micSignal()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
@@ -6,6 +6,11 @@ import Testing
 @Suite("MeetingNeuralAec")
 struct MeetingNeuralAecTests {
 
+    @Test("LocalVQE defaults to one inference thread")
+    func localVQEDefaultsToOneInferenceThread() {
+        #expect(LocalVQEAudioProcessor.defaultThreadCount == 1)
+    }
+
     @Test("bundle candidates prefer Contents/Resources in packaged apps")
     func candidateURLsPreferResourceDirectory() throws {
         let fixture = try makeTemporaryAppBundle()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
@@ -209,6 +209,19 @@ struct MeetingPromptStateMachineTests {
         #expect(result.reason == .recordingStartedSuppression)
     }
 
+    @Test("restarting a recording recognizes the already consumed meeting session")
+    func restartingRecordingRecognizesConsumedSession() {
+        let machine = immediateMachine()
+        let accepted = candidate(
+            "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1",
+            suppressionID: "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1"
+        )
+
+        #expect(machine.markRecordingStarted(accepted))
+        #expect(!machine.markRecordingStarted(accepted))
+        #expect(machine.isRecordingStartedSuppressed(accepted))
+    }
+
     @Test("recording start does not permanently suppress a URL-only recurring meeting")
     func recordingStartDoesNotPermanentlySuppressURLOnlyCandidate() {
         let machine = immediateMachine()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
@@ -37,6 +37,23 @@ struct MeetingSignalRefreshPolicyTests {
         #expect(decision.refreshAudioAttribution == true)
     }
 
+    @Test("Muesli-owned recording suppresses attribution until capture ends")
+    func ownedRecordingSuppressesAttributionUntilCaptureEnds() {
+        var gate = MeetingRecordingAttributionGate()
+
+        #expect(gate.shouldSuppress(isRecording: true) == false)
+        #expect(gate.markCaptureOwned() == true)
+        #expect(gate.markCaptureOwned() == false)
+        #expect(gate.shouldSuppress(isRecording: true) == true)
+
+        gate.synchronize(isRecording: false, isStartingRecording: true)
+        #expect(gate.ownsActiveCapture == true)
+
+        gate.synchronize(isRecording: false, isStartingRecording: false)
+        #expect(gate.ownsActiveCapture == false)
+        #expect(gate.shouldSuppress(isRecording: true) == false)
+    }
+
     @Test("repeated suspicious fallback respects expensive collector throttle")
     func repeatedSuspiciousFallbackRespectsThrottle() {
         let policy = MeetingSignalRefreshPolicy()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
@@ -69,6 +69,30 @@ struct MeetingSignalRefreshPolicyTests {
         #expect(decision.refreshBrowserMeetings == true)
     }
 
+    @Test(
+        "associated recording suppresses CoreAudio attribution",
+        arguments: [
+            MeetingDetectionTrigger.fallbackTimer,
+            MeetingDetectionTrigger.micChanged,
+            MeetingDetectionTrigger.sensorAttributionChanged,
+            MeetingDetectionTrigger.manualRefresh,
+        ]
+    )
+    func associatedRecordingSuppressesAudioAttribution(trigger: MeetingDetectionTrigger) {
+        let policy = MeetingSignalRefreshPolicy()
+        var state = MeetingSignalRefreshState()
+        state.hasActiveCandidate = true
+
+        let decision = policy.decision(
+            trigger: trigger,
+            state: state,
+            suppressAudioAttribution: true,
+            now: now
+        )
+
+        #expect(decision.refreshAudioAttribution == false)
+    }
+
     @Test("active-tab fallback is throttled per browser bundle")
     func activeTabFallbackIsThrottledPerBundle() {
         let policy = MeetingSignalRefreshPolicy()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSystemAudioWatchdogTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSystemAudioWatchdogTests.swift
@@ -9,20 +9,24 @@ struct MeetingSystemAudioWatchdogTests {
         var recoveryRequests: [String] = []
         var micBridgeReasons: [String] = []
         var now = Date(timeIntervalSince1970: 2_000_000)
-        var heartbeat: UInt64 = 0
         var captureActive = true
         var paused = false
+        var routeSettling = false
         var micLastCallbackAt: Date?
+        var acceptsRecovery = true
 
         init(policy: MeetingSystemAudioWatchdog.Policy = .default) {
-            watchdog = MeetingSystemAudioWatchdog(policy: policy, now: { [weak self] in self?.now ?? Date() })
-            watchdog.captureHeartbeat = { [weak self] in self?.heartbeat ?? 0 }
+            watchdog = MeetingSystemAudioWatchdog(
+                policy: policy,
+                now: { [weak self] in self?.now ?? Date() }
+            )
             watchdog.isCaptureActive = { [weak self] in self?.captureActive ?? false }
             watchdog.isPaused = { [weak self] in self?.paused ?? false }
+            watchdog.isRouteSettling = { [weak self] in self?.routeSettling ?? false }
             watchdog.lastMicCallbackAt = { [weak self] in self?.micLastCallbackAt }
             watchdog.recoveryRequest = { [weak self] reason in
                 self?.recoveryRequests.append(reason)
-                return true
+                return self?.acceptsRecovery ?? false
             }
             watchdog.onMicBlindnessDegradation = { [weak self] reason in
                 self?.micBridgeReasons.append(reason)
@@ -32,202 +36,163 @@ struct MeetingSystemAudioWatchdogTests {
             }
         }
 
-        /// One watchdog tick with the heartbeat advancing (healthy capture).
-        func aliveTick() {
-            heartbeat &+= 1
+        func tick() {
             watchdog.tick()
             now = now.addingTimeInterval(1)
         }
 
-        /// One tick with no heartbeat advance (stalled capture).
-        func stalledTick() {
-            watchdog.tick()
-            now = now.addingTimeInterval(1)
+        func fail(_ reason: String = "rebuild_exhausted: tapCreationFailed") {
+            captureActive = false
+            watchdog.noteCaptureFailure(reason: reason)
         }
     }
 
-    @Test("heartbeat advancing keeps the pipeline healthy")
-    func advancingHeartbeatIsHealthy() {
+    @Test("ordinary capture ticks never infer failure from missing callbacks")
+    func ordinaryTicksAreInert() {
         let harness = Harness()
-        for _ in 0..<10 { harness.aliveTick() }
+        for _ in 0..<120 { harness.tick() }
+
         #expect(harness.events.isEmpty)
         #expect(harness.recoveryRequests.isEmpty)
     }
 
-    @Test("a stalled heartbeat opens one episode and requests one immediate rebuild")
-    func stallOpensEpisode() {
+    @Test("inactive capture alone is not positive failure evidence")
+    func inactiveCaptureDoesNotOpenEpisode() {
         let harness = Harness()
-        harness.aliveTick() // establish heartbeat
-        for _ in 0..<3 { harness.stalledTick() }
+        harness.captureActive = false
+        harness.micLastCallbackAt = harness.now.addingTimeInterval(-10)
+        for _ in 0..<20 { harness.tick() }
 
-        #expect(harness.events.count == 1)
-        #expect(harness.events.first?.kind == .degraded)
-        #expect(harness.events.first?.reason == "capture_heartbeat_stalled")
+        #expect(harness.events.isEmpty)
+        #expect(harness.recoveryRequests.isEmpty)
+        #expect(harness.micBridgeReasons.isEmpty)
+    }
+
+    @Test("explicit capture failure opens one episode and requests recovery")
+    func explicitFailureOpensEpisode() {
+        let harness = Harness()
+        harness.fail()
+
+        #expect(harness.events.map(\.kind) == [.degraded])
+        #expect(harness.events.first?.reason == "rebuild_exhausted: tapCreationFailed")
+        #expect(harness.recoveryRequests == ["rebuild_exhausted: tapCreationFailed"])
+        #expect(harness.watchdog.hasActiveEpisode)
+    }
+
+    @Test("repeated failure reports do not duplicate an active episode")
+    func repeatedFailureDoesNotDuplicateEpisode() {
+        let harness = Harness()
+        harness.fail()
+        harness.watchdog.noteCaptureFailure(reason: "second failure")
+
+        #expect(harness.events.map(\.kind) == [.degraded])
         #expect(harness.recoveryRequests.count == 1)
     }
 
-    @Test("capture inactive (recorder stopped reporting) is treated as dead")
-    func inactiveCaptureIsDead() {
-        let harness = Harness()
-        harness.captureActive = false
-        harness.watchdog.tick()
-        #expect(harness.events.first?.kind == .degraded)
-    }
-
-    @Test("resumed heartbeat closes the episode after two alive ticks")
+    @Test("successful recorder state closes an episode after two ticks")
     func recoveryClosesEpisode() {
         let harness = Harness()
-        harness.aliveTick()
-        harness.stalledTick()
-        harness.stalledTick()
-        harness.aliveTick()
+        harness.fail()
+        harness.captureActive = true
+
+        harness.tick()
         #expect(harness.events.map(\.kind) == [.degraded])
-        harness.aliveTick()
+        harness.tick()
+
         #expect(harness.events.map(\.kind) == [.degraded, .recovered])
         #expect(harness.events.last?.recoveryAttempts == 1)
         #expect(!harness.watchdog.hasActiveEpisode)
     }
 
-    @Test("retries are cooldown-limited and capped per episode")
+    @Test("retries are cooldown-limited and capped per explicit failure episode")
     func retriesAreBounded() {
         let harness = Harness(policy: .init(
-            stallThreshold: 2,
             recoveredAfterTicks: 2,
             attemptCooldown: 5,
             maxAttemptsPerEpisode: 3
         ))
-        harness.aliveTick()
-        harness.stalledTick() // episode + attempt 1
-        for _ in 0..<4 { harness.stalledTick() } // within cooldown
-        #expect(harness.recoveryRequests.count == 1)
-        harness.stalledTick() // t=+5 past first attempt → attempt 2
-        harness.stalledTick() // t=+6 < cooldown since attempt 2
+        harness.fail()
+        for _ in 0..<6 { harness.tick() }
         #expect(harness.recoveryRequests.count == 2)
-        for _ in 0..<5 { harness.stalledTick() } // attempt 3 at t=+10s
+        for _ in 0..<5 { harness.tick() }
         #expect(harness.recoveryRequests.count == 3)
-        for _ in 0..<6 { harness.stalledTick() } // cap reached
+        for _ in 0..<20 { harness.tick() }
         #expect(harness.recoveryRequests.count == 3)
     }
 
-    @Test("terminal capture failure opens an episode immediately with an immediate rebuild")
-    func captureFailureOpensEpisode() {
-        let harness = Harness()
-        harness.aliveTick()
-        harness.watchdog.noteCaptureFailure(reason: "rebuild_exhausted: tapCreationFailed")
-
-        #expect(harness.events.map(\.kind) == [.degraded])
-        #expect(harness.events.first?.reason.contains("rebuild_exhausted") == true)
+    @Test("a rejected recovery keeps cooldown back-pressure without burning budget")
+    func rejectedRecoveryKeepsCooldown() {
+        let harness = Harness(policy: .init(
+            recoveredAfterTicks: 2,
+            attemptCooldown: 5,
+            maxAttemptsPerEpisode: 3
+        ))
+        harness.acceptsRecovery = false
+        harness.fail()
         #expect(harness.recoveryRequests.count == 1)
+
+        for _ in 0..<5 { harness.tick() }
+        #expect(harness.recoveryRequests.count == 1)
+        harness.tick()
+        #expect(harness.recoveryRequests.count == 2)
     }
 
-    @Test("meeting end with an open episode terminalizes as unrecovered")
-    func meetingEndTerminalizes() {
+    @Test("route settling pauses retries for an explicit failure")
+    func routeSettlingPausesRetries() {
+        let harness = Harness(policy: .init(
+            recoveredAfterTicks: 2,
+            attemptCooldown: 2,
+            maxAttemptsPerEpisode: 3
+        ))
+        harness.fail()
+        harness.routeSettling = true
+        for _ in 0..<10 { harness.tick() }
+        #expect(harness.recoveryRequests.count == 1)
+
+        harness.routeSettling = false
+        harness.tick()
+        #expect(harness.recoveryRequests.count == 2)
+    }
+
+    @Test("mic blindness bridge requires a confirmed tap failure and fires once")
+    func micBlindnessBridgeFiresOnce() {
         let harness = Harness()
-        harness.aliveTick()
-        harness.stalledTick()
-        harness.stalledTick() // past the 2s stall threshold: episode open
+        harness.micLastCallbackAt = harness.now.addingTimeInterval(-10)
+        harness.fail()
+        for _ in 0..<4 { harness.tick() }
+
+        #expect(harness.micBridgeReasons == ["mic_callbacks_stale_while_system_tap_dead"])
+    }
+
+    @Test("capture failure while paused opens no episode")
+    func captureFailureWhilePausedIsIgnored() {
+        let harness = Harness()
+        harness.paused = true
+        harness.fail()
+
+        #expect(harness.events.isEmpty)
+        #expect(harness.recoveryRequests.isEmpty)
+        #expect(!harness.watchdog.hasActiveEpisode)
+    }
+
+    @Test("meeting end terminalizes only an explicit open failure episode")
+    func meetingEndTerminalizesOpenEpisode() {
+        let harness = Harness()
+        harness.fail()
         harness.watchdog.finishMeeting()
 
         #expect(harness.events.map(\.kind) == [.degraded, .unrecovered])
         #expect(!harness.watchdog.hasActiveEpisode)
     }
 
-    @Test("ticks after finishMeeting are ignored")
+    @Test("ticks after finish are ignored")
     func ticksAfterFinishAreIgnored() {
         let harness = Harness()
         harness.watchdog.finishMeeting()
-        harness.stalledTick()
+        harness.captureActive = false
+        for _ in 0..<20 { harness.tick() }
+
         #expect(harness.events.isEmpty)
         #expect(harness.recoveryRequests.isEmpty)
-    }
-
-    @Test("paused capture suppresses evaluation entirely")
-    func pauseSuppressesEvaluation() {
-        let harness = Harness()
-        harness.aliveTick()
-        harness.paused = true
-        harness.stalledTick()
-        harness.stalledTick()
-        #expect(harness.events.isEmpty)
-        #expect(harness.recoveryRequests.isEmpty)
-    }
-
-    @Test("route transitions suppress stall evaluation while settling")
-    func routeSettlingSuppressesEvaluation() {
-        let harness = Harness()
-        var settling = false
-        harness.watchdog.isRouteSettling = { settling }
-        harness.aliveTick()
-
-        settling = true
-        harness.stalledTick()
-        harness.stalledTick()
-        harness.stalledTick()
-        #expect(harness.events.isEmpty)
-        #expect(harness.recoveryRequests.isEmpty)
-
-        settling = false
-        harness.stalledTick()
-        harness.stalledTick()
-        #expect(harness.events.map(\.kind) == [.degraded])
-        #expect(harness.recoveryRequests.count == 1)
-    }
-
-    @Test("mic blindness bridge fires once when the tap is dead and mic callbacks are stale")
-    func micBlindnessBridgeFiresOnce() {
-        let harness = Harness()
-        harness.aliveTick()
-        harness.micLastCallbackAt = harness.now.addingTimeInterval(-10) // stale mic
-        harness.stalledTick() // episode opens
-        harness.stalledTick() // bridge fires
-        harness.stalledTick()
-        #expect(harness.micBridgeReasons == ["mic_callbacks_stale_while_system_tap_dead"])
-    }
-
-    @Test("no bridge while the mic is alive")
-    func noBridgeWhenMicAlive() {
-        let harness = Harness()
-        harness.aliveTick()
-        harness.micLastCallbackAt = harness.now
-        harness.stalledTick()
-        harness.stalledTick()
-        harness.stalledTick()
-        #expect(harness.micBridgeReasons.isEmpty)
-    }
-
-    @Test("capture failure while paused opens no episode and requests nothing")
-    func captureFailureWhilePausedIsIgnored() {
-        let harness = Harness()
-        harness.paused = true
-        harness.watchdog.noteCaptureFailure(reason: "rebuild_exhausted: tapCreationFailed")
-        #expect(harness.events.isEmpty)
-        #expect(harness.recoveryRequests.isEmpty)
-        #expect(!harness.watchdog.hasActiveEpisode)
-    }
-
-    @Test("a rejected recovery request refunds the attempt but keeps back-pressure")
-    func rejectedRecoveryKeepsCooldown() {
-        let harness = Harness(policy: .init(
-            stallThreshold: 2,
-            recoveredAfterTicks: 2,
-            attemptCooldown: 5,
-            maxAttemptsPerEpisode: 3
-        ))
-        var requestCount = 0
-        harness.watchdog.recoveryRequest = { _ in
-            requestCount += 1
-            return false // rejected (paused / rebuild in flight)
-        }
-
-        harness.aliveTick()
-        harness.stalledTick()
-        harness.stalledTick() // episode confirmed → dispatch → rejected
-        #expect(requestCount == 1)
-
-        harness.stalledTick() // inside cooldown: nothing
-        #expect(requestCount == 1)
-
-        for _ in 0..<4 { harness.stalledTick() } // cooldown elapses → one more
-        #expect(requestCount == 2)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
@@ -564,18 +564,13 @@ struct RouteAwareMeetingMicRecorderTests {
         #expect(!state.isRunning)
     }
 
-    @Test("health-triggered recovery hands off the same route and promotes on first buffer")
+    @Test("health-triggered recovery switches the default route to the alternate backend")
     func healthTriggeredRecoveryPromotesOnFirstBuffer() async throws {
         let degraded = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
-        let replacement = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
-        var factoryCalls = 0
+        let replacement = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
         let recorder = RouteAwareMeetingMicRecorder(
             systemDefaultRecorder: degraded,
-            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
-            systemDefaultRecorderFactory: {
-                factoryCalls += 1
-                return replacement
-            },
+            appScopedRecorder: replacement,
             handoffTimeout: 1,
             handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
         )
@@ -583,16 +578,27 @@ struct RouteAwareMeetingMicRecorderTests {
         recorder.onRawPCMSamples = { samples.append($0) }
 
         try recorder.start()
-        #expect(recorder.requestSameRouteRecovery(reason: "system_audio_active_with_zero_mic") == .initiated)
+        #expect(recorder.requestHealthRecovery(.init(
+            reason: "system_audio_active_with_zero_mic",
+            requiresNonZeroSamples: true
+        )) == .initiated)
         try await waitUntil { replacement.startCalls == 1 }
-        #expect(factoryCalls == 1)
+        #expect(replacement.preferredInputDeviceID == nil)
 
         // No samples yet: the degraded graph remains active and un-retired.
         #expect(degraded.stopCalls == 0)
 
+        // An all-zero callback is not evidence that an all-zero failure has
+        // recovered, so it must not replace the active graph.
+        replacement.onRawPCMSamples?([0, 0, 0])
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(degraded.stopCalls == 0)
+        #expect(samples.isEmpty)
+
         replacement.onRawPCMSamples?([4, 5, 6])
         try await waitUntil { samples == [[4, 5, 6]] }
         #expect(degraded.stopCalls == 1)
+        #expect(recorder.activeRecorderKindForDebug() == .appScoped)
     }
 
     @Test("health-triggered recovery is a no-op when not recording")
@@ -609,44 +615,43 @@ struct RouteAwareMeetingMicRecorderTests {
             handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
         )
 
-        #expect(recorder.requestSameRouteRecovery(reason: "system_audio_active_without_mic_callbacks") == .unavailable)
+        #expect(recorder.requestHealthRecovery(.init(
+            reason: "system_audio_active_without_mic_callbacks",
+            requiresNonZeroSamples: false
+        )) == .unavailable)
         #expect(factoryCalls == 0)
     }
 
     @Test("a second health recovery request does not stack behind a pending handoff")
     func healthRecoveryDoesNotStackPendingHandoffs() async throws {
         let degraded = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
-        var factoryCalls = 0
+        let replacement = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
         let recorder = RouteAwareMeetingMicRecorder(
             systemDefaultRecorder: degraded,
-            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
-            systemDefaultRecorderFactory: {
-                factoryCalls += 1
-                return FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
-            },
+            appScopedRecorder: replacement,
             handoffTimeout: 1,
             handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
         )
 
         try recorder.start()
-        #expect(recorder.requestSameRouteRecovery(reason: "first") == .initiated)
-        #expect(recorder.requestSameRouteRecovery(reason: "second") == .busy)
-        try await waitUntil { factoryCalls == 1 }
+        #expect(recorder.requestHealthRecovery(.init(reason: "first", requiresNonZeroSamples: false)) == .initiated)
+        #expect(recorder.requestHealthRecovery(.init(reason: "second", requiresNonZeroSamples: false)) == .busy)
+        try await waitUntil { replacement.startCalls == 1 }
         try await Task.sleep(for: .milliseconds(50))
-        #expect(factoryCalls == 1)
+        #expect(replacement.startCalls == 1)
     }
 
     @Test("handoff outcome reports promotion and candidate failure")
     func handoffOutcomeReportsPromotionAndFailure() async throws {
-        let failingReplacement = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let failingReplacement = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
         failingReplacement.startError = NSError(domain: "test", code: 7)
-        let goodReplacement = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let goodReplacement = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
         var replacements = [failingReplacement, goodReplacement]
         let initial = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
         let recorder = RouteAwareMeetingMicRecorder(
             systemDefaultRecorder: initial,
-            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
-            systemDefaultRecorderFactory: { replacements.removeFirst() },
+            appScopedRecorder: replacements.removeFirst(),
+            appScopedRecorderFactory: { replacements.removeFirst() },
             handoffTimeout: 1,
             handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
         )
@@ -654,11 +659,11 @@ struct RouteAwareMeetingMicRecorderTests {
         recorder.onHandoffOutcome = { outcomes.append($0) }
 
         try recorder.start()
-        #expect(recorder.requestSameRouteRecovery(reason: "first attempt") == .initiated)
+        #expect(recorder.requestHealthRecovery(.init(reason: "first attempt", requiresNonZeroSamples: false)) == .initiated)
         try await waitUntil { failingReplacement.cancelCalls == 1 }
         try await waitUntil { outcomes == [.failed] }
 
-        #expect(recorder.requestSameRouteRecovery(reason: "second attempt") == .initiated)
+        #expect(recorder.requestHealthRecovery(.init(reason: "second attempt", requiresNonZeroSamples: false)) == .initiated)
         try await waitUntil { goodReplacement.startCalls == 1 }
         goodReplacement.onRawPCMSamples?([1, 2])
         try await waitUntil { outcomes == [.failed, .promoted] }
@@ -670,19 +675,18 @@ struct RouteAwareMeetingMicRecorderTests {
         let prepareStarted = DispatchSemaphore(value: 0)
         let allowPrepare = DispatchSemaphore(value: 0)
         let initial = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
-        let candidate = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let candidate = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
         candidate.onPrepareStarted = { prepareStarted.signal() }
         candidate.prepareGate = allowPrepare
         let recorder = RouteAwareMeetingMicRecorder(
             systemDefaultRecorder: initial,
-            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
-            systemDefaultRecorderFactory: { candidate },
+            appScopedRecorder: candidate,
             handoffTimeout: 1,
             handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
         )
 
         try recorder.start()
-        #expect(recorder.requestSameRouteRecovery(reason: "queued then stopped") == .initiated)
+        #expect(recorder.requestHealthRecovery(.init(reason: "queued then stopped", requiresNonZeroSamples: false)) == .initiated)
         #expect(prepareStarted.wait(timeout: .now() + 2) == .success)
 
         // Tear down while the worker is blocked inside candidate.prepare().


### PR DESCRIPTION
## Summary

- reduce the default LocalVQE inference setting from two threads to one, matching the lowest-cost real-time configuration reported in #484
- carry microphone degradation semantics into recovery and use the independent AudioQueue backend when the system-default AVAudioEngine graph is semantically dead
- require a non-zero candidate buffer before declaring an all-zero microphone failure recovered
- retain the existing AVAudioEngine path for healthy default-device meeting startup and the app-scoped path for explicitly selected devices

## Why one PR

#480 and #484 share the meeting-audio runtime boundary but not a causal failure: #480 is raw microphone capture upstream of AEC, while #484 is LocalVQE compute cost. Keeping the two small changes together lets us validate the complete meeting capture pipeline without claiming the echo canceller caused the missing microphone.

The source in v0.8.3 requested two LocalVQE threads, not four, and already spelled `localvqe-strict` correctly. This PR therefore makes the measured one-thread optimization without carrying forward those two inaccurate report details.

## Historical constraint

Earlier meeting-mic work avoided AudioQueue on the healthy system-default startup path because it could block or contend with call apps. This change uses AudioQueue only after the existing health tracker confirms missing/all-zero mic delivery, through the already bounded handoff and teardown machinery.

## Validation

- focused AEC, mic-health, and route-recorder suites: 71 tests passed
- full native suite: 1,954 tests across 173 suites passed
- `./scripts/test_classify_changed_files.sh`
- `./scripts/test_ci_test_shards.sh`
- `./scripts/verify_update_flow.sh --skip-dmg`

Fixes #480
Fixes #484

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790856441&installation_model_id=422865&pr_number=491&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F491&signature=6eac679bc54e4096e6701683ce52e8edb3ecc2d58d51d5813c41f1ed5d819150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved microphone recovery by switching to an alternate capture backend when needed.
  * Recovery now verifies that replacement audio contains valid, non-silent samples before completing handoff.
  * Local voice processing now defaults to one inference thread.
  * Improved recording detection and audio attribution handling during active meetings.

* **Bug Fixes**
  * System-audio recovery now responds to confirmed capture failures rather than ordinary silence or stalled activity.
  * Improved handling and reporting of microphone recovery outcomes.
  * Prevented audio attribution refreshes when an active recording is already associated with the meeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->