### PR TITLE
Polish onboarding permission guidance and capability selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Key implementation details:
 - Hotkey, calendar, and mic monitors are **deferred until after onboarding completes** to prevent premature permission prompts
 - App restart via detached shell: `/bin/sh -c "sleep 1; open -- \"$1\"" -- <bundlePath>` then `NSApp.terminate(nil)`
 - Progress saved on every step transition to `onboarding-progress.json` (schema-versioned, atomic writes)
-- Dictation test step uses real hold-to-talk hotkey flow with `dictationTestCallback` routing (no paste, no floating indicator)
+- Dictation test step uses the real hold-to-talk hotkey flow with `dictationTestCallback` routing. It never pastes, but intentionally keeps the floating waveform visible so onboarding exercises the same recording feedback as normal dictation; releasing the hotkey leaves the active state immediately.
 - `OnboardingView.dictationTestStep` (static Int = 4) — hotkey monitor only starts when resuming at this step or later
 
 ## Screen Context (opt-in, `enableScreenContext` in config)

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -6,6 +6,20 @@ struct AccessibilityPermissionGuideFrames: Equatable {
     let guide: CGRect
     let dragSource: CGRect
     let completedGuide: CGRect
+    let dragDirection: PermissionGuideDragDirection
+}
+
+enum PermissionGuideDragDirection: Equatable {
+    case up
+    case down
+
+    var symbolName: String {
+        self == .up ? "arrow.up" : "arrow.down"
+    }
+
+    var instruction: String {
+        self == .up ? "Drag this row up into this list" : "Drag this row down into this list"
+    }
 }
 
 enum AccessibilityPermissionGuideLayout {
@@ -46,7 +60,8 @@ enum AccessibilityPermissionGuideLayout {
         return AccessibilityPermissionGuideFrames(
             guide: guide.integral,
             dragSource: dragSource.integral,
-            completedGuide: completedGuide.integral
+            completedGuide: completedGuide.integral,
+            dragDirection: guide.midY <= settingsWindow.midY ? .up : .down
         )
     }
 }
@@ -218,6 +233,7 @@ final class AccessibilityPermissionGuideController {
 
         ensurePanels()
         setPresenting(true)
+        model.dragDirection = frames.dragDirection
         if model.didCompleteDrag {
             guidePanel?.setFrame(frames.completedGuide, display: true)
             dragPanel?.orderOut(nil)
@@ -350,11 +366,14 @@ private enum SystemSettingsWindowLocator {
 @MainActor
 private final class AccessibilityPermissionGuideModel: ObservableObject {
     @Published var didCompleteDrag = false
+    @Published var dragDirection: PermissionGuideDragDirection = .up
 }
 
 private struct CompactAccessibilityPermissionGuideView: View {
     let appName: String
     @ObservedObject var model: AccessibilityPermissionGuideModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var arrowIsDisplaced = false
 
     var body: some View {
         Group {
@@ -378,9 +397,16 @@ private struct CompactAccessibilityPermissionGuideView: View {
                 .padding(.horizontal, 16)
             } else {
                 VStack(spacing: 0) {
-                    Text("Drag this row up into this list")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(Color.white.opacity(0.72))
+                    HStack(spacing: 7) {
+                        Image(systemName: model.dragDirection.symbolName)
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(MuesliTheme.accent)
+                            .offset(y: arrowOffset)
+
+                        Text(model.dragDirection.instruction)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color.white.opacity(0.72))
+                    }
 
                     Spacer(minLength: 82)
                 }
@@ -397,6 +423,24 @@ private struct CompactAccessibilityPermissionGuideView: View {
         )
         .shadow(color: .black.opacity(0.10), radius: 10, y: 4)
         .padding(2)
+        .onAppear { startArrowAnimation() }
+        .onChange(of: model.dragDirection) { _, _ in
+            arrowIsDisplaced = false
+            startArrowAnimation()
+        }
+    }
+
+    private var arrowOffset: CGFloat {
+        guard !reduceMotion else { return 0 }
+        let displacement: CGFloat = arrowIsDisplaced ? 4 : -1
+        return model.dragDirection == .up ? -displacement : displacement
+    }
+
+    private func startArrowAnimation() {
+        guard !reduceMotion else { return }
+        withAnimation(.easeInOut(duration: 0.72).repeatForever(autoreverses: true)) {
+            arrowIsDisplaced = true
+        }
     }
 }
 
@@ -454,6 +498,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
     private let appURL: URL
     private var mouseDownLocation: CGPoint?
     private var hasStartedDrag = false
+    private var cursorTrackingArea: NSTrackingArea?
 
     init(frame frameRect: NSRect, appURL: URL, appName: String, appIcon: NSImage) {
         self.appURL = appURL
@@ -473,6 +518,33 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
         addCursorRect(bounds, cursor: .openHand)
     }
 
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let cursorTrackingArea {
+            removeTrackingArea(cursorTrackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .cursorUpdate],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        cursorTrackingArea = area
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        (hasStartedDrag ? NSCursor.closedHand : NSCursor.openHand).set()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        NSCursor.openHand.set()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        NSCursor.arrow.set()
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -481,6 +553,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
     override func mouseDown(with event: NSEvent) {
         mouseDownLocation = convert(event.locationInWindow, from: nil)
         hasStartedDrag = false
+        NSCursor.closedHand.set()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -497,6 +570,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
     override func mouseUp(with event: NSEvent) {
         mouseDownLocation = nil
         hasStartedDrag = false
+        NSCursor.openHand.set()
     }
 
     func draggingSession(
@@ -513,6 +587,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
     ) {
         mouseDownLocation = nil
         hasStartedDrag = false
+        NSCursor.openHand.set()
         if !operation.isEmpty {
             onDragEnded?()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -105,6 +105,15 @@ enum AccessibilityPermissionGuideDropPolicy {
     }
 }
 
+enum AccessibilityPermissionGuideInvocationPolicy {
+    static func shouldResetDragCompletion(
+        previousPermission: PermissionDragGuidePermission?,
+        nextPermission: PermissionDragGuidePermission
+    ) -> Bool {
+        previousPermission != nextPermission
+    }
+}
+
 enum PermissionDragGuidePermission {
     case accessibility
     case inputMonitoring
@@ -198,8 +207,13 @@ final class AccessibilityPermissionGuideController {
             return
         }
 
+        if AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
+            previousPermission: requestedPermission,
+            nextPermission: permission
+        ) {
+            model.didCompleteDrag = false
+        }
         requestedPermission = permission
-        model.didCompleteDrag = false
         installObserversIfNeeded()
         startRefreshTimerIfNeeded()
         refreshPresentation()

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -18,10 +18,10 @@ enum AccessibilityPermissionGuideLayout {
         let contentWidth = contentMaxX - contentMinX
         guard contentWidth >= 360 else { return nil }
 
-        let guideWidth = min(720, contentWidth - 16)
-        let guideHeight: CGFloat = 226
-        let preferredY = settingsWindow.minY + max(96, settingsWindow.height * 0.22)
-        let guideY = min(preferredY, settingsWindow.maxY - guideHeight - 92)
+        let guideWidth = min(640, contentWidth - 24)
+        let guideHeight: CGFloat = 128
+        let preferredY = settingsWindow.minY + max(88, settingsWindow.height * 0.18)
+        let guideY = min(preferredY, settingsWindow.maxY - guideHeight - 80)
         let guide = CGRect(
             x: contentMinX + (contentWidth - guideWidth) / 2,
             y: guideY,
@@ -30,17 +30,17 @@ enum AccessibilityPermissionGuideLayout {
         )
 
         let dragSource = CGRect(
-            x: guide.minX + 14,
-            y: guide.minY + 14,
-            width: guide.width - 28,
-            height: 76
+            x: guide.minX + 12,
+            y: guide.minY + 12,
+            width: guide.width - 24,
+            height: 70
         )
 
         let completedGuide = CGRect(
-            x: guide.minX + 46,
-            y: dragSource.minY + 8,
-            width: guide.width - 92,
-            height: 58
+            x: guide.minX + 64,
+            y: dragSource.minY + 7,
+            width: guide.width - 128,
+            height: 56
         )
 
         return AccessibilityPermissionGuideFrames(
@@ -51,17 +51,31 @@ enum AccessibilityPermissionGuideLayout {
     }
 }
 
+enum PermissionDragGuidePermission {
+    case accessibility
+    case inputMonitoring
+
+    var isGranted: Bool {
+        switch self {
+        case .accessibility:
+            AXIsProcessTrusted()
+        case .inputMonitoring:
+            CGPreflightListenEventAccess()
+        }
+    }
+}
+
 enum AccessibilityPermissionGuidePresentationPolicy {
     static let systemSettingsBundleID = "com.apple.systempreferences"
 
     static func shouldShow(
         isRequested: Bool,
-        isTrusted: Bool,
+        isGranted: Bool,
         frontmostBundleID: String?,
         hasSettingsWindow: Bool
     ) -> Bool {
         isRequested
-            && !isTrusted
+            && !isGranted
             && frontmostBundleID == systemSettingsBundleID
             && hasSettingsWindow
     }
@@ -92,7 +106,7 @@ final class AccessibilityPermissionGuideController {
     private var refreshTimer: Timer?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var applicationObservers: [NSObjectProtocol] = []
-    private var isRequested = false
+    private var requestedPermission: PermissionDragGuidePermission?
     private var isPresenting = false
 
     init(
@@ -105,13 +119,13 @@ final class AccessibilityPermissionGuideController {
         self.appIcon = appIcon ?? NSApplication.shared.applicationIconImage
     }
 
-    func showWhenSystemSettingsIsAvailable() {
-        guard !AXIsProcessTrusted() else {
+    func showWhenSystemSettingsIsAvailable(for permission: PermissionDragGuidePermission) {
+        guard !permission.isGranted else {
             dismiss()
             return
         }
 
-        isRequested = true
+        requestedPermission = permission
         model.didCompleteDrag = false
         installObserversIfNeeded()
         startRefreshTimerIfNeeded()
@@ -119,7 +133,7 @@ final class AccessibilityPermissionGuideController {
     }
 
     func dismiss() {
-        isRequested = false
+        requestedPermission = nil
         refreshTimer?.invalidate()
         refreshTimer = nil
 
@@ -178,7 +192,12 @@ final class AccessibilityPermissionGuideController {
     }
 
     private func refreshPresentation() {
-        if AXIsProcessTrusted() {
+        guard let requestedPermission else {
+            dismiss()
+            return
+        }
+
+        if requestedPermission.isGranted {
             dismiss()
             return
         }
@@ -186,8 +205,8 @@ final class AccessibilityPermissionGuideController {
         let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
         let settingsWindow = SystemSettingsWindowLocator.mainWindowFrame()
         guard AccessibilityPermissionGuidePresentationPolicy.shouldShow(
-            isRequested: isRequested,
-            isTrusted: false,
+            isRequested: true,
+            isGranted: false,
             frontmostBundleID: frontmostBundleID,
             hasSettingsWindow: settingsWindow != nil
         ), let settingsWindow,
@@ -219,7 +238,6 @@ final class AccessibilityPermissionGuideController {
                 ignoresMouseEvents: true,
                 contentView: NSHostingView(rootView: CompactAccessibilityPermissionGuideView(
                     appName: appName,
-                    appIcon: appIcon,
                     model: model
                 ).preferredColorScheme(.dark))
             )
@@ -336,11 +354,7 @@ private final class AccessibilityPermissionGuideModel: ObservableObject {
 
 private struct CompactAccessibilityPermissionGuideView: View {
     let appName: String
-    let appIcon: NSImage
     @ObservedObject var model: AccessibilityPermissionGuideModel
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isAnimating = false
 
     var body: some View {
         Group {
@@ -363,23 +377,15 @@ private struct CompactAccessibilityPermissionGuideView: View {
                 }
                 .padding(.horizontal, 16)
             } else {
-                VStack(spacing: 5) {
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 21, weight: .bold))
-                        .foregroundStyle(MuesliTheme.accent)
+                VStack(spacing: 0) {
+                    Text("Drag this row up into this list")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.white.opacity(0.72))
 
-                    PermissionGuideAppRow(appName: appName, appIcon: appIcon, isGhost: true)
-                        .frame(height: 52)
-                        .offset(y: reduceMotion ? 0 : (isAnimating ? -7 : 4))
-
-                    Text("Drag this row up into the list")
-                        .font(.system(size: 11.5, weight: .medium))
-                        .foregroundStyle(Color.white.opacity(0.66))
-
-                    Spacer(minLength: 88)
+                    Spacer(minLength: 82)
                 }
-                .padding(.horizontal, 14)
-                .padding(.top, 12)
+                .padding(.horizontal, 12)
+                .padding(.top, 14)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -389,14 +395,8 @@ private struct CompactAccessibilityPermissionGuideView: View {
             RoundedRectangle(cornerRadius: model.didCompleteDrag ? 14 : 18)
                 .stroke(Color.white.opacity(0.10), lineWidth: 1)
         )
-        .shadow(color: .black.opacity(0.18), radius: 12, y: 5)
+        .shadow(color: .black.opacity(0.10), radius: 10, y: 4)
         .padding(2)
-        .onAppear {
-            guard !reduceMotion else { return }
-            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                isAnimating = true
-            }
-        }
     }
 }
 
@@ -421,7 +421,6 @@ private struct AccessibilityPermissionDragRowView: View {
 private struct PermissionGuideAppRow: View {
     let appName: String
     let appIcon: NSImage
-    var isGhost = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -433,17 +432,17 @@ private struct PermissionGuideAppRow: View {
 
             Text(appName)
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(.white.opacity(isGhost ? 0.84 : 0.94))
+                .foregroundStyle(.white.opacity(0.94))
 
             Spacer()
         }
         .padding(.horizontal, 14)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.white.opacity(isGhost ? 0.07 : 0.10))
+        .background(Color.white.opacity(0.10))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
             RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.white.opacity(isGhost ? 0.10 : 0.15), lineWidth: 1)
+                .stroke(Color.white.opacity(0.15), lineWidth: 1)
         )
     }
 }
@@ -467,7 +466,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
         hostingView.frame = bounds
         hostingView.autoresizingMask = [.width, .height]
         addSubview(hostingView)
-        toolTip = "Drag \(appName) into the Accessibility list"
+        toolTip = "Drag \(appName) into the permission list"
     }
 
     override func resetCursorRects() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -114,10 +114,24 @@ enum AccessibilityPermissionGuideCopy {
 }
 
 enum AccessibilityPermissionGuideRetryPolicy {
-    static let attemptedDropRetryDelay: TimeInterval = 4
+    static let permissionCheckInterval: TimeInterval = 0.5
+    static let attemptedDropRetryWindow: TimeInterval = 10
 
-    static func shouldRestoreDragSource(didAttemptDrop: Bool, isGranted: Bool) -> Bool {
-        didAttemptDrop && !isGranted
+    static func retryDeadline(startingAt date: Date) -> Date {
+        date.addingTimeInterval(attemptedDropRetryWindow)
+    }
+
+    static func shouldRestoreDragSource(
+        didAttemptDrop: Bool,
+        isGranted: Bool,
+        retryDeadline: Date?,
+        now: Date,
+        isMuesliFrontmost: Bool
+    ) -> Bool {
+        guard didAttemptDrop, !isGranted else { return false }
+        if isMuesliFrontmost { return true }
+        guard let retryDeadline else { return false }
+        return now >= retryDeadline
     }
 }
 
@@ -215,7 +229,7 @@ final class AccessibilityPermissionGuideController {
     private var guidePanel: NSPanel?
     private var dragPanel: NSPanel?
     private var refreshTimer: Timer?
-    private var attemptedDropRetryTimer: Timer?
+    private var attemptedDropRetryDeadline: Date?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var applicationObservers: [NSObjectProtocol] = []
     private var requestedPermission: PermissionDragGuidePermission?
@@ -239,8 +253,7 @@ final class AccessibilityPermissionGuideController {
 
         // Each explicit invocation starts with a draggable row. A prior drop is
         // only an attempt; the TCC permission state is the sole completion signal.
-        cancelAttemptedDropRetry()
-        model.didAttemptDrop = false
+        resetAttemptedDrop()
         requestedPermission = permission
         installObserversIfNeeded()
         startRefreshTimerIfNeeded()
@@ -251,7 +264,7 @@ final class AccessibilityPermissionGuideController {
         requestedPermission = nil
         refreshTimer?.invalidate()
         refreshTimer = nil
-        cancelAttemptedDropRetry()
+        resetAttemptedDrop()
 
         let workspaceCenter = NSWorkspace.shared.notificationCenter
         workspaceObservers.forEach { workspaceCenter.removeObserver($0) }
@@ -298,7 +311,10 @@ final class AccessibilityPermissionGuideController {
 
     private func startRefreshTimerIfNeeded() {
         guard refreshTimer == nil else { return }
-        let timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+        let timer = Timer.scheduledTimer(
+            withTimeInterval: AccessibilityPermissionGuideRetryPolicy.permissionCheckInterval,
+            repeats: true
+        ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.refreshPresentation()
             }
@@ -313,12 +329,22 @@ final class AccessibilityPermissionGuideController {
             return
         }
 
-        if requestedPermission.isGranted {
+        let isGranted = requestedPermission.isGranted
+        if isGranted {
             dismiss()
             return
         }
 
         let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        if AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: model.didAttemptDrop,
+            isGranted: isGranted,
+            retryDeadline: attemptedDropRetryDeadline,
+            now: Date(),
+            isMuesliFrontmost: frontmostBundleID == Bundle.main.bundleIdentifier
+        ) {
+            resetAttemptedDrop()
+        }
         let settingsWindow = SystemSettingsWindowLocator.mainWindowFrame()
         let frames = settingsWindow.flatMap {
             AccessibilityPermissionGuideLayout.frames(for: $0)
@@ -384,8 +410,7 @@ final class AccessibilityPermissionGuideController {
                     settingsWindow: SystemSettingsWindowLocator.mainWindowFrame()
                 )
                 guard isLikelyPermissionListDropAttempt else {
-                    self.cancelAttemptedDropRetry()
-                    self.model.didAttemptDrop = false
+                    self.resetAttemptedDrop()
                     self.refreshPresentation()
                     return
                 }
@@ -393,7 +418,8 @@ final class AccessibilityPermissionGuideController {
                 // the URL, but not which System Settings view accepted it. Treat
                 // this as an attempted drop, never as proof that Muesli was added.
                 self.model.didAttemptDrop = true
-                self.scheduleAttemptedDropRetry()
+                self.attemptedDropRetryDeadline = AccessibilityPermissionGuideRetryPolicy
+                    .retryDeadline(startingAt: Date())
                 self.refreshPresentation()
             }
             dragPanel = makePanel(
@@ -404,35 +430,9 @@ final class AccessibilityPermissionGuideController {
         }
     }
 
-    private func scheduleAttemptedDropRetry() {
-        cancelAttemptedDropRetry()
-
-        let timer = Timer(
-            timeInterval: AccessibilityPermissionGuideRetryPolicy.attemptedDropRetryDelay,
-            repeats: false
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.attemptedDropRetryTimer = nil
-                guard let requestedPermission = self.requestedPermission,
-                      AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
-                        didAttemptDrop: self.model.didAttemptDrop,
-                        isGranted: requestedPermission.isGranted
-                      ) else {
-                    return
-                }
-
-                self.model.didAttemptDrop = false
-                self.refreshPresentation()
-            }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        attemptedDropRetryTimer = timer
-    }
-
-    private func cancelAttemptedDropRetry() {
-        attemptedDropRetryTimer?.invalidate()
-        attemptedDropRetryTimer = nil
+    private func resetAttemptedDrop() {
+        attemptedDropRetryDeadline = nil
+        model.didAttemptDrop = false
     }
 
     private func setOnboardingPresentation(

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -6,6 +6,7 @@ struct AccessibilityPermissionGuideFrames: Equatable {
     let guide: CGRect
     let dragSource: CGRect
     let completedGuide: CGRect
+    let permissionListDropRegion: CGRect
     let dragDirection: PermissionGuideDragDirection
 }
 
@@ -57,12 +58,50 @@ enum AccessibilityPermissionGuideLayout {
             height: 56
         )
 
+        let dragDirection: PermissionGuideDragDirection = guide.midY <= settingsWindow.midY ? .up : .down
+        let contentTop = settingsWindow.maxY - 88
+        let contentBottom = settingsWindow.minY + 64
+        let permissionListDropRegion: CGRect
+        if dragDirection == .up {
+            permissionListDropRegion = CGRect(
+                x: dragSource.minX,
+                y: guide.maxY + 8,
+                width: dragSource.width,
+                height: max(0, contentTop - guide.maxY - 8)
+            )
+        } else {
+            permissionListDropRegion = CGRect(
+                x: dragSource.minX,
+                y: contentBottom,
+                width: dragSource.width,
+                height: max(0, guide.minY - contentBottom - 8)
+            )
+        }
+
         return AccessibilityPermissionGuideFrames(
             guide: guide.integral,
             dragSource: dragSource.integral,
             completedGuide: completedGuide.integral,
-            dragDirection: guide.midY <= settingsWindow.midY ? .up : .down
+            permissionListDropRegion: permissionListDropRegion.integral,
+            dragDirection: dragDirection
         )
+    }
+}
+
+enum AccessibilityPermissionGuideDropPolicy {
+    static func isPermissionListDrop(
+        operationAccepted: Bool,
+        dropPoint: CGPoint,
+        frontmostBundleID: String?,
+        settingsWindow: CGRect?
+    ) -> Bool {
+        guard operationAccepted,
+              frontmostBundleID == AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
+              let settingsWindow,
+              let frames = AccessibilityPermissionGuideLayout.frames(for: settingsWindow) else {
+            return false
+        }
+        return frames.permissionListDropRegion.contains(dropPoint)
     }
 }
 
@@ -93,6 +132,25 @@ enum AccessibilityPermissionGuidePresentationPolicy {
             && !isGranted
             && frontmostBundleID == systemSettingsBundleID
             && hasSettingsWindow
+    }
+}
+
+enum AccessibilityPermissionGuideSuppressionPolicy {
+    static func shouldSuppressOnboarding(
+        isRequested: Bool,
+        isGranted: Bool,
+        frontmostBundleID: String?,
+        muesliBundleID: String?,
+        isCurrentlySuppressed: Bool
+    ) -> Bool {
+        guard isRequested, !isGranted else { return false }
+        if frontmostBundleID == AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID {
+            return true
+        }
+        if frontmostBundleID == muesliBundleID {
+            return false
+        }
+        return isCurrentlySuppressed
     }
 }
 
@@ -218,6 +276,13 @@ final class AccessibilityPermissionGuideController {
         }
 
         let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        setPresenting(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: frontmostBundleID,
+            muesliBundleID: Bundle.main.bundleIdentifier,
+            isCurrentlySuppressed: isPresenting
+        ))
         let settingsWindow = SystemSettingsWindowLocator.mainWindowFrame()
         guard AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
@@ -227,12 +292,10 @@ final class AccessibilityPermissionGuideController {
         ), let settingsWindow,
            let frames = AccessibilityPermissionGuideLayout.frames(for: settingsWindow) else {
             hidePanels()
-            setPresenting(false)
             return
         }
 
         ensurePanels()
-        setPresenting(true)
         model.dragDirection = frames.dragDirection
         if model.didCompleteDrag {
             guidePanel?.setFrame(frames.completedGuide, display: true)
@@ -266,8 +329,19 @@ final class AccessibilityPermissionGuideController {
                 appName: appName,
                 appIcon: appIcon
             )
-            dragView.onDragEnded = { [weak self] in
+            dragView.onDragEnded = { [weak self] screenPoint, operation in
                 guard let self else { return }
+                let isPermissionListDrop = AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+                    operationAccepted: !operation.isEmpty,
+                    dropPoint: screenPoint,
+                    frontmostBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
+                    settingsWindow: SystemSettingsWindowLocator.mainWindowFrame()
+                )
+                guard isPermissionListDrop else {
+                    self.model.didCompleteDrag = false
+                    self.refreshPresentation()
+                    return
+                }
                 self.model.didCompleteDrag = true
                 self.refreshPresentation()
             }
@@ -493,7 +567,7 @@ private struct PermissionGuideAppRow: View {
 
 @MainActor
 private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSource {
-    var onDragEnded: (() -> Void)?
+    var onDragEnded: ((NSPoint, NSDragOperation) -> Void)?
 
     private let appURL: URL
     private var mouseDownLocation: CGPoint?
@@ -588,9 +662,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
         mouseDownLocation = nil
         hasStartedDrag = false
         NSCursor.openHand.set()
-        if !operation.isEmpty {
-            onDragEnded?()
-        }
+        onDragEnded?(screenPoint, operation)
     }
 
     private func dragImage() -> NSImage {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -113,6 +113,14 @@ enum AccessibilityPermissionGuideCopy {
     static let attemptedDropDetail = "If it appears above, turn on its switch"
 }
 
+enum AccessibilityPermissionGuideRetryPolicy {
+    static let attemptedDropRetryDelay: TimeInterval = 4
+
+    static func shouldRestoreDragSource(didAttemptDrop: Bool, isGranted: Bool) -> Bool {
+        didAttemptDrop && !isGranted
+    }
+}
+
 enum PermissionDragGuidePermission {
     case accessibility
     case inputMonitoring
@@ -186,6 +194,7 @@ final class AccessibilityPermissionGuideController {
     private var guidePanel: NSPanel?
     private var dragPanel: NSPanel?
     private var refreshTimer: Timer?
+    private var attemptedDropRetryTimer: Timer?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var applicationObservers: [NSObjectProtocol] = []
     private var requestedPermission: PermissionDragGuidePermission?
@@ -209,6 +218,7 @@ final class AccessibilityPermissionGuideController {
 
         // Each explicit invocation starts with a draggable row. A prior drop is
         // only an attempt; the TCC permission state is the sole completion signal.
+        cancelAttemptedDropRetry()
         model.didAttemptDrop = false
         requestedPermission = permission
         installObserversIfNeeded()
@@ -220,6 +230,7 @@ final class AccessibilityPermissionGuideController {
         requestedPermission = nil
         refreshTimer?.invalidate()
         refreshTimer = nil
+        cancelAttemptedDropRetry()
 
         let workspaceCenter = NSWorkspace.shared.notificationCenter
         workspaceObservers.forEach { workspaceCenter.removeObserver($0) }
@@ -353,6 +364,7 @@ final class AccessibilityPermissionGuideController {
                     settingsWindow: SystemSettingsWindowLocator.mainWindowFrame()
                 )
                 guard isLikelyPermissionListDropAttempt else {
+                    self.cancelAttemptedDropRetry()
                     self.model.didAttemptDrop = false
                     self.refreshPresentation()
                     return
@@ -361,6 +373,7 @@ final class AccessibilityPermissionGuideController {
                 // the URL, but not which System Settings view accepted it. Treat
                 // this as an attempted drop, never as proof that Muesli was added.
                 self.model.didAttemptDrop = true
+                self.scheduleAttemptedDropRetry()
                 self.refreshPresentation()
             }
             dragPanel = makePanel(
@@ -369,6 +382,37 @@ final class AccessibilityPermissionGuideController {
                 contentView: dragView
             )
         }
+    }
+
+    private func scheduleAttemptedDropRetry() {
+        cancelAttemptedDropRetry()
+
+        let timer = Timer(
+            timeInterval: AccessibilityPermissionGuideRetryPolicy.attemptedDropRetryDelay,
+            repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.attemptedDropRetryTimer = nil
+                guard let requestedPermission = self.requestedPermission,
+                      AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+                        didAttemptDrop: self.model.didAttemptDrop,
+                        isGranted: requestedPermission.isGranted
+                      ) else {
+                    return
+                }
+
+                self.model.didAttemptDrop = false
+                self.refreshPresentation()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        attemptedDropRetryTimer = timer
+    }
+
+    private func cancelAttemptedDropRetry() {
+        attemptedDropRetryTimer?.invalidate()
+        attemptedDropRetryTimer = nil
     }
 
     private func setPresenting(_ presenting: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -3,9 +3,9 @@ import ApplicationServices
 import SwiftUI
 
 struct AccessibilityPermissionGuideFrames: Equatable {
-    let target: CGRect
-    let card: CGRect
+    let guide: CGRect
     let dragSource: CGRect
+    let completedGuide: CGRect
 }
 
 enum AccessibilityPermissionGuideLayout {
@@ -18,34 +18,35 @@ enum AccessibilityPermissionGuideLayout {
         let contentWidth = contentMaxX - contentMinX
         guard contentWidth >= 360 else { return nil }
 
-        let targetHeight = min(250, max(170, settingsWindow.height * 0.30))
-        let target = CGRect(
-            x: contentMinX,
-            y: settingsWindow.minY + settingsWindow.height * 0.38,
-            width: contentWidth,
-            height: targetHeight
-        )
-
-        let cardWidth = min(560, contentWidth - 24)
-        let cardHeight: CGFloat = 190
-        let card = CGRect(
-            x: contentMinX + (contentWidth - cardWidth) / 2,
-            y: max(settingsWindow.minY + 28, target.minY - cardHeight - 12),
-            width: cardWidth,
-            height: cardHeight
+        let guideWidth = min(720, contentWidth - 16)
+        let guideHeight: CGFloat = 226
+        let preferredY = settingsWindow.minY + max(96, settingsWindow.height * 0.22)
+        let guideY = min(preferredY, settingsWindow.maxY - guideHeight - 92)
+        let guide = CGRect(
+            x: contentMinX + (contentWidth - guideWidth) / 2,
+            y: guideY,
+            width: guideWidth,
+            height: guideHeight
         )
 
         let dragSource = CGRect(
-            x: card.minX + 24,
-            y: card.minY + 52,
-            width: card.width - 48,
-            height: 68
+            x: guide.minX + 14,
+            y: guide.minY + 14,
+            width: guide.width - 28,
+            height: 76
+        )
+
+        let completedGuide = CGRect(
+            x: guide.minX + 46,
+            y: dragSource.minY + 8,
+            width: guide.width - 92,
+            height: 58
         )
 
         return AccessibilityPermissionGuideFrames(
-            target: target.integral,
-            card: card.integral,
-            dragSource: dragSource.integral
+            guide: guide.integral,
+            dragSource: dragSource.integral,
+            completedGuide: completedGuide.integral
         )
     }
 }
@@ -79,18 +80,20 @@ enum SystemSettingsWindowGeometry {
 
 @MainActor
 final class AccessibilityPermissionGuideController {
+    var onPresentationChanged: ((Bool) -> Void)?
+
     private let appURL: URL
     private let appName: String
     private let appIcon: NSImage
     private let model = AccessibilityPermissionGuideModel()
 
-    private var targetPanel: NSPanel?
-    private var cardPanel: NSPanel?
+    private var guidePanel: NSPanel?
     private var dragPanel: NSPanel?
     private var refreshTimer: Timer?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var applicationObservers: [NSObjectProtocol] = []
     private var isRequested = false
+    private var isPresenting = false
 
     init(
         appURL: URL = Bundle.main.bundleURL,
@@ -128,6 +131,7 @@ final class AccessibilityPermissionGuideController {
         applicationObservers.forEach { notificationCenter.removeObserver($0) }
         applicationObservers.removeAll()
 
+        setPresenting(false)
         closePanels()
     }
 
@@ -189,38 +193,33 @@ final class AccessibilityPermissionGuideController {
         ), let settingsWindow,
            let frames = AccessibilityPermissionGuideLayout.frames(for: settingsWindow) else {
             hidePanels()
+            setPresenting(false)
             return
         }
 
         ensurePanels()
-        targetPanel?.setFrame(frames.target, display: true)
-        cardPanel?.setFrame(frames.card, display: true)
-        dragPanel?.setFrame(frames.dragSource, display: true)
-
-        targetPanel?.orderFrontRegardless()
-        cardPanel?.orderFrontRegardless()
-        dragPanel?.orderFrontRegardless()
+        setPresenting(true)
+        if model.didCompleteDrag {
+            guidePanel?.setFrame(frames.completedGuide, display: true)
+            dragPanel?.orderOut(nil)
+        } else {
+            guidePanel?.setFrame(frames.guide, display: true)
+            dragPanel?.setFrame(frames.dragSource, display: true)
+        }
+        guidePanel?.orderFrontRegardless()
+        if !model.didCompleteDrag {
+            dragPanel?.orderFrontRegardless()
+        }
     }
 
     private func ensurePanels() {
-        if targetPanel == nil {
-            targetPanel = makePanel(
+        if guidePanel == nil {
+            guidePanel = makePanel(
                 frame: .zero,
                 ignoresMouseEvents: true,
-                contentView: NSHostingView(rootView: AccessibilityPermissionGuideTargetView(
+                contentView: NSHostingView(rootView: CompactAccessibilityPermissionGuideView(
                     appName: appName,
                     appIcon: appIcon,
-                    model: model
-                ).preferredColorScheme(.dark))
-            )
-        }
-
-        if cardPanel == nil {
-            cardPanel = makePanel(
-                frame: .zero,
-                ignoresMouseEvents: true,
-                contentView: NSHostingView(rootView: AccessibilityPermissionGuideCardView(
-                    appName: appName,
                     model: model
                 ).preferredColorScheme(.dark))
             )
@@ -234,7 +233,9 @@ final class AccessibilityPermissionGuideController {
                 appIcon: appIcon
             )
             dragView.onDragEnded = { [weak self] in
-                self?.model.didCompleteDrag = true
+                guard let self else { return }
+                self.model.didCompleteDrag = true
+                self.refreshPresentation()
             }
             dragPanel = makePanel(
                 frame: .zero,
@@ -242,6 +243,12 @@ final class AccessibilityPermissionGuideController {
                 contentView: dragView
             )
         }
+    }
+
+    private func setPresenting(_ presenting: Bool) {
+        guard isPresenting != presenting else { return }
+        isPresenting = presenting
+        onPresentationChanged?(presenting)
     }
 
     private func makePanel(
@@ -270,18 +277,16 @@ final class AccessibilityPermissionGuideController {
     }
 
     private func hidePanels() {
-        targetPanel?.orderOut(nil)
-        cardPanel?.orderOut(nil)
+        guidePanel?.orderOut(nil)
         dragPanel?.orderOut(nil)
     }
 
     private func closePanels() {
-        for panel in [targetPanel, cardPanel, dragPanel] {
+        for panel in [guidePanel, dragPanel] {
             panel?.orderOut(nil)
             panel?.close()
         }
-        targetPanel = nil
-        cardPanel = nil
+        guidePanel = nil
         dragPanel = nil
     }
 }
@@ -329,7 +334,7 @@ private final class AccessibilityPermissionGuideModel: ObservableObject {
     @Published var didCompleteDrag = false
 }
 
-private struct AccessibilityPermissionGuideTargetView: View {
+private struct CompactAccessibilityPermissionGuideView: View {
     let appName: String
     let appIcon: NSImage
     @ObservedObject var model: AccessibilityPermissionGuideModel
@@ -338,69 +343,78 @@ private struct AccessibilityPermissionGuideTargetView: View {
     @State private var isAnimating = false
 
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 22)
-                .fill(Color.black.opacity(0.12))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 22)
-                        .stroke(
-                            MuesliTheme.accent,
-                            style: StrokeStyle(lineWidth: 2.5, dash: [9, 7])
-                        )
-                )
+        Group {
+            if model.didCompleteDrag {
+                HStack(spacing: 10) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.success)
 
-            VStack(spacing: 8) {
-                Image(systemName: model.didCompleteDrag ? "checkmark" : "arrow.up")
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundStyle(model.didCompleteDrag ? MuesliTheme.success : MuesliTheme.accent)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("\(appName) added")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Color.white.opacity(0.94))
+                        Text("Turn it on in the list above")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(Color.white.opacity(0.62))
+                    }
 
-                PermissionGuideAppRow(appName: appName, appIcon: appIcon, isGhost: true)
-                    .frame(maxWidth: 430)
-                    .offset(y: reduceMotion || model.didCompleteDrag ? 0 : (isAnimating ? -30 : 28))
-                    .opacity(model.didCompleteDrag ? 0.62 : 0.88)
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 16)
+            } else {
+                VStack(spacing: 5) {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 21, weight: .bold))
+                        .foregroundStyle(MuesliTheme.accent)
+
+                    PermissionGuideAppRow(appName: appName, appIcon: appIcon, isGhost: true)
+                        .frame(height: 52)
+                        .offset(y: reduceMotion ? 0 : (isAnimating ? -7 : 4))
+
+                    Text("Drag this row up into the list")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(Color.white.opacity(0.66))
+
+                    Spacer(minLength: 88)
+                }
+                .padding(.horizontal, 14)
+                .padding(.top, 12)
             }
-            .padding(.horizontal, 24)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: NSColor(red: 0.10, green: 0.12, blue: 0.14, alpha: 0.91)))
+        .clipShape(RoundedRectangle(cornerRadius: model.didCompleteDrag ? 14 : 18))
+        .overlay(
+            RoundedRectangle(cornerRadius: model.didCompleteDrag ? 14 : 18)
+                .stroke(Color.white.opacity(0.10), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.18), radius: 12, y: 5)
         .padding(2)
         .onAppear {
-            guard !reduceMotion, !model.didCompleteDrag else { return }
-            withAnimation(.easeInOut(duration: 1.45).repeatForever(autoreverses: false)) {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
                 isAnimating = true
             }
         }
     }
 }
 
-private struct AccessibilityPermissionGuideCardView: View {
+private struct AccessibilityPermissionDragRowView: View {
     let appName: String
-    @ObservedObject var model: AccessibilityPermissionGuideModel
+    let appIcon: NSImage
 
     var body: some View {
-        VStack(spacing: 0) {
-            Text(model.didCompleteDrag ? "Turn \(appName) on" : "Drag \(appName) into the list")
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(.white)
-                .padding(.top, 20)
-
-            Spacer()
-                .frame(height: 80)
-
-            Text(model.didCompleteDrag
-                ? "Use the switch beside \(appName) above."
-                : "If it is already listed, just turn its switch on.")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(Color.white.opacity(0.66))
-                .padding(.bottom, 18)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: NSColor(red: 0.10, green: 0.12, blue: 0.14, alpha: 0.96)))
-        .clipShape(RoundedRectangle(cornerRadius: 22))
-        .overlay(
-            RoundedRectangle(cornerRadius: 22)
-                .stroke(Color.white.opacity(0.12), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.34), radius: 20, y: 8)
-        .padding(2)
+        PermissionGuideAppRow(appName: appName, appIcon: appIcon)
+            .padding(7)
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(
+                        MuesliTheme.accent,
+                        style: StrokeStyle(lineWidth: 2, dash: [7, 5])
+                    )
+            )
+            .padding(1)
     }
 }
 
@@ -414,28 +428,22 @@ private struct PermissionGuideAppRow: View {
             Image(nsImage: appIcon)
                 .resizable()
                 .scaledToFit()
-                .frame(width: 34, height: 34)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .frame(width: 30, height: 30)
+                .clipShape(RoundedRectangle(cornerRadius: 7))
 
             Text(appName)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.white.opacity(isGhost ? 0.84 : 0.94))
 
             Spacer()
-
-            if !isGhost {
-                Image(systemName: "hand.draw.fill")
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(MuesliTheme.accent)
-            }
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 14)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.white.opacity(isGhost ? 0.08 : 0.11))
-        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .background(Color.white.opacity(isGhost ? 0.07 : 0.10))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(Color.white.opacity(isGhost ? 0.12 : 0.18), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(isGhost ? 0.10 : 0.15), lineWidth: 1)
         )
     }
 }
@@ -452,7 +460,7 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
         self.appURL = appURL
         super.init(frame: frameRect)
 
-        let hostingView = NSHostingView(rootView: PermissionGuideAppRow(
+        let hostingView = NSHostingView(rootView: AccessibilityPermissionDragRowView(
             appName: appName,
             appIcon: appIcon
         ).preferredColorScheme(.dark))
@@ -460,6 +468,10 @@ private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSou
         hostingView.autoresizingMask = [.width, .height]
         addSubview(hostingView)
         toolTip = "Drag \(appName) into the Accessibility list"
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .openHand)
     }
 
     @available(*, unavailable)

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct AccessibilityPermissionGuideFrames: Equatable {
     let guide: CGRect
     let dragSource: CGRect
-    let completedGuide: CGRect
+    let postDropGuide: CGRect
     let permissionListDropRegion: CGRect
     let dragDirection: PermissionGuideDragDirection
 }
@@ -51,7 +51,7 @@ enum AccessibilityPermissionGuideLayout {
             height: 70
         )
 
-        let completedGuide = CGRect(
+        let postDropGuide = CGRect(
             x: guide.minX + 64,
             y: dragSource.minY + 7,
             width: guide.width - 128,
@@ -81,7 +81,7 @@ enum AccessibilityPermissionGuideLayout {
         return AccessibilityPermissionGuideFrames(
             guide: guide.integral,
             dragSource: dragSource.integral,
-            completedGuide: completedGuide.integral,
+            postDropGuide: postDropGuide.integral,
             permissionListDropRegion: permissionListDropRegion.integral,
             dragDirection: dragDirection
         )
@@ -89,7 +89,7 @@ enum AccessibilityPermissionGuideLayout {
 }
 
 enum AccessibilityPermissionGuideDropPolicy {
-    static func isPermissionListDrop(
+    static func isLikelyPermissionListDropAttempt(
         operationAccepted: Bool,
         dropPoint: CGPoint,
         frontmostBundleID: String?,
@@ -105,13 +105,12 @@ enum AccessibilityPermissionGuideDropPolicy {
     }
 }
 
-enum AccessibilityPermissionGuideInvocationPolicy {
-    static func shouldResetDragCompletion(
-        previousPermission: PermissionDragGuidePermission?,
-        nextPermission: PermissionDragGuidePermission
-    ) -> Bool {
-        previousPermission != nextPermission
+enum AccessibilityPermissionGuideCopy {
+    static func attemptedDropTitle(appName: String) -> String {
+        "Turn \(appName) on"
     }
+
+    static let attemptedDropDetail = "If it appears above, turn on its switch"
 }
 
 enum PermissionDragGuidePermission {
@@ -150,11 +149,12 @@ enum AccessibilityPermissionGuideSuppressionPolicy {
         isGranted: Bool,
         frontmostBundleID: String?,
         muesliBundleID: String?,
+        hasUsableGuide: Bool,
         isCurrentlySuppressed: Bool
     ) -> Bool {
         guard isRequested, !isGranted else { return false }
         if frontmostBundleID == AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID {
-            return true
+            return hasUsableGuide
         }
         if frontmostBundleID == muesliBundleID {
             return false
@@ -207,12 +207,9 @@ final class AccessibilityPermissionGuideController {
             return
         }
 
-        if AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
-            previousPermission: requestedPermission,
-            nextPermission: permission
-        ) {
-            model.didCompleteDrag = false
-        }
+        // Each explicit invocation starts with a draggable row. A prior drop is
+        // only an attempt; the TCC permission state is the sole completion signal.
+        model.didAttemptDrop = false
         requestedPermission = permission
         installObserversIfNeeded()
         startRefreshTimerIfNeeded()
@@ -290,36 +287,39 @@ final class AccessibilityPermissionGuideController {
         }
 
         let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        let settingsWindow = SystemSettingsWindowLocator.mainWindowFrame()
+        let frames = settingsWindow.flatMap {
+            AccessibilityPermissionGuideLayout.frames(for: $0)
+        }
         setPresenting(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: frontmostBundleID,
             muesliBundleID: Bundle.main.bundleIdentifier,
+            hasUsableGuide: frames != nil,
             isCurrentlySuppressed: isPresenting
         ))
-        let settingsWindow = SystemSettingsWindowLocator.mainWindowFrame()
         guard AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: frontmostBundleID,
-            hasSettingsWindow: settingsWindow != nil
-        ), let settingsWindow,
-           let frames = AccessibilityPermissionGuideLayout.frames(for: settingsWindow) else {
+            hasSettingsWindow: frames != nil
+        ), let frames else {
             hidePanels()
             return
         }
 
         ensurePanels()
         model.dragDirection = frames.dragDirection
-        if model.didCompleteDrag {
-            guidePanel?.setFrame(frames.completedGuide, display: true)
+        if model.didAttemptDrop {
+            guidePanel?.setFrame(frames.postDropGuide, display: true)
             dragPanel?.orderOut(nil)
         } else {
             guidePanel?.setFrame(frames.guide, display: true)
             dragPanel?.setFrame(frames.dragSource, display: true)
         }
         guidePanel?.orderFrontRegardless()
-        if !model.didCompleteDrag {
+        if !model.didAttemptDrop {
             dragPanel?.orderFrontRegardless()
         }
     }
@@ -345,18 +345,22 @@ final class AccessibilityPermissionGuideController {
             )
             dragView.onDragEnded = { [weak self] screenPoint, operation in
                 guard let self else { return }
-                let isPermissionListDrop = AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+                let isLikelyPermissionListDropAttempt = AccessibilityPermissionGuideDropPolicy
+                    .isLikelyPermissionListDropAttempt(
                     operationAccepted: !operation.isEmpty,
                     dropPoint: screenPoint,
                     frontmostBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
                     settingsWindow: SystemSettingsWindowLocator.mainWindowFrame()
                 )
-                guard isPermissionListDrop else {
-                    self.model.didCompleteDrag = false
+                guard isLikelyPermissionListDropAttempt else {
+                    self.model.didAttemptDrop = false
                     self.refreshPresentation()
                     return
                 }
-                self.model.didCompleteDrag = true
+                // AppKit tells a dragging source that some destination accepted
+                // the URL, but not which System Settings view accepted it. Treat
+                // this as an attempted drop, never as proof that Muesli was added.
+                self.model.didAttemptDrop = true
                 self.refreshPresentation()
             }
             dragPanel = makePanel(
@@ -453,7 +457,7 @@ private enum SystemSettingsWindowLocator {
 
 @MainActor
 private final class AccessibilityPermissionGuideModel: ObservableObject {
-    @Published var didCompleteDrag = false
+    @Published var didAttemptDrop = false
     @Published var dragDirection: PermissionGuideDragDirection = .up
 }
 
@@ -465,17 +469,17 @@ private struct CompactAccessibilityPermissionGuideView: View {
 
     var body: some View {
         Group {
-            if model.didCompleteDrag {
+            if model.didAttemptDrop {
                 HStack(spacing: 10) {
-                    Image(systemName: "checkmark.circle.fill")
+                    Image(systemName: "hand.tap.fill")
                         .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.success)
+                        .foregroundStyle(MuesliTheme.accent)
 
                     VStack(alignment: .leading, spacing: 1) {
-                        Text("\(appName) added")
+                        Text(AccessibilityPermissionGuideCopy.attemptedDropTitle(appName: appName))
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(Color.white.opacity(0.94))
-                        Text("Turn it on in the list above")
+                        Text(AccessibilityPermissionGuideCopy.attemptedDropDetail)
                             .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(Color.white.opacity(0.62))
                     }
@@ -504,9 +508,9 @@ private struct CompactAccessibilityPermissionGuideView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: NSColor(red: 0.10, green: 0.12, blue: 0.14, alpha: 0.91)))
-        .clipShape(RoundedRectangle(cornerRadius: model.didCompleteDrag ? 14 : 18))
+        .clipShape(RoundedRectangle(cornerRadius: model.didAttemptDrop ? 14 : 18))
         .overlay(
-            RoundedRectangle(cornerRadius: model.didCompleteDrag ? 14 : 18)
+            RoundedRectangle(cornerRadius: model.didAttemptDrop ? 14 : 18)
                 .stroke(Color.white.opacity(0.10), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.10), radius: 10, y: 4)

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -152,23 +152,44 @@ enum AccessibilityPermissionGuidePresentationPolicy {
 }
 
 enum AccessibilityPermissionGuideSuppressionPolicy {
-    static func shouldSuppressOnboarding(
+    static func onboardingPresentation(
         isRequested: Bool,
         isGranted: Bool,
         frontmostBundleID: String?,
         muesliBundleID: String?,
-        hasUsableGuide: Bool,
-        isCurrentlySuppressed: Bool
-    ) -> Bool {
-        guard isRequested, !isGranted else { return false }
-        if frontmostBundleID == AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID {
-            return hasUsableGuide
+        hasUsableGuide: Bool
+    ) -> AccessibilityPermissionGuideOnboardingPresentation {
+        if shouldSuppressOnboarding(
+            isRequested: isRequested,
+            isGranted: isGranted,
+            frontmostBundleID: frontmostBundleID,
+            hasUsableGuide: hasUsableGuide
+        ) {
+            return .suppressed
         }
-        if frontmostBundleID == muesliBundleID {
-            return false
+        if !isRequested || isGranted || frontmostBundleID == muesliBundleID {
+            return .restoredAndActive
         }
-        return isCurrentlySuppressed
+        return .restoredWithoutActivation
     }
+
+    static func shouldSuppressOnboarding(
+        isRequested: Bool,
+        isGranted: Bool,
+        frontmostBundleID: String?,
+        hasUsableGuide: Bool
+    ) -> Bool {
+        isRequested
+            && !isGranted
+            && frontmostBundleID == AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID
+            && hasUsableGuide
+    }
+}
+
+enum AccessibilityPermissionGuideOnboardingPresentation: Equatable {
+    case suppressed
+    case restoredWithoutActivation
+    case restoredAndActive
 }
 
 enum SystemSettingsWindowGeometry {
@@ -184,7 +205,7 @@ enum SystemSettingsWindowGeometry {
 
 @MainActor
 final class AccessibilityPermissionGuideController {
-    var onPresentationChanged: ((Bool) -> Void)?
+    var onPresentationChanged: ((AccessibilityPermissionGuideOnboardingPresentation) -> Void)?
 
     private let appURL: URL
     private let appName: String
@@ -198,7 +219,7 @@ final class AccessibilityPermissionGuideController {
     private var workspaceObservers: [NSObjectProtocol] = []
     private var applicationObservers: [NSObjectProtocol] = []
     private var requestedPermission: PermissionDragGuidePermission?
-    private var isPresenting = false
+    private var onboardingPresentation: AccessibilityPermissionGuideOnboardingPresentation = .restoredAndActive
 
     init(
         appURL: URL = Bundle.main.bundleURL,
@@ -240,7 +261,7 @@ final class AccessibilityPermissionGuideController {
         applicationObservers.forEach { notificationCenter.removeObserver($0) }
         applicationObservers.removeAll()
 
-        setPresenting(false)
+        setOnboardingPresentation(.restoredAndActive)
         closePanels()
     }
 
@@ -302,13 +323,12 @@ final class AccessibilityPermissionGuideController {
         let frames = settingsWindow.flatMap {
             AccessibilityPermissionGuideLayout.frames(for: $0)
         }
-        setPresenting(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+        setOnboardingPresentation(AccessibilityPermissionGuideSuppressionPolicy.onboardingPresentation(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: frontmostBundleID,
             muesliBundleID: Bundle.main.bundleIdentifier,
-            hasUsableGuide: frames != nil,
-            isCurrentlySuppressed: isPresenting
+            hasUsableGuide: frames != nil
         ))
         guard AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
@@ -415,10 +435,12 @@ final class AccessibilityPermissionGuideController {
         attemptedDropRetryTimer = nil
     }
 
-    private func setPresenting(_ presenting: Bool) {
-        guard isPresenting != presenting else { return }
-        isPresenting = presenting
-        onPresentationChanged?(presenting)
+    private func setOnboardingPresentation(
+        _ presentation: AccessibilityPermissionGuideOnboardingPresentation
+    ) {
+        guard onboardingPresentation != presentation else { return }
+        onboardingPresentation = presentation
+        onPresentationChanged?(presentation)
     }
 
     private func makePanel(

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -135,9 +135,20 @@ enum AccessibilityPermissionGuideRetryPolicy {
     }
 }
 
-enum PermissionDragGuidePermission {
+enum PermissionDragGuidePermission: Equatable {
     case accessibility
     case inputMonitoring
+
+    init?(permissionName: String) {
+        switch permissionName {
+        case "Accessibility":
+            self = .accessibility
+        case "Input Monitoring":
+            self = .inputMonitoring
+        default:
+            return nil
+        }
+    }
 
     var isGranted: Bool {
         switch self {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AccessibilityPermissionGuideController.swift
@@ -1,0 +1,519 @@
+import AppKit
+import ApplicationServices
+import SwiftUI
+
+struct AccessibilityPermissionGuideFrames: Equatable {
+    let target: CGRect
+    let card: CGRect
+    let dragSource: CGRect
+}
+
+enum AccessibilityPermissionGuideLayout {
+    static func frames(for settingsWindow: CGRect) -> AccessibilityPermissionGuideFrames? {
+        guard settingsWindow.width >= 720, settingsWindow.height >= 500 else { return nil }
+
+        let sidebarWidth = min(max(settingsWindow.width * 0.32, 250), 370)
+        let contentMinX = settingsWindow.minX + sidebarWidth + 24
+        let contentMaxX = settingsWindow.maxX - 28
+        let contentWidth = contentMaxX - contentMinX
+        guard contentWidth >= 360 else { return nil }
+
+        let targetHeight = min(250, max(170, settingsWindow.height * 0.30))
+        let target = CGRect(
+            x: contentMinX,
+            y: settingsWindow.minY + settingsWindow.height * 0.38,
+            width: contentWidth,
+            height: targetHeight
+        )
+
+        let cardWidth = min(560, contentWidth - 24)
+        let cardHeight: CGFloat = 190
+        let card = CGRect(
+            x: contentMinX + (contentWidth - cardWidth) / 2,
+            y: max(settingsWindow.minY + 28, target.minY - cardHeight - 12),
+            width: cardWidth,
+            height: cardHeight
+        )
+
+        let dragSource = CGRect(
+            x: card.minX + 24,
+            y: card.minY + 52,
+            width: card.width - 48,
+            height: 68
+        )
+
+        return AccessibilityPermissionGuideFrames(
+            target: target.integral,
+            card: card.integral,
+            dragSource: dragSource.integral
+        )
+    }
+}
+
+enum AccessibilityPermissionGuidePresentationPolicy {
+    static let systemSettingsBundleID = "com.apple.systempreferences"
+
+    static func shouldShow(
+        isRequested: Bool,
+        isTrusted: Bool,
+        frontmostBundleID: String?,
+        hasSettingsWindow: Bool
+    ) -> Bool {
+        isRequested
+            && !isTrusted
+            && frontmostBundleID == systemSettingsBundleID
+            && hasSettingsWindow
+    }
+}
+
+enum SystemSettingsWindowGeometry {
+    static func appKitFrame(fromQuartz frame: CGRect, primaryScreenMaxY: CGFloat) -> CGRect {
+        CGRect(
+            x: frame.minX,
+            y: primaryScreenMaxY - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+}
+
+@MainActor
+final class AccessibilityPermissionGuideController {
+    private let appURL: URL
+    private let appName: String
+    private let appIcon: NSImage
+    private let model = AccessibilityPermissionGuideModel()
+
+    private var targetPanel: NSPanel?
+    private var cardPanel: NSPanel?
+    private var dragPanel: NSPanel?
+    private var refreshTimer: Timer?
+    private var workspaceObservers: [NSObjectProtocol] = []
+    private var applicationObservers: [NSObjectProtocol] = []
+    private var isRequested = false
+
+    init(
+        appURL: URL = Bundle.main.bundleURL,
+        appName: String = AppIdentity.displayName,
+        appIcon: NSImage? = nil
+    ) {
+        self.appURL = appURL
+        self.appName = appName
+        self.appIcon = appIcon ?? NSApplication.shared.applicationIconImage
+    }
+
+    func showWhenSystemSettingsIsAvailable() {
+        guard !AXIsProcessTrusted() else {
+            dismiss()
+            return
+        }
+
+        isRequested = true
+        model.didCompleteDrag = false
+        installObserversIfNeeded()
+        startRefreshTimerIfNeeded()
+        refreshPresentation()
+    }
+
+    func dismiss() {
+        isRequested = false
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObservers.forEach { workspaceCenter.removeObserver($0) }
+        workspaceObservers.removeAll()
+
+        let notificationCenter = NotificationCenter.default
+        applicationObservers.forEach { notificationCenter.removeObserver($0) }
+        applicationObservers.removeAll()
+
+        closePanels()
+    }
+
+    private func installObserversIfNeeded() {
+        guard workspaceObservers.isEmpty, applicationObservers.isEmpty else { return }
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        for name in [
+            NSWorkspace.didActivateApplicationNotification,
+            NSWorkspace.didLaunchApplicationNotification,
+            NSWorkspace.didTerminateApplicationNotification,
+        ] {
+            workspaceObservers.append(workspaceCenter.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.refreshPresentation()
+                }
+            })
+        }
+
+        applicationObservers.append(NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshPresentation()
+            }
+        })
+    }
+
+    private func startRefreshTimerIfNeeded() {
+        guard refreshTimer == nil else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshPresentation()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        refreshTimer = timer
+    }
+
+    private func refreshPresentation() {
+        if AXIsProcessTrusted() {
+            dismiss()
+            return
+        }
+
+        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        let settingsWindow = SystemSettingsWindowLocator.mainWindowFrame()
+        guard AccessibilityPermissionGuidePresentationPolicy.shouldShow(
+            isRequested: isRequested,
+            isTrusted: false,
+            frontmostBundleID: frontmostBundleID,
+            hasSettingsWindow: settingsWindow != nil
+        ), let settingsWindow,
+           let frames = AccessibilityPermissionGuideLayout.frames(for: settingsWindow) else {
+            hidePanels()
+            return
+        }
+
+        ensurePanels()
+        targetPanel?.setFrame(frames.target, display: true)
+        cardPanel?.setFrame(frames.card, display: true)
+        dragPanel?.setFrame(frames.dragSource, display: true)
+
+        targetPanel?.orderFrontRegardless()
+        cardPanel?.orderFrontRegardless()
+        dragPanel?.orderFrontRegardless()
+    }
+
+    private func ensurePanels() {
+        if targetPanel == nil {
+            targetPanel = makePanel(
+                frame: .zero,
+                ignoresMouseEvents: true,
+                contentView: NSHostingView(rootView: AccessibilityPermissionGuideTargetView(
+                    appName: appName,
+                    appIcon: appIcon,
+                    model: model
+                ).preferredColorScheme(.dark))
+            )
+        }
+
+        if cardPanel == nil {
+            cardPanel = makePanel(
+                frame: .zero,
+                ignoresMouseEvents: true,
+                contentView: NSHostingView(rootView: AccessibilityPermissionGuideCardView(
+                    appName: appName,
+                    model: model
+                ).preferredColorScheme(.dark))
+            )
+        }
+
+        if dragPanel == nil {
+            let dragView = AccessibilityPermissionDragSourceView(
+                frame: .zero,
+                appURL: appURL,
+                appName: appName,
+                appIcon: appIcon
+            )
+            dragView.onDragEnded = { [weak self] in
+                self?.model.didCompleteDrag = true
+            }
+            dragPanel = makePanel(
+                frame: .zero,
+                ignoresMouseEvents: false,
+                contentView: dragView
+            )
+        }
+    }
+
+    private func makePanel(
+        frame: CGRect,
+        ignoresMouseEvents: Bool,
+        contentView: NSView
+    ) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.ignoresMouseEvents = ignoresMouseEvents
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.level = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue + 1)
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary, .transient, .ignoresCycle]
+        contentView.frame = CGRect(origin: .zero, size: frame.size)
+        contentView.autoresizingMask = [.width, .height]
+        panel.contentView = contentView
+        return panel
+    }
+
+    private func hidePanels() {
+        targetPanel?.orderOut(nil)
+        cardPanel?.orderOut(nil)
+        dragPanel?.orderOut(nil)
+    }
+
+    private func closePanels() {
+        for panel in [targetPanel, cardPanel, dragPanel] {
+            panel?.orderOut(nil)
+            panel?.close()
+        }
+        targetPanel = nil
+        cardPanel = nil
+        dragPanel = nil
+    }
+}
+
+private enum SystemSettingsWindowLocator {
+    static func mainWindowFrame() -> CGRect? {
+        guard let settingsApp = NSRunningApplication.runningApplications(
+            withBundleIdentifier: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID
+        ).first else {
+            return nil
+        }
+
+        let windows = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] ?? []
+
+        let quartzFrame = windows.compactMap { info -> CGRect? in
+            guard let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+                  ownerPID == settingsApp.processIdentifier,
+                  let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue,
+                  layer == 0,
+                  let bounds = info[kCGWindowBounds as String] as? [String: Any],
+                  let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+                  frame.width >= 720,
+                  frame.height >= 500 else {
+                return nil
+            }
+            return frame
+        }.max { lhs, rhs in
+            lhs.width * lhs.height < rhs.width * rhs.height
+        }
+
+        guard let quartzFrame else { return nil }
+        let primaryScreenMaxY = NSScreen.screens.first?.frame.maxY ?? quartzFrame.maxY
+        return SystemSettingsWindowGeometry.appKitFrame(
+            fromQuartz: quartzFrame,
+            primaryScreenMaxY: primaryScreenMaxY
+        )
+    }
+}
+
+@MainActor
+private final class AccessibilityPermissionGuideModel: ObservableObject {
+    @Published var didCompleteDrag = false
+}
+
+private struct AccessibilityPermissionGuideTargetView: View {
+    let appName: String
+    let appIcon: NSImage
+    @ObservedObject var model: AccessibilityPermissionGuideModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 22)
+                .fill(Color.black.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22)
+                        .stroke(
+                            MuesliTheme.accent,
+                            style: StrokeStyle(lineWidth: 2.5, dash: [9, 7])
+                        )
+                )
+
+            VStack(spacing: 8) {
+                Image(systemName: model.didCompleteDrag ? "checkmark" : "arrow.up")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(model.didCompleteDrag ? MuesliTheme.success : MuesliTheme.accent)
+
+                PermissionGuideAppRow(appName: appName, appIcon: appIcon, isGhost: true)
+                    .frame(maxWidth: 430)
+                    .offset(y: reduceMotion || model.didCompleteDrag ? 0 : (isAnimating ? -30 : 28))
+                    .opacity(model.didCompleteDrag ? 0.62 : 0.88)
+            }
+            .padding(.horizontal, 24)
+        }
+        .padding(2)
+        .onAppear {
+            guard !reduceMotion, !model.didCompleteDrag else { return }
+            withAnimation(.easeInOut(duration: 1.45).repeatForever(autoreverses: false)) {
+                isAnimating = true
+            }
+        }
+    }
+}
+
+private struct AccessibilityPermissionGuideCardView: View {
+    let appName: String
+    @ObservedObject var model: AccessibilityPermissionGuideModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(model.didCompleteDrag ? "Turn \(appName) on" : "Drag \(appName) into the list")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.top, 20)
+
+            Spacer()
+                .frame(height: 80)
+
+            Text(model.didCompleteDrag
+                ? "Use the switch beside \(appName) above."
+                : "If it is already listed, just turn its switch on.")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(Color.white.opacity(0.66))
+                .padding(.bottom, 18)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: NSColor(red: 0.10, green: 0.12, blue: 0.14, alpha: 0.96)))
+        .clipShape(RoundedRectangle(cornerRadius: 22))
+        .overlay(
+            RoundedRectangle(cornerRadius: 22)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.34), radius: 20, y: 8)
+        .padding(2)
+    }
+}
+
+private struct PermissionGuideAppRow: View {
+    let appName: String
+    let appIcon: NSImage
+    var isGhost = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: appIcon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 34, height: 34)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            Text(appName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white.opacity(isGhost ? 0.84 : 0.94))
+
+            Spacer()
+
+            if !isGhost {
+                Image(systemName: "hand.draw.fill")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(MuesliTheme.accent)
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.white.opacity(isGhost ? 0.08 : 0.11))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.white.opacity(isGhost ? 0.12 : 0.18), lineWidth: 1)
+        )
+    }
+}
+
+@MainActor
+private final class AccessibilityPermissionDragSourceView: NSView, NSDraggingSource {
+    var onDragEnded: (() -> Void)?
+
+    private let appURL: URL
+    private var mouseDownLocation: CGPoint?
+    private var hasStartedDrag = false
+
+    init(frame frameRect: NSRect, appURL: URL, appName: String, appIcon: NSImage) {
+        self.appURL = appURL
+        super.init(frame: frameRect)
+
+        let hostingView = NSHostingView(rootView: PermissionGuideAppRow(
+            appName: appName,
+            appIcon: appIcon
+        ).preferredColorScheme(.dark))
+        hostingView.frame = bounds
+        hostingView.autoresizingMask = [.width, .height]
+        addSubview(hostingView)
+        toolTip = "Drag \(appName) into the Accessibility list"
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        mouseDownLocation = convert(event.locationInWindow, from: nil)
+        hasStartedDrag = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard !hasStartedDrag, let mouseDownLocation else { return }
+        let current = convert(event.locationInWindow, from: nil)
+        guard hypot(current.x - mouseDownLocation.x, current.y - mouseDownLocation.y) >= 4 else { return }
+
+        hasStartedDrag = true
+        let item = NSDraggingItem(pasteboardWriter: appURL as NSURL)
+        item.setDraggingFrame(bounds, contents: dragImage())
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        mouseDownLocation = nil
+        hasStartedDrag = false
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .copy
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        mouseDownLocation = nil
+        hasStartedDrag = false
+        if !operation.isEmpty {
+            onDragEnded?()
+        }
+    }
+
+    private func dragImage() -> NSImage {
+        guard let representation = bitmapImageRepForCachingDisplay(in: bounds) else {
+            return NSWorkspace.shared.icon(forFile: appURL.path)
+        }
+        cacheDisplay(in: bounds, to: representation)
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(representation)
+        return image
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -175,9 +175,14 @@ struct DictationsView: View {
             || appState.dictationApplicationFilter != nil {
             return "Try another source, app, or time range"
         }
-        return appState.config.resolvedOnboardingUseCase.includesDictation
-            ? "Hold \(appState.config.dictationHotkey.label) to start dictating"
-            : "Click Record Voice Note to capture your first note"
+        let useCase = appState.config.resolvedOnboardingUseCase
+        if useCase.includesDictation {
+            return "Hold \(appState.config.dictationHotkey.label) to start dictating"
+        }
+        if useCase.includesVoiceNotes {
+            return "Click Record Voice Note to capture your first note"
+        }
+        return "No dictations yet"
     }
 
     private var emptyStateTitle: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -175,9 +175,9 @@ struct DictationsView: View {
             || appState.dictationApplicationFilter != nil {
             return "Try another source, app, or time range"
         }
-        return appState.config.resolvedOnboardingUseCase.includesVoiceNotes
-            ? "Click Record Voice Note to capture your first note"
-            : "Hold \(appState.config.dictationHotkey.label) to start dictating"
+        return appState.config.resolvedOnboardingUseCase.includesDictation
+            ? "Hold \(appState.config.dictationHotkey.label) to start dictating"
+            : "Click Record Voice Note to capture your first note"
     }
 
     private var emptyStateTitle: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1404,18 +1404,48 @@ struct HotkeyConfig: Codable, Equatable {
     }
 }
 
+enum OnboardingCapability: String, Codable, CaseIterable, Hashable {
+    case voiceNotes = "voice_notes"
+    case dictation
+    case meetings
+}
+
 enum OnboardingUseCase: String, Codable, CaseIterable {
     case voiceNotes = "voice_notes"
     case dictation = "dictation"
     case meetings = "meetings"
+    case voiceNotesAndDictation = "voice_notes_and_dictation"
+    case voiceNotesAndMeetings = "voice_notes_and_meetings"
     case dictationAndMeetings = "dictation_and_meetings"
+    case everything = "everything"
+
+    static let allCapabilities = Set(OnboardingCapability.allCases)
+
+    var capabilities: Set<OnboardingCapability> {
+        switch self {
+        case .voiceNotes:
+            [.voiceNotes]
+        case .dictation:
+            [.dictation]
+        case .meetings:
+            [.meetings]
+        case .voiceNotesAndDictation:
+            [.voiceNotes, .dictation]
+        case .voiceNotesAndMeetings:
+            [.voiceNotes, .meetings]
+        case .dictationAndMeetings:
+            [.dictation, .meetings]
+        case .everything:
+            Self.allCapabilities
+        }
+    }
 
     var includesDictation: Bool {
-        self == .dictation || self == .dictationAndMeetings
+        capabilities.contains(.dictation)
     }
 
     var includesVoiceNotes: Bool {
-        self == .voiceNotes
+        capabilities.contains(.voiceNotes)
     }
 
     var includesPushToTalk: Bool {
@@ -1423,11 +1453,40 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
     }
 
     var includesMeetings: Bool {
-        self == .meetings || self == .dictationAndMeetings
+        capabilities.contains(.meetings)
     }
 
     var canSwitchToVoiceNotesOnly: Bool {
-        self == .dictation
+        includesDictation && !includesVoiceNotes
+    }
+
+    func toggling(_ capability: OnboardingCapability) -> OnboardingUseCase {
+        var updated = capabilities
+        if updated.contains(capability) {
+            guard updated.count > 1 else { return self }
+            updated.remove(capability)
+        } else {
+            updated.insert(capability)
+        }
+        return Self.from(capabilities: updated)
+    }
+
+    var replacingDictationWithVoiceNotes: OnboardingUseCase {
+        var updated = capabilities
+        updated.remove(.dictation)
+        updated.insert(.voiceNotes)
+        return Self.from(capabilities: updated)
+    }
+
+    static func from(capabilities: Set<OnboardingCapability>) -> OnboardingUseCase {
+        let normalized = capabilities.isEmpty ? Set([OnboardingCapability.dictation]) : capabilities
+        if normalized == [.voiceNotes] { return .voiceNotes }
+        if normalized == [.dictation] { return .dictation }
+        if normalized == [.meetings] { return .meetings }
+        if normalized == [.voiceNotes, .dictation] { return .voiceNotesAndDictation }
+        if normalized == [.voiceNotes, .meetings] { return .voiceNotesAndMeetings }
+        if normalized == [.dictation, .meetings] { return .dictationAndMeetings }
+        return .everything
     }
 
     static func resolved(_ rawValue: String?) -> OnboardingUseCase {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -422,7 +422,13 @@ public final class MuesliController: NSObject {
     private var historyWindowController: RecentHistoryWindowController?
     private var preferencesWindowController: PreferencesWindowController?
     private var onboardingWindowController: OnboardingWindowController?
-    private lazy var accessibilityPermissionGuideController = AccessibilityPermissionGuideController()
+    private lazy var accessibilityPermissionGuideController: AccessibilityPermissionGuideController = {
+        let guide = AccessibilityPermissionGuideController()
+        guide.onPresentationChanged = { [weak self] isPresenting in
+            self?.onboardingWindowController?.setSuppressedForSystemSettings(isPresenting)
+        }
+        return guide
+    }()
     private let featureTourStore = FeatureTourStore()
     private var isFeatureTourPresentationQueued = false
     var updaterController: SPUStandardUpdaterController?

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -424,8 +424,8 @@ public final class MuesliController: NSObject {
     private var onboardingWindowController: OnboardingWindowController?
     private lazy var systemPermissionGuideController: AccessibilityPermissionGuideController = {
         let guide = AccessibilityPermissionGuideController()
-        guide.onPresentationChanged = { [weak self] isPresenting in
-            self?.onboardingWindowController?.setSuppressedForSystemSettings(isPresenting)
+        guide.onPresentationChanged = { [weak self] presentation in
+            self?.onboardingWindowController?.applySystemSettingsGuidePresentation(presentation)
         }
         return guide
     }()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4637,10 +4637,13 @@ public final class MuesliController: NSObject {
     }
 
     @discardableResult
-    func transitionStoppedDictationTestToTranscribing() -> Bool {
+    func stopDictationTestRecordingFeedback() -> Bool {
         guard isDictationTestMode else { return false }
         dictationTestRecordingStopped?()
-        setState(.transcribing)
+        // Release the active recording pill immediately. A valid recording moves
+        // to transcribing after the recorder reports its duration; short presses
+        // remain idle instead of flashing a state for work that will be discarded.
+        setState(.idle)
         return true
     }
 
@@ -4904,15 +4907,16 @@ public final class MuesliController: NSObject {
         inputMonitoringGranted: Bool
     ) {
         let previousUseCase = config.resolvedOnboardingUseCase
-        guard previousUseCase.includesVoiceNotes, !previousUseCase.includesDictation else { return }
-        guard OnboardingPermissionGate.hasRequiredDictationPermissions(
-            OnboardingPermissionSnapshot(
-                microphone: microphoneGranted,
-                accessibility: accessibilityGranted,
-                inputMonitoring: inputMonitoringGranted,
-                systemAudio: false,
-                screenRecording: false
-            )
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: microphoneGranted,
+            accessibility: accessibilityGranted,
+            inputMonitoring: inputMonitoringGranted,
+            systemAudio: false,
+            screenRecording: false
+        )
+        guard OnboardingFlow.shouldReclassifyVoiceNotesAsDictation(
+            previousUseCase: previousUseCase,
+            permissions: permissions
         ) else { return }
 
         let updatedUseCase = OnboardingUseCase.from(
@@ -10451,7 +10455,7 @@ public final class MuesliController: NSObject {
         fputs("[muesli-native] stop\n", stderr)
         let startedAt = dictationStartedAt ?? Date()
         dictationStartedAt = nil
-        transitionStoppedDictationTestToTranscribing()
+        stopDictationTestRecordingFeedback()
 
         // Nemotron streaming: text already typed — just finalize and store
         if isNemotron35Streaming {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4627,6 +4627,23 @@ public final class MuesliController: NSObject {
 
     var isDictationTestMode: Bool { dictationTestCallback != nil }
 
+    func clearDictationTestLifecycle() {
+        dictationTestCallback = nil
+        dictationTestFailureCallback = nil
+        dictationTestRecordingStarted = nil
+        dictationTestRecordingStopped = nil
+        dictationTestBackend = nil
+        dictationTestCohereLanguage = nil
+    }
+
+    @discardableResult
+    func transitionStoppedDictationTestToTranscribing() -> Bool {
+        guard isDictationTestMode else { return false }
+        dictationTestRecordingStopped?()
+        setState(.transcribing)
+        return true
+    }
+
     func cancelTestDictation() {
         dictationTestTask?.cancel()
         dictationTestTask = nil
@@ -4808,12 +4825,7 @@ public final class MuesliController: NSObject {
         selectBackend(backend)
         hotkeyMonitor.configure(keyCode: hotkey.keyCode)
         configureComputerUseHotkeyMonitor()
-        dictationTestCallback = nil
-        dictationTestFailureCallback = nil
-        dictationTestRecordingStarted = nil
-        dictationTestRecordingStopped = nil
-        dictationTestBackend = nil
-        dictationTestCohereLanguage = nil
+        clearDictationTestLifecycle()
 
         systemPermissionGuideController.dismiss()
         onboardingWindowController?.close()
@@ -10439,10 +10451,7 @@ public final class MuesliController: NSObject {
         fputs("[muesli-native] stop\n", stderr)
         let startedAt = dictationStartedAt ?? Date()
         dictationStartedAt = nil
-        if isDictationTestMode {
-            dictationTestRecordingStopped?()
-            setState(.transcribing)
-        }
+        transitionStoppedDictationTestToTranscribing()
 
         // Nemotron streaming: text already typed — just finalize and store
         if isNemotron35Streaming {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4615,10 +4615,12 @@ public final class MuesliController: NSObject {
     // MARK: - Dictation Test Mode (onboarding)
 
     /// When set, handleStop routes transcribed text to this callback instead of pasting.
-    /// The floating indicator and sounds are suppressed during test mode.
+    /// Lifecycle sounds are suppressed, while the floating indicator stays live so
+    /// onboarding exercises the same recording feedback as normal dictation.
     var dictationTestCallback: ((String) -> Void)?
     var dictationTestFailureCallback: ((String) -> Void)?
     var dictationTestRecordingStarted: (() -> Void)?
+    var dictationTestRecordingStopped: (() -> Void)?
     var dictationTestBackend: BackendOption?
     var dictationTestCohereLanguage: CohereTranscribeLanguage?
     private var dictationTestTask: Task<Void, Never>?
@@ -4809,6 +4811,7 @@ public final class MuesliController: NSObject {
         dictationTestCallback = nil
         dictationTestFailureCallback = nil
         dictationTestRecordingStarted = nil
+        dictationTestRecordingStopped = nil
         dictationTestBackend = nil
         dictationTestCohereLanguage = nil
 
@@ -4888,7 +4891,8 @@ public final class MuesliController: NSObject {
         accessibilityGranted: Bool,
         inputMonitoringGranted: Bool
     ) {
-        guard config.resolvedOnboardingUseCase == .voiceNotes else { return }
+        let previousUseCase = config.resolvedOnboardingUseCase
+        guard previousUseCase.includesVoiceNotes, !previousUseCase.includesDictation else { return }
         guard OnboardingPermissionGate.hasRequiredDictationPermissions(
             OnboardingPermissionSnapshot(
                 microphone: microphoneGranted,
@@ -4899,14 +4903,19 @@ public final class MuesliController: NSObject {
             )
         ) else { return }
 
-        updateConfig { $0.onboardingUseCase = OnboardingUseCase.dictation.rawValue }
+        let updatedUseCase = OnboardingUseCase.from(
+            capabilities: previousUseCase.capabilities
+                .subtracting([.voiceNotes])
+                .union([.dictation])
+        )
+        updateConfig { $0.onboardingUseCase = updatedUseCase.rawValue }
         hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
         hotkeyMonitor.start()
         startComputerUseHotkeyMonitorIfNeeded()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
         TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
-            "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
-            "to_use_case": OnboardingUseCase.dictation.rawValue,
+            "from_use_case": previousUseCase.rawValue,
+            "to_use_case": updatedUseCase.rawValue,
             "reason": "dictation_permissions_granted",
         ])
     }
@@ -8122,17 +8131,15 @@ public final class MuesliController: NSObject {
         case .transcribing: status = "Transcribing"
         }
         statusBarController?.setStatus(status)
-        if !isDictationTestMode {
-            if state == .preparing {
-                let workItem = DispatchWorkItem { [weak self] in
-                    guard let self, self.dictationState == .preparing else { return }
-                    self.indicator.setPreparingWaveformWaiting(config: self.config)
-                }
-                pendingPreparingIndicatorWorkItem = workItem
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
-            } else {
-                indicator.setState(state, config: config)
+        if state == .preparing {
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self, self.dictationState == .preparing else { return }
+                self.indicator.setPreparingWaveformWaiting(config: self.config)
             }
+            pendingPreparingIndicatorWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
+        } else {
+            indicator.setState(state, config: config)
         }
     }
 
@@ -9624,7 +9631,7 @@ public final class MuesliController: NSObject {
     }
 
     private var defaultDictationOutputMode: DictationOutputMode {
-        config.resolvedOnboardingUseCase.includesVoiceNotes ? .voiceNote : .paste
+        config.resolvedOnboardingUseCase.includesDictation ? .paste : .voiceNote
     }
 
     private func beginDictationOutput(mode: DictationOutputMode? = nil) {
@@ -9923,10 +9930,8 @@ public final class MuesliController: NSObject {
 
     private func activateDictationPreparingIndicator() {
         setState(.preparing)
-        if !isDictationTestMode {
-            indicator.powerProvider = { [weak self] in
-                self?.dictationAudioSessionManager.currentPower() ?? -160
-            }
+        indicator.powerProvider = { [weak self] in
+            self?.dictationAudioSessionManager.currentPower() ?? -160
         }
     }
 
@@ -9939,10 +9944,8 @@ public final class MuesliController: NSObject {
             setState(.recording)
             indicator.setRecordingWaveformLevel(config: config)
         }
-        if !isDictationTestMode {
-            indicator.powerProvider = { [weak self] in
-                self?.dictationAudioSessionManager.currentPower() ?? -160
-            }
+        indicator.powerProvider = { [weak self] in
+            self?.dictationAudioSessionManager.currentPower() ?? -160
         }
     }
 
@@ -10436,6 +10439,10 @@ public final class MuesliController: NSObject {
         fputs("[muesli-native] stop\n", stderr)
         let startedAt = dictationStartedAt ?? Date()
         dictationStartedAt = nil
+        if isDictationTestMode {
+            dictationTestRecordingStopped?()
+            setState(.transcribing)
+        }
 
         // Nemotron streaming: text already typed — just finalize and store
         if isNemotron35Streaming {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4497,8 +4497,8 @@ public final class MuesliController: NSObject {
     }
 
     @MainActor
-    func yieldOnboardingFocusToSystemSettings() {
-        onboardingWindowController?.yieldFocusToSystemSettings()
+    func yieldOnboardingFocusToSystemSettings(using behavior: OnboardingSystemSettingsYieldBehavior) {
+        onboardingWindowController?.yieldFocusToSystemSettings(using: behavior)
     }
 
     @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -422,7 +422,7 @@ public final class MuesliController: NSObject {
     private var historyWindowController: RecentHistoryWindowController?
     private var preferencesWindowController: PreferencesWindowController?
     private var onboardingWindowController: OnboardingWindowController?
-    private lazy var accessibilityPermissionGuideController: AccessibilityPermissionGuideController = {
+    private lazy var systemPermissionGuideController: AccessibilityPermissionGuideController = {
         let guide = AccessibilityPermissionGuideController()
         guide.onPresentationChanged = { [weak self] isPresenting in
             self?.onboardingWindowController?.setSuppressedForSystemSettings(isPresenting)
@@ -947,7 +947,7 @@ public final class MuesliController: NSObject {
     }
 
     func shutdown() async {
-        accessibilityPermissionGuideController.dismiss()
+        systemPermissionGuideController.dismiss()
         if let workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(workspaceObserver)
             self.workspaceObserver = nil
@@ -4502,13 +4502,13 @@ public final class MuesliController: NSObject {
     }
 
     @MainActor
-    func beginAccessibilityPermissionGuide() {
-        accessibilityPermissionGuideController.showWhenSystemSettingsIsAvailable()
+    func beginSystemPermissionGuide(for permission: PermissionDragGuidePermission) {
+        systemPermissionGuideController.showWhenSystemSettingsIsAvailable(for: permission)
     }
 
     @MainActor
-    func dismissAccessibilityPermissionGuide() {
-        accessibilityPermissionGuideController.dismiss()
+    func dismissSystemPermissionGuide() {
+        systemPermissionGuideController.dismiss()
     }
 
     @MainActor
@@ -4812,7 +4812,7 @@ public final class MuesliController: NSObject {
         dictationTestBackend = nil
         dictationTestCohereLanguage = nil
 
-        accessibilityPermissionGuideController.dismiss()
+        systemPermissionGuideController.dismiss()
         onboardingWindowController?.close()
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -422,6 +422,7 @@ public final class MuesliController: NSObject {
     private var historyWindowController: RecentHistoryWindowController?
     private var preferencesWindowController: PreferencesWindowController?
     private var onboardingWindowController: OnboardingWindowController?
+    private lazy var accessibilityPermissionGuideController = AccessibilityPermissionGuideController()
     private let featureTourStore = FeatureTourStore()
     private var isFeatureTourPresentationQueued = false
     var updaterController: SPUStandardUpdaterController?
@@ -940,6 +941,7 @@ public final class MuesliController: NSObject {
     }
 
     func shutdown() async {
+        accessibilityPermissionGuideController.dismiss()
         if let workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(workspaceObserver)
             self.workspaceObserver = nil
@@ -4494,6 +4496,16 @@ public final class MuesliController: NSObject {
     }
 
     @MainActor
+    func beginAccessibilityPermissionGuide() {
+        accessibilityPermissionGuideController.showWhenSystemSettingsIsAvailable()
+    }
+
+    @MainActor
+    func dismissAccessibilityPermissionGuide() {
+        accessibilityPermissionGuideController.dismiss()
+    }
+
+    @MainActor
     func prepareOnboardingForNativePermissionPrompt() {
         onboardingWindowController?.prepareForNativePermissionPrompt()
     }
@@ -4794,6 +4806,7 @@ public final class MuesliController: NSObject {
         dictationTestBackend = nil
         dictationTestCohereLanguage = nil
 
+        accessibilityPermissionGuideController.dismiss()
         onboardingWindowController?.close()
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
@@ -1,6 +1,17 @@
 import Foundation
 
 enum OnboardingFlow {
+    struct UseCaseSelectionState: Equatable {
+        let selectedUseCase: OnboardingUseCase
+        let selectionBeforeEverything: OnboardingUseCase?
+    }
+
+    enum PermissionAdvanceAction: Equatable {
+        case restartForDictationTest
+        case finish
+        case next
+    }
+
     enum DictationTestMonitorAction: Equatable {
         case start
         case stop(cancelTestDictation: Bool)
@@ -18,6 +29,48 @@ enum OnboardingFlow {
     }
 
     static let dictationTestStep = Step.dictationTest.rawValue
+
+    static func toggling(
+        _ capability: OnboardingCapability,
+        in state: UseCaseSelectionState
+    ) -> UseCaseSelectionState {
+        UseCaseSelectionState(
+            selectedUseCase: state.selectedUseCase.toggling(capability),
+            selectionBeforeEverything: nil
+        )
+    }
+
+    static func togglingEverything(in state: UseCaseSelectionState) -> UseCaseSelectionState {
+        if state.selectedUseCase == .everything {
+            guard let previousSelection = state.selectionBeforeEverything else { return state }
+            return UseCaseSelectionState(
+                selectedUseCase: previousSelection,
+                selectionBeforeEverything: nil
+            )
+        }
+        return UseCaseSelectionState(
+            selectedUseCase: .everything,
+            selectionBeforeEverything: state.selectedUseCase
+        )
+    }
+
+    static func permissionAdvanceAction(
+        for useCase: OnboardingUseCase,
+        currentStepIndex: Int,
+        orderedStepCount: Int
+    ) -> PermissionAdvanceAction {
+        if useCase.includesPushToTalk { return .restartForDictationTest }
+        if currentStepIndex == orderedStepCount - 1 { return .finish }
+        return .next
+    }
+
+    static func shouldReclassifyVoiceNotesAsDictation(
+        previousUseCase: OnboardingUseCase,
+        permissions: OnboardingPermissionSnapshot
+    ) -> Bool {
+        previousUseCase == .voiceNotes
+            && OnboardingPermissionGate.hasRequiredDictationPermissions(permissions)
+    }
 
     static func shouldStartDictationTestMonitor(
         currentStep: Int,

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
@@ -30,6 +30,22 @@ enum OnboardingFlow {
 
     static let dictationTestStep = Step.dictationTest.rawValue
 
+    static func hasCompletedPermissionsStep(resumingAt step: Int) -> Bool {
+        step > Step.permissions.rawValue
+    }
+
+    static func shouldSchedulePermissionAdvance(
+        currentStep: Int,
+        requiredPermissionsGranted: Bool,
+        hasCompletedPermissionsStep: Bool,
+        hasScheduledTask: Bool
+    ) -> Bool {
+        currentStep == Step.permissions.rawValue
+            && requiredPermissionsGranted
+            && !hasCompletedPermissionsStep
+            && !hasScheduledTask
+    }
+
     static func toggling(
         _ capability: OnboardingCapability,
         in state: UseCaseSelectionState
@@ -57,8 +73,12 @@ enum OnboardingFlow {
     static func permissionAdvanceAction(
         for useCase: OnboardingUseCase,
         currentStepIndex: Int,
-        orderedStepCount: Int
+        orderedStepCount: Int,
+        hasCompletedPermissionsStep: Bool = false
     ) -> PermissionAdvanceAction {
+        if hasCompletedPermissionsStep {
+            return currentStepIndex == orderedStepCount - 1 ? .finish : .next
+        }
         if useCase.includesPushToTalk { return .restartForDictationTest }
         if currentStepIndex == orderedStepCount - 1 { return .finish }
         return .next

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
@@ -73,6 +73,6 @@ enum OnboardingFlow {
     }
 
     static func completionTab(for useCase: OnboardingUseCase) -> DashboardTab {
-        useCase == .meetings ? .meetings : .dictations
+        useCase.includesMeetings && !useCase.includesPushToTalk ? .meetings : .dictations
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -32,6 +32,7 @@ struct OnboardingView: View {
     @State private var grantingPermissionName: String?
     @State private var nativePermissionPromptName: String?
     @State private var recentlyGrantedPermissionName: String?
+    @State private var hasScheduledPermissionAdvance = false
 
     // Hotkey recorder
     @State private var selectedHotkey: HotkeyConfig
@@ -67,6 +68,13 @@ struct OnboardingView: View {
 
     static let permissionsStep = OnboardingFlow.Step.permissions.rawValue
     static let dictationTestStep = OnboardingFlow.dictationTestStep
+    private static let bundledMuesliLogo: NSImage = {
+        if let url = Bundle.main.url(forResource: "muesli_app_icon", withExtension: "png"),
+           let image = NSImage(contentsOf: url) {
+            return image
+        }
+        return NSApplication.shared.applicationIconImage
+    }()
 
     private var orderedSteps: [Int] {
         OnboardingFlow.orderedSteps(for: selectedUseCase)
@@ -518,7 +526,7 @@ struct OnboardingView: View {
     private var dictationTestSubtitle: AttributedString {
         let markdown: String
         if isSelectedModelReadyForDictationTest {
-            markdown = selectedUseCase.includesVoiceNotes
+            markdown = selectedUseCase.includesVoiceNotes && !selectedUseCase.includesDictation
                 ? "Hold **\(selectedHotkey.label)** to record a voice note, then release.\nYour words should appear below."
                 : "Hold **\(selectedHotkey.label)** and say something, then release.\nYour words should appear below."
         } else {
@@ -528,7 +536,9 @@ struct OnboardingView: View {
     }
 
     private var dictationTestPreparationSubtitleMarkdown: String {
-        let unlockCopy = selectedUseCase.includesVoiceNotes ? "Voice note test" : "Dictation"
+        let unlockCopy = selectedUseCase.includesVoiceNotes && !selectedUseCase.includesDictation
+            ? "Voice note test"
+            : "Dictation"
         if isModelPreparingAfterDownload {
             return "Optimizing **\(selectedBackend.label)** for this Mac.\n\(unlockCopy) will unlock when it is ready."
         }
@@ -557,9 +567,12 @@ struct OnboardingView: View {
         VStack(spacing: MuesliTheme.spacing16) {
             Spacer()
 
-            MWaveformIcon(barCount: 13, spacing: 3)
-                .foregroundStyle(MuesliTheme.accent)
-                .frame(width: 80, height: 48)
+            Image(nsImage: Self.bundledMuesliLogo)
+                .resizable()
+                .interpolation(.high)
+                .scaledToFit()
+                .frame(width: 64, height: 64)
+                .accessibilityLabel("Muesli")
 
             VStack(spacing: MuesliTheme.spacing8) {
                 Text("Welcome to Muesli")
@@ -600,36 +613,36 @@ struct OnboardingView: View {
                         icon: "waveform",
                         title: "Voice Notes",
                         subtitle: "Record in Muesli",
-                        selected: selectedUseCase == .voiceNotes
+                        selected: selectedUseCase.includesVoiceNotes
                     ) {
-                        selectedUseCase = .voiceNotes
+                        selectedUseCase = selectedUseCase.toggling(.voiceNotes)
                     }
 
                     useCaseCard(
                         icon: "keyboard.fill",
                         title: "Dictation",
                         subtitle: "Paste into apps",
-                        selected: selectedUseCase == .dictation
+                        selected: selectedUseCase.includesDictation
                     ) {
-                        selectedUseCase = .dictation
+                        selectedUseCase = selectedUseCase.toggling(.dictation)
                     }
 
                     useCaseCard(
                         icon: "person.2.fill",
                         title: "Meetings",
                         subtitle: "Notes and summaries",
-                        selected: selectedUseCase == .meetings
+                        selected: selectedUseCase.includesMeetings
                     ) {
-                        selectedUseCase = .meetings
+                        selectedUseCase = selectedUseCase.toggling(.meetings)
                     }
 
                     useCaseCard(
                         icon: "rectangle.3.group.fill",
                         title: "Everything",
-                        subtitle: "Dictation + meetings",
-                        selected: selectedUseCase == .dictationAndMeetings
+                        subtitle: "All workflows",
+                        selected: selectedUseCase == .everything
                     ) {
-                        selectedUseCase = .dictationAndMeetings
+                        selectedUseCase = selectedUseCase == .everything ? .dictation : .everything
                     }
                 }
             }
@@ -666,8 +679,18 @@ struct OnboardingView: View {
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .strokeBorder(selected ? MuesliTheme.accent : MuesliTheme.surfaceBorder, lineWidth: 1)
             )
+            .overlay(alignment: .topLeading) {
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(7)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
         }
         .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.18), value: selected)
     }
 
     // MARK: - Step 2: Model Selection
@@ -984,7 +1007,17 @@ struct OnboardingView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
-        .onAppear { startPermissionPolling() }
+        .onAppear {
+            startPermissionPolling()
+            schedulePermissionAdvanceIfReady()
+        }
+        .onChange(of: requiredPermissionsGranted) { _, granted in
+            if granted {
+                schedulePermissionAdvanceIfReady()
+            } else {
+                hasScheduledPermissionAdvance = false
+            }
+        }
         .onDisappear {
             stopPermissionPolling()
             controller.dismissSystemPermissionGuide()
@@ -1024,8 +1057,8 @@ struct OnboardingView: View {
         grantingPermissionName = nil
         nativePermissionPromptName = nil
         recentlyGrantedPermissionName = nil
-        selectedUseCase = .voiceNotes
-        currentStep = OnboardingFlow.normalizedStep(currentStep, for: .voiceNotes)
+        selectedUseCase = selectedUseCase.replacingDictationWithVoiceNotes
+        currentStep = OnboardingFlow.normalizedStep(currentStep, for: selectedUseCase)
         saveProgress(atStep: currentStep)
     }
 
@@ -1117,6 +1150,30 @@ struct OnboardingView: View {
     private func stopPermissionPolling() {
         permissionPollTimer?.invalidate()
         permissionPollTimer = nil
+    }
+
+    private func schedulePermissionAdvanceIfReady() {
+        guard currentStep == Self.permissionsStep,
+              requiredPermissionsGranted,
+              !hasScheduledPermissionAdvance else { return }
+        hasScheduledPermissionAdvance = true
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(900))
+            guard currentStep == Self.permissionsStep, requiredPermissionsGranted else {
+                hasScheduledPermissionAdvance = false
+                return
+            }
+
+            controller.dismissSystemPermissionGuide()
+            if selectedUseCase.includesPushToTalk {
+                saveProgressAndRestart()
+            } else if currentStepIndex == orderedSteps.count - 1 {
+                finishOnboarding(withKey: false)
+            } else {
+                goToNextStep()
+            }
+        }
     }
 
     private func refreshPermissions() {
@@ -1309,7 +1366,7 @@ struct OnboardingView: View {
             Spacer()
 
             VStack(spacing: MuesliTheme.spacing8) {
-                Text(selectedUseCase.includesVoiceNotes ? "Test Voice Note" : "Test Dictation")
+                Text(selectedUseCase.includesVoiceNotes && !selectedUseCase.includesDictation ? "Test Voice Note" : "Test Dictation")
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
@@ -1436,6 +1493,9 @@ struct OnboardingView: View {
                 withAnimation { isDictationTesting = true }
                 dictationTestError = nil
             }
+            controller.dictationTestRecordingStopped = {
+                withAnimation { isDictationTesting = false }
+            }
             controller.dictationTestCallback = { text in
                 if text.isEmpty {
                     dictationTestError = "No speech detected. Try again."
@@ -1458,6 +1518,7 @@ struct OnboardingView: View {
             controller.dictationTestCallback = nil
             controller.dictationTestFailureCallback = nil
             controller.dictationTestRecordingStarted = nil
+            controller.dictationTestRecordingStopped = nil
             controller.dictationTestBackend = nil
             controller.dictationTestCohereLanguage = nil
             // Stop the test monitor while moving through onboarding, but leave the

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -857,7 +857,10 @@ struct OnboardingView: View {
             ("keyboard.fill", "Input Monitoring", "Detect hotkey for push-to-talk recording", inputMonitoringGranted, {
                 self.controller.beginSystemPermissionGuide(for: .inputMonitoring)
                 if !CGRequestListenEventAccess() {
-                    self.openSystemSettings("Privacy_ListenEvent")
+                    self.openSystemSettings(
+                        "Privacy_ListenEvent",
+                        yieldBehavior: OnboardingSystemSettingsYieldPolicy.behavior(for: .inputMonitoring)
+                    )
                 }
             }),
             ]
@@ -1303,6 +1306,7 @@ struct OnboardingView: View {
 
     private func openSystemSettingsForPermission(at permissionIndex: Int) {
         let steps = permissionSteps
+        var guidePermission: PermissionDragGuidePermission?
         if permissionIndex < steps.count {
             grantingPermissionName = steps[permissionIndex].name
             nativePermissionPromptName = nil
@@ -1310,20 +1314,28 @@ struct OnboardingView: View {
             saveProgress(atStep: currentStep)
             switch steps[permissionIndex].name {
             case "Accessibility":
+                guidePermission = .accessibility
                 controller.beginSystemPermissionGuide(for: .accessibility)
             case "Input Monitoring":
+                guidePermission = .inputMonitoring
                 controller.beginSystemPermissionGuide(for: .inputMonitoring)
             default:
                 break
             }
         }
-        openSystemSettings(systemSettingsPane(for: permissionIndex))
+        openSystemSettings(
+            systemSettingsPane(for: permissionIndex),
+            yieldBehavior: OnboardingSystemSettingsYieldPolicy.behavior(for: guidePermission)
+        )
     }
 
-    private func openSystemSettings(_ pane: String) {
+    private func openSystemSettings(
+        _ pane: String,
+        yieldBehavior: OnboardingSystemSettingsYieldBehavior
+    ) {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
             if NSWorkspace.shared.open(url) {
-                controller.yieldOnboardingFocusToSystemSettings()
+                controller.yieldOnboardingFocusToSystemSettings(using: yieldBehavior)
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -32,7 +32,9 @@ struct OnboardingView: View {
     @State private var grantingPermissionName: String?
     @State private var nativePermissionPromptName: String?
     @State private var recentlyGrantedPermissionName: String?
-    @State private var hasScheduledPermissionAdvance = false
+    @State private var permissionAdvanceTask: Task<Void, Never>?
+    @State private var permissionAdvanceGeneration: UUID?
+    @State private var selectionBeforeEverything: OnboardingUseCase?
 
     // Hotkey recorder
     @State private var selectedHotkey: HotkeyConfig
@@ -273,13 +275,7 @@ struct OnboardingView: View {
             }
         case 3:
             onboardingButton(currentStepIndex == orderedSteps.count - 1 ? "Finish" : "Continue", enabled: requiredPermissionsGranted) {
-                if selectedUseCase.includesPushToTalk {
-                    saveProgressAndRestart()
-                } else if currentStepIndex == orderedSteps.count - 1 {
-                    finishOnboarding(withKey: false)
-                } else {
-                    goToNextStep()
-                }
+                advancePastPermissions()
             }
         case 4:
             if dictationTestResult != nil {
@@ -615,7 +611,7 @@ struct OnboardingView: View {
                         subtitle: "Record in Muesli",
                         selected: selectedUseCase.includesVoiceNotes
                     ) {
-                        selectedUseCase = selectedUseCase.toggling(.voiceNotes)
+                        toggleCapability(.voiceNotes)
                     }
 
                     useCaseCard(
@@ -624,7 +620,7 @@ struct OnboardingView: View {
                         subtitle: "Paste into apps",
                         selected: selectedUseCase.includesDictation
                     ) {
-                        selectedUseCase = selectedUseCase.toggling(.dictation)
+                        toggleCapability(.dictation)
                     }
 
                     useCaseCard(
@@ -633,7 +629,7 @@ struct OnboardingView: View {
                         subtitle: "Notes and summaries",
                         selected: selectedUseCase.includesMeetings
                     ) {
-                        selectedUseCase = selectedUseCase.toggling(.meetings)
+                        toggleCapability(.meetings)
                     }
 
                     useCaseCard(
@@ -642,7 +638,7 @@ struct OnboardingView: View {
                         subtitle: "All workflows",
                         selected: selectedUseCase == .everything
                     ) {
-                        selectedUseCase = selectedUseCase == .everything ? .dictation : .everything
+                        toggleEverything()
                     }
                 }
             }
@@ -1015,10 +1011,11 @@ struct OnboardingView: View {
             if granted {
                 schedulePermissionAdvanceIfReady()
             } else {
-                hasScheduledPermissionAdvance = false
+                cancelScheduledPermissionAdvance()
             }
         }
         .onDisappear {
+            cancelScheduledPermissionAdvance()
             stopPermissionPolling()
             controller.dismissSystemPermissionGuide()
         }
@@ -1156,25 +1153,70 @@ struct OnboardingView: View {
     private func schedulePermissionAdvanceIfReady() {
         guard currentStep == Self.permissionsStep,
               requiredPermissionsGranted,
-              !hasScheduledPermissionAdvance else { return }
-        hasScheduledPermissionAdvance = true
+              permissionAdvanceTask == nil else { return }
 
-        Task { @MainActor in
+        let generation = UUID()
+        permissionAdvanceGeneration = generation
+        permissionAdvanceTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(900))
+            guard permissionAdvanceGeneration == generation, !Task.isCancelled else { return }
             guard currentStep == Self.permissionsStep, requiredPermissionsGranted else {
-                hasScheduledPermissionAdvance = false
+                permissionAdvanceGeneration = nil
+                permissionAdvanceTask = nil
                 return
             }
 
-            controller.dismissSystemPermissionGuide()
-            if selectedUseCase.includesPushToTalk {
-                saveProgressAndRestart()
-            } else if currentStepIndex == orderedSteps.count - 1 {
-                finishOnboarding(withKey: false)
-            } else {
-                goToNextStep()
-            }
+            permissionAdvanceGeneration = nil
+            permissionAdvanceTask = nil
+            advancePastPermissions()
         }
+    }
+
+    private func cancelScheduledPermissionAdvance() {
+        permissionAdvanceGeneration = nil
+        permissionAdvanceTask?.cancel()
+        permissionAdvanceTask = nil
+    }
+
+    private func advancePastPermissions() {
+        cancelScheduledPermissionAdvance()
+        controller.dismissSystemPermissionGuide()
+        switch OnboardingFlow.permissionAdvanceAction(
+            for: selectedUseCase,
+            currentStepIndex: currentStepIndex,
+            orderedStepCount: orderedSteps.count
+        ) {
+        case .restartForDictationTest:
+            saveProgressAndRestart()
+        case .finish:
+            finishOnboarding(withKey: false)
+        case .next:
+            goToNextStep()
+        }
+    }
+
+    private func toggleCapability(_ capability: OnboardingCapability) {
+        applyUseCaseSelection(OnboardingFlow.toggling(
+            capability,
+            in: OnboardingFlow.UseCaseSelectionState(
+                selectedUseCase: selectedUseCase,
+                selectionBeforeEverything: selectionBeforeEverything
+            )
+        ))
+    }
+
+    private func toggleEverything() {
+        applyUseCaseSelection(OnboardingFlow.togglingEverything(
+            in: OnboardingFlow.UseCaseSelectionState(
+                selectedUseCase: selectedUseCase,
+                selectionBeforeEverything: selectionBeforeEverything
+            )
+        ))
+    }
+
+    private func applyUseCaseSelection(_ state: OnboardingFlow.UseCaseSelectionState) {
+        selectedUseCase = state.selectedUseCase
+        selectionBeforeEverything = state.selectionBeforeEverything
     }
 
     private func refreshPermissions() {
@@ -1267,8 +1309,9 @@ struct OnboardingView: View {
 
     private func openSystemSettings(_ pane: String) {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane)") {
-            controller.yieldOnboardingFocusToSystemSettings()
-            NSWorkspace.shared.open(url)
+            if NSWorkspace.shared.open(url) {
+                controller.yieldOnboardingFocusToSystemSettings()
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -34,6 +34,7 @@ struct OnboardingView: View {
     @State private var recentlyGrantedPermissionName: String?
     @State private var permissionAdvanceTask: Task<Void, Never>?
     @State private var permissionAdvanceGeneration: UUID?
+    @State private var hasCompletedPermissionsStep: Bool
     @State private var selectionBeforeEverything: OnboardingUseCase?
 
     // Hotkey recorder
@@ -144,6 +145,9 @@ struct OnboardingView: View {
         let effectiveInitialStep = OnboardingFlow.normalizedStep(permissionGatedInitialStep, for: initialUseCase)
 
         _currentStep = State(initialValue: effectiveInitialStep)
+        _hasCompletedPermissionsStep = State(initialValue: OnboardingFlow.hasCompletedPermissionsStep(
+            resumingAt: effectiveInitialStep
+        ))
         _userName = State(initialValue: initialUserName)
         _selectedUseCase = State(initialValue: initialUseCase)
         let sanitizedInitialBackend = BackendOption.onboarding.contains(initialBackend)
@@ -227,7 +231,10 @@ struct OnboardingView: View {
         .onChange(of: userName) { _, _ in
             saveProgress(atStep: currentStep)
         }
-        .onChange(of: selectedUseCase) { _, _ in
+        .onChange(of: selectedUseCase) { previousUseCase, newUseCase in
+            if previousUseCase != newUseCase {
+                hasCompletedPermissionsStep = false
+            }
             if !orderedSteps.contains(currentStep) {
                 currentStep = OnboardingFlow.normalizedStep(currentStep, for: selectedUseCase)
             }
@@ -1151,9 +1158,12 @@ struct OnboardingView: View {
     }
 
     private func schedulePermissionAdvanceIfReady() {
-        guard currentStep == Self.permissionsStep,
-              requiredPermissionsGranted,
-              permissionAdvanceTask == nil else { return }
+        guard OnboardingFlow.shouldSchedulePermissionAdvance(
+            currentStep: currentStep,
+            requiredPermissionsGranted: requiredPermissionsGranted,
+            hasCompletedPermissionsStep: hasCompletedPermissionsStep,
+            hasScheduledTask: permissionAdvanceTask != nil
+        ) else { return }
 
         let generation = UUID()
         permissionAdvanceGeneration = generation
@@ -1181,11 +1191,14 @@ struct OnboardingView: View {
     private func advancePastPermissions() {
         cancelScheduledPermissionAdvance()
         controller.dismissSystemPermissionGuide()
-        switch OnboardingFlow.permissionAdvanceAction(
+        let action = OnboardingFlow.permissionAdvanceAction(
             for: selectedUseCase,
             currentStepIndex: currentStepIndex,
-            orderedStepCount: orderedSteps.count
-        ) {
+            orderedStepCount: orderedSteps.count,
+            hasCompletedPermissionsStep: hasCompletedPermissionsStep
+        )
+        hasCompletedPermissionsStep = true
+        switch action {
         case .restartForDictationTest:
             saveProgressAndRestart()
         case .finish:

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -984,7 +984,10 @@ struct OnboardingView: View {
         }
         .frame(maxWidth: .infinity)
         .onAppear { startPermissionPolling() }
-        .onDisappear { stopPermissionPolling() }
+        .onDisappear {
+            stopPermissionPolling()
+            controller.dismissAccessibilityPermissionGuide()
+        }
     }
 
     private func permissionButtonTitle(for permissionName: String, isConfirmingGrant: Bool) -> String {
@@ -1000,6 +1003,7 @@ struct OnboardingView: View {
 
     private func requestAccessibilityPermission() {
         nativePermissionPromptName = "Accessibility"
+        controller.beginAccessibilityPermissionGuide()
         controller.prepareOnboardingForNativePermissionPrompt()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
@@ -1141,6 +1145,9 @@ struct OnboardingView: View {
     @MainActor
     private func notePermissionGranted(_ permissionName: String) {
         guard recentlyGrantedPermissionName != permissionName else { return }
+        if permissionName == "Accessibility" {
+            controller.dismissAccessibilityPermissionGuide()
+        }
         grantingPermissionName = nil
         nativePermissionPromptName = nil
         recentlyGrantedPermissionName = permissionName
@@ -1187,6 +1194,9 @@ struct OnboardingView: View {
             nativePermissionPromptName = nil
             recentlyGrantedPermissionName = nil
             saveProgress(atStep: currentStep)
+            if steps[permissionIndex].name == "Accessibility" {
+                controller.beginAccessibilityPermissionGuide()
+            }
         }
         openSystemSettings(systemSettingsPane(for: permissionIndex))
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1262,7 +1262,7 @@ struct OnboardingView: View {
     @MainActor
     private func notePermissionGranted(_ permissionName: String) {
         guard recentlyGrantedPermissionName != permissionName else { return }
-        if permissionName == "Accessibility" {
+        if PermissionDragGuidePermission(permissionName: permissionName) != nil {
             controller.dismissSystemPermissionGuide()
         }
         grantingPermissionName = nil
@@ -1308,19 +1308,14 @@ struct OnboardingView: View {
         let steps = permissionSteps
         var guidePermission: PermissionDragGuidePermission?
         if permissionIndex < steps.count {
-            grantingPermissionName = steps[permissionIndex].name
+            let permissionName = steps[permissionIndex].name
+            grantingPermissionName = permissionName
             nativePermissionPromptName = nil
             recentlyGrantedPermissionName = nil
             saveProgress(atStep: currentStep)
-            switch steps[permissionIndex].name {
-            case "Accessibility":
-                guidePermission = .accessibility
-                controller.beginSystemPermissionGuide(for: .accessibility)
-            case "Input Monitoring":
-                guidePermission = .inputMonitoring
-                controller.beginSystemPermissionGuide(for: .inputMonitoring)
-            default:
-                break
+            guidePermission = PermissionDragGuidePermission(permissionName: permissionName)
+            if let guidePermission {
+                controller.beginSystemPermissionGuide(for: guidePermission)
             }
         }
         openSystemSettings(

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1057,6 +1057,7 @@ struct OnboardingView: View {
         grantingPermissionName = nil
         nativePermissionPromptName = nil
         recentlyGrantedPermissionName = nil
+        controller.dismissSystemPermissionGuide()
         selectedUseCase = selectedUseCase.replacingDictationWithVoiceNotes
         currentStep = OnboardingFlow.normalizedStep(currentStep, for: selectedUseCase)
         saveProgress(atStep: currentStep)
@@ -1515,12 +1516,7 @@ struct OnboardingView: View {
             // Cancel any in-flight recording before clearing callbacks to prevent
             // the transcription Task from falling through to the production paste path
             controller.cancelTestDictation()
-            controller.dictationTestCallback = nil
-            controller.dictationTestFailureCallback = nil
-            controller.dictationTestRecordingStarted = nil
-            controller.dictationTestRecordingStopped = nil
-            controller.dictationTestBackend = nil
-            controller.dictationTestCohereLanguage = nil
+            controller.clearDictationTestLifecycle()
             // Stop the test monitor while moving through onboarding, but leave the
             // production monitor running when finishing from the dictation test.
             if !hasFinishedOnboarding {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -829,6 +829,7 @@ struct OnboardingView: View {
             }
             steps += [
             ("keyboard.fill", "Input Monitoring", "Detect hotkey for push-to-talk recording", inputMonitoringGranted, {
+                self.controller.beginSystemPermissionGuide(for: .inputMonitoring)
                 if !CGRequestListenEventAccess() {
                     self.openSystemSettings("Privacy_ListenEvent")
                 }
@@ -986,7 +987,7 @@ struct OnboardingView: View {
         .onAppear { startPermissionPolling() }
         .onDisappear {
             stopPermissionPolling()
-            controller.dismissAccessibilityPermissionGuide()
+            controller.dismissSystemPermissionGuide()
         }
     }
 
@@ -1003,7 +1004,7 @@ struct OnboardingView: View {
 
     private func requestAccessibilityPermission() {
         nativePermissionPromptName = "Accessibility"
-        controller.beginAccessibilityPermissionGuide()
+        controller.beginSystemPermissionGuide(for: .accessibility)
         controller.prepareOnboardingForNativePermissionPrompt()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
@@ -1146,7 +1147,7 @@ struct OnboardingView: View {
     private func notePermissionGranted(_ permissionName: String) {
         guard recentlyGrantedPermissionName != permissionName else { return }
         if permissionName == "Accessibility" {
-            controller.dismissAccessibilityPermissionGuide()
+            controller.dismissSystemPermissionGuide()
         }
         grantingPermissionName = nil
         nativePermissionPromptName = nil
@@ -1194,8 +1195,13 @@ struct OnboardingView: View {
             nativePermissionPromptName = nil
             recentlyGrantedPermissionName = nil
             saveProgress(atStep: currentStep)
-            if steps[permissionIndex].name == "Accessibility" {
-                controller.beginAccessibilityPermissionGuide()
+            switch steps[permissionIndex].name {
+            case "Accessibility":
+                controller.beginSystemPermissionGuide(for: .accessibility)
+            case "Input Monitoring":
+                controller.beginSystemPermissionGuide(for: .inputMonitoring)
+            default:
+                break
             }
         }
         openSystemSettings(systemSettingsPane(for: permissionIndex))

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -4,7 +4,7 @@ import MuesliCore
 
 enum OnboardingSystemSettingsYieldBehavior: Equatable {
     case orderedBehind
-    case hiddenButMounted
+    case guideControlled
 }
 
 enum OnboardingSystemSettingsYieldPolicy {
@@ -13,7 +13,7 @@ enum OnboardingSystemSettingsYieldPolicy {
     ) -> OnboardingSystemSettingsYieldBehavior {
         switch guidePermission {
         case .some:
-            return .hiddenButMounted
+            return .guideControlled
         case nil:
             return .orderedBehind
         }
@@ -59,13 +59,14 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
             window.ignoresMouseEvents = false
             window.level = .normal
             window.orderBack(nil)
-        case .hiddenButMounted:
-            // Keep the SwiftUI hierarchy mounted so its permission polling and
-            // guide lifecycle continue, but get the onboarding window out of
-            // the way even when System Settings takes a moment to appear.
+        case .guideControlled:
+            // Keep onboarding mounted and recoverable behind System Settings
+            // while the guide validates the target window. The guide controller
+            // only suppresses it after usable overlay frames are available.
             window.level = .normal
-            window.alphaValue = 0
-            window.ignoresMouseEvents = true
+            window.alphaValue = 1
+            window.ignoresMouseEvents = false
+            window.orderBack(nil)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -88,6 +88,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
             window.level = .normal
             window.alphaValue = 1
             window.ignoresMouseEvents = false
+            window.orderFrontRegardless()
         case .restoredAndActive:
             bringToFront()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -2,6 +2,24 @@ import AppKit
 import SwiftUI
 import MuesliCore
 
+enum OnboardingSystemSettingsYieldBehavior: Equatable {
+    case orderedBehind
+    case hiddenButMounted
+}
+
+enum OnboardingSystemSettingsYieldPolicy {
+    static func behavior(
+        for guidePermission: PermissionDragGuidePermission?
+    ) -> OnboardingSystemSettingsYieldBehavior {
+        switch guidePermission {
+        case .some:
+            return .hiddenButMounted
+        case nil:
+            return .orderedBehind
+        }
+    }
+}
+
 @MainActor
 final class OnboardingWindowController: NSObject, NSWindowDelegate {
     private let controller: MuesliController
@@ -29,14 +47,26 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
-    func yieldFocusToSystemSettings() {
+    func yieldFocusToSystemSettings(using behavior: OnboardingSystemSettingsYieldBehavior) {
         guard let window else { return }
-        // Keep the SwiftUI hierarchy mounted so its permission polling and guide
-        // lifecycle continue, but get the onboarding window out of the way even
-        // when System Settings takes a moment to appear.
-        window.level = .normal
-        window.alphaValue = 0
-        window.ignoresMouseEvents = true
+        switch behavior {
+        case .orderedBehind:
+            // Preserve the original onboarding behavior for permissions without
+            // a floating guide, such as Microphone. The user can return to the
+            // still-visible, interactive onboarding window without first
+            // granting the permission.
+            window.alphaValue = 1
+            window.ignoresMouseEvents = false
+            window.level = .normal
+            window.orderBack(nil)
+        case .hiddenButMounted:
+            // Keep the SwiftUI hierarchy mounted so its permission polling and
+            // guide lifecycle continue, but get the onboarding window out of
+            // the way even when System Settings takes a moment to appear.
+            window.level = .normal
+            window.alphaValue = 0
+            window.ignoresMouseEvents = true
+        }
     }
 
     func setSuppressedForSystemSettings(_ isSuppressed: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -70,16 +70,25 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         }
     }
 
-    func setSuppressedForSystemSettings(_ isSuppressed: Bool) {
+    func applySystemSettingsGuidePresentation(
+        _ presentation: AccessibilityPermissionGuideOnboardingPresentation
+    ) {
         guard let window else { return }
-        if isSuppressed {
+        switch presentation {
+        case .suppressed:
             // Keep the SwiftUI hierarchy mounted while the guide is attached to
             // System Settings. Ordering the window out fires OnboardingView's
             // onDisappear, which intentionally dismisses the permission guide.
             window.level = .normal
             window.alphaValue = 0
             window.ignoresMouseEvents = true
-        } else {
+        case .restoredWithoutActivation:
+            // Leaving System Settings must make onboarding recoverable without
+            // activating Muesli over the application the user chose.
+            window.level = .normal
+            window.alphaValue = 1
+            window.ignoresMouseEvents = false
+        case .restoredAndActive:
             bringToFront()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -28,10 +28,20 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     }
 
     func yieldFocusToSystemSettings() {
+        window?.level = .normal
+    }
+
+    func setSuppressedForSystemSettings(_ isSuppressed: Bool) {
         guard let window else { return }
-        window.level = .normal
-        // Let System Settings take focus without explicitly reordering onboarding.
-        // Reordering can make the window disappear on newer macOS releases.
+        if isSuppressed {
+            // Keep onboarding alive but entirely out of the way while the compact
+            // guide is attached to System Settings. Restoring with orderFront below
+            // avoids the macOS 26 orderBack behavior that can strand the window.
+            window.orderOut(nil)
+        } else {
+            window.level = .normal
+            window.orderFront(nil)
+        }
     }
 
     func prepareForNativePermissionPrompt() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -21,6 +21,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     }
 
     func bringToFront() {
+        window?.alphaValue = 1
+        window?.ignoresMouseEvents = false
         window?.level = .floating
         window?.makeKeyAndOrderFront(nil)
         window?.orderFrontRegardless()
@@ -34,18 +36,24 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     func setSuppressedForSystemSettings(_ isSuppressed: Bool) {
         guard let window else { return }
         if isSuppressed {
-            // Keep onboarding alive but entirely out of the way while the compact
-            // guide is attached to System Settings. Restoring with orderFront below
-            // avoids the macOS 26 orderBack behavior that can strand the window.
-            window.orderOut(nil)
+            // Keep the SwiftUI hierarchy mounted while the guide is attached to
+            // System Settings. Ordering the window out fires OnboardingView's
+            // onDisappear, which intentionally dismisses the permission guide.
+            window.level = .normal
+            window.alphaValue = 0
+            window.ignoresMouseEvents = true
         } else {
             window.level = .normal
+            window.alphaValue = 1
+            window.ignoresMouseEvents = false
             window.orderFront(nil)
         }
     }
 
     func prepareForNativePermissionPrompt() {
         guard let window else { return }
+        window.alphaValue = 1
+        window.ignoresMouseEvents = false
         window.level = .normal
         window.makeKeyAndOrderFront(nil)
         NSApplication.shared.activate(ignoringOtherApps: true)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -30,7 +30,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     func yieldFocusToSystemSettings() {
         guard let window else { return }
         window.level = .normal
-        window.orderBack(nil)
+        // Let System Settings take focus without explicitly reordering onboarding.
+        // Reordering can make the window disappear on newer macOS releases.
     }
 
     func prepareForNativePermissionPrompt() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -30,7 +30,13 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     }
 
     func yieldFocusToSystemSettings() {
-        window?.level = .normal
+        guard let window else { return }
+        // Keep the SwiftUI hierarchy mounted so its permission polling and guide
+        // lifecycle continue, but get the onboarding window out of the way even
+        // when System Settings takes a moment to appear.
+        window.level = .normal
+        window.alphaValue = 0
+        window.ignoresMouseEvents = true
     }
 
     func setSuppressedForSystemSettings(_ isSuppressed: Bool) {
@@ -43,10 +49,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
             window.alphaValue = 0
             window.ignoresMouseEvents = true
         } else {
-            window.level = .normal
-            window.alphaValue = 1
-            window.ignoresMouseEvents = false
-            window.orderFront(nil)
+            bringToFront()
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -64,6 +64,23 @@ struct AccessibilityPermissionGuideTests {
         #expect(AccessibilityPermissionGuideCopy.attemptedDropDetail == "If it appears above, turn on its switch")
     }
 
+    @Test("restores the drag source after an ungranted drop attempt")
+    func restoresDragSourceAfterFailedDropAttempt() {
+        #expect(AccessibilityPermissionGuideRetryPolicy.attemptedDropRetryDelay == 4)
+        #expect(AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: true,
+            isGranted: false
+        ))
+        #expect(!AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: true,
+            isGranted: true
+        ))
+        #expect(!AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: false,
+            isGranted: false
+        ))
+    }
+
     @Test("does not present when System Settings is too small")
     func rejectsSmallSettingsWindows() {
         #expect(AccessibilityPermissionGuideLayout.frames(

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -4,16 +4,19 @@ import Testing
 
 @Suite("Accessibility permission guide")
 struct AccessibilityPermissionGuideTests {
-    @Test("lays the guide out inside the System Settings content area")
+    @Test("lays out a compact guide inside the System Settings content area")
     func layoutFitsSettingsContent() throws {
         let settingsWindow = CGRect(x: 100, y: 80, width: 1_000, height: 800)
         let frames = try #require(AccessibilityPermissionGuideLayout.frames(for: settingsWindow))
 
-        #expect(settingsWindow.contains(frames.target))
-        #expect(settingsWindow.contains(frames.card))
-        #expect(frames.card.contains(frames.dragSource))
-        #expect(frames.target.minY > frames.card.maxY)
-        #expect(frames.target.minX > settingsWindow.minX + 250)
+        #expect(settingsWindow.contains(frames.guide))
+        #expect(frames.guide.contains(frames.dragSource))
+        #expect(frames.guide.contains(frames.completedGuide))
+        #expect(frames.guide.height == 226)
+        #expect(frames.guide.width <= 720)
+        #expect(frames.dragSource.height == 76)
+        #expect(frames.dragSource.minY - frames.guide.minY == 14)
+        #expect(frames.guide.minX > settingsWindow.minX + 250)
     }
 
     @Test("does not present when System Settings is too small")

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -159,6 +159,13 @@ struct AccessibilityPermissionGuideTests {
         ))
     }
 
+    @Test("only drag-guide permissions hide onboarding while keeping it mounted")
+    func onboardingSystemSettingsYieldPolicy() {
+        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: nil) == .orderedBehind)
+        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .accessibility) == .hiddenButMounted)
+        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .inputMonitoring) == .hiddenButMounted)
+    }
+
     @Test("converts Quartz window coordinates to AppKit coordinates")
     func convertsWindowCoordinates() {
         let converted = SystemSettingsWindowGeometry.appKitFrame(

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -58,6 +58,26 @@ struct AccessibilityPermissionGuideTests {
         ))
     }
 
+    @Test("preserves completion when reopening the same permission guide")
+    func invocationPolicy() {
+        let reopeningSamePermission = AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
+            previousPermission: .accessibility,
+            nextPermission: .accessibility
+        )
+        let changingPermission = AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
+            previousPermission: .accessibility,
+            nextPermission: .inputMonitoring
+        )
+        let firstInvocation = AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
+            previousPermission: nil,
+            nextPermission: .accessibility
+        )
+
+        #expect(!reopeningSamePermission)
+        #expect(changingPermission)
+        #expect(firstInvocation)
+    }
+
     @Test("does not present when System Settings is too small")
     func rejectsSmallSettingsWindows() {
         #expect(AccessibilityPermissionGuideLayout.frames(

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -12,10 +12,10 @@ struct AccessibilityPermissionGuideTests {
         #expect(settingsWindow.contains(frames.guide))
         #expect(frames.guide.contains(frames.dragSource))
         #expect(frames.guide.contains(frames.completedGuide))
-        #expect(frames.guide.height == 226)
-        #expect(frames.guide.width <= 720)
-        #expect(frames.dragSource.height == 76)
-        #expect(frames.dragSource.minY - frames.guide.minY == 14)
+        #expect(frames.guide.height == 128)
+        #expect(frames.guide.width <= 640)
+        #expect(frames.dragSource.height == 70)
+        #expect(frames.dragSource.minY - frames.guide.minY == 12)
         #expect(frames.guide.minX > settingsWindow.minX + 250)
     }
 
@@ -29,37 +29,37 @@ struct AccessibilityPermissionGuideTests {
         ) == nil)
     }
 
-    @Test("presents only for an active untrusted Accessibility request")
+    @Test("presents only for an active ungranted permission request")
     func presentationPolicy() {
         let settingsBundleID = AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID
 
         #expect(AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
-            isTrusted: false,
+            isGranted: false,
             frontmostBundleID: settingsBundleID,
             hasSettingsWindow: true
         ))
         #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: false,
-            isTrusted: false,
+            isGranted: false,
             frontmostBundleID: settingsBundleID,
             hasSettingsWindow: true
         ))
         #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
-            isTrusted: true,
+            isGranted: true,
             frontmostBundleID: settingsBundleID,
             hasSettingsWindow: true
         ))
         #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
-            isTrusted: false,
+            isGranted: false,
             frontmostBundleID: "com.apple.finder",
             hasSettingsWindow: true
         ))
         #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
             isRequested: true,
-            isTrusted: false,
+            isGranted: false,
             frontmostBundleID: settingsBundleID,
             hasSettingsWindow: false
         ))

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -1,0 +1,74 @@
+import CoreGraphics
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Accessibility permission guide")
+struct AccessibilityPermissionGuideTests {
+    @Test("lays the guide out inside the System Settings content area")
+    func layoutFitsSettingsContent() throws {
+        let settingsWindow = CGRect(x: 100, y: 80, width: 1_000, height: 800)
+        let frames = try #require(AccessibilityPermissionGuideLayout.frames(for: settingsWindow))
+
+        #expect(settingsWindow.contains(frames.target))
+        #expect(settingsWindow.contains(frames.card))
+        #expect(frames.card.contains(frames.dragSource))
+        #expect(frames.target.minY > frames.card.maxY)
+        #expect(frames.target.minX > settingsWindow.minX + 250)
+    }
+
+    @Test("does not present when System Settings is too small")
+    func rejectsSmallSettingsWindows() {
+        #expect(AccessibilityPermissionGuideLayout.frames(
+            for: CGRect(x: 0, y: 0, width: 719, height: 800)
+        ) == nil)
+        #expect(AccessibilityPermissionGuideLayout.frames(
+            for: CGRect(x: 0, y: 0, width: 900, height: 499)
+        ) == nil)
+    }
+
+    @Test("presents only for an active untrusted Accessibility request")
+    func presentationPolicy() {
+        let settingsBundleID = AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID
+
+        #expect(AccessibilityPermissionGuidePresentationPolicy.shouldShow(
+            isRequested: true,
+            isTrusted: false,
+            frontmostBundleID: settingsBundleID,
+            hasSettingsWindow: true
+        ))
+        #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
+            isRequested: false,
+            isTrusted: false,
+            frontmostBundleID: settingsBundleID,
+            hasSettingsWindow: true
+        ))
+        #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
+            isRequested: true,
+            isTrusted: true,
+            frontmostBundleID: settingsBundleID,
+            hasSettingsWindow: true
+        ))
+        #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
+            isRequested: true,
+            isTrusted: false,
+            frontmostBundleID: "com.apple.finder",
+            hasSettingsWindow: true
+        ))
+        #expect(!AccessibilityPermissionGuidePresentationPolicy.shouldShow(
+            isRequested: true,
+            isTrusted: false,
+            frontmostBundleID: settingsBundleID,
+            hasSettingsWindow: false
+        ))
+    }
+
+    @Test("converts Quartz window coordinates to AppKit coordinates")
+    func convertsWindowCoordinates() {
+        let converted = SystemSettingsWindowGeometry.appKitFrame(
+            fromQuartz: CGRect(x: 120, y: 100, width: 900, height: 700),
+            primaryScreenMaxY: 1_200
+        )
+
+        #expect(converted == CGRect(x: 120, y: 400, width: 900, height: 700))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -17,6 +17,7 @@ struct AccessibilityPermissionGuideTests {
         #expect(frames.dragSource.height == 70)
         #expect(frames.dragSource.minY - frames.guide.minY == 12)
         #expect(frames.guide.minX > settingsWindow.minX + 250)
+        #expect(frames.dragDirection == .up)
     }
 
     @Test("does not present when System Settings is too small")

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 import Testing
 @testable import MuesliNativeApp
 
@@ -66,18 +67,53 @@ struct AccessibilityPermissionGuideTests {
 
     @Test("restores the drag source after an ungranted drop attempt")
     func restoresDragSourceAfterFailedDropAttempt() {
-        #expect(AccessibilityPermissionGuideRetryPolicy.attemptedDropRetryDelay == 4)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        let deadline = AccessibilityPermissionGuideRetryPolicy.retryDeadline(startingAt: start)
+
+        #expect(AccessibilityPermissionGuideRetryPolicy.permissionCheckInterval == 0.5)
+        #expect(AccessibilityPermissionGuideRetryPolicy.attemptedDropRetryWindow == 10)
+        #expect(deadline == start.addingTimeInterval(10))
+        #expect(!AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: true,
+            isGranted: false,
+            retryDeadline: deadline,
+            now: start.addingTimeInterval(9.999),
+            isMuesliFrontmost: false
+        ))
         #expect(AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
             didAttemptDrop: true,
-            isGranted: false
+            isGranted: false,
+            retryDeadline: deadline,
+            now: deadline,
+            isMuesliFrontmost: false
+        ))
+        #expect(AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: true,
+            isGranted: false,
+            retryDeadline: deadline,
+            now: start,
+            isMuesliFrontmost: true
         ))
         #expect(!AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
             didAttemptDrop: true,
-            isGranted: true
+            isGranted: true,
+            retryDeadline: deadline,
+            now: deadline,
+            isMuesliFrontmost: true
         ))
         #expect(!AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
             didAttemptDrop: false,
-            isGranted: false
+            isGranted: false,
+            retryDeadline: deadline,
+            now: deadline,
+            isMuesliFrontmost: false
+        ))
+        #expect(!AccessibilityPermissionGuideRetryPolicy.shouldRestoreDragSource(
+            didAttemptDrop: true,
+            isGranted: false,
+            retryDeadline: nil,
+            now: deadline,
+            isMuesliFrontmost: false
         ))
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -12,12 +12,50 @@ struct AccessibilityPermissionGuideTests {
         #expect(settingsWindow.contains(frames.guide))
         #expect(frames.guide.contains(frames.dragSource))
         #expect(frames.guide.contains(frames.completedGuide))
+        #expect(settingsWindow.contains(frames.permissionListDropRegion))
+        #expect(!frames.guide.intersects(frames.permissionListDropRegion))
+        #expect(frames.permissionListDropRegion.height > frames.dragSource.height)
         #expect(frames.guide.height == 128)
         #expect(frames.guide.width <= 640)
         #expect(frames.dragSource.height == 70)
         #expect(frames.dragSource.minY - frames.guide.minY == 12)
         #expect(frames.guide.minX > settingsWindow.minX + 250)
         #expect(frames.dragDirection == .up)
+    }
+
+    @Test("completes only for an accepted drop in the active System Settings permission list")
+    func validatesPermissionListDrop() throws {
+        let settingsWindow = CGRect(x: 100, y: 80, width: 1_000, height: 800)
+        let frames = try #require(AccessibilityPermissionGuideLayout.frames(for: settingsWindow))
+        let targetPoint = CGPoint(
+            x: frames.permissionListDropRegion.midX,
+            y: frames.permissionListDropRegion.midY
+        )
+
+        #expect(AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+            operationAccepted: true,
+            dropPoint: targetPoint,
+            frontmostBundleID: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
+            settingsWindow: settingsWindow
+        ))
+        #expect(!AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+            operationAccepted: false,
+            dropPoint: targetPoint,
+            frontmostBundleID: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
+            settingsWindow: settingsWindow
+        ))
+        #expect(!AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+            operationAccepted: true,
+            dropPoint: CGPoint(x: frames.dragSource.midX, y: frames.dragSource.midY),
+            frontmostBundleID: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
+            settingsWindow: settingsWindow
+        ))
+        #expect(!AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+            operationAccepted: true,
+            dropPoint: targetPoint,
+            frontmostBundleID: "com.apple.finder",
+            settingsWindow: settingsWindow
+        ))
     }
 
     @Test("does not present when System Settings is too small")
@@ -63,6 +101,41 @@ struct AccessibilityPermissionGuideTests {
             isGranted: false,
             frontmostBundleID: settingsBundleID,
             hasSettingsWindow: false
+        ))
+    }
+
+    @Test("keeps onboarding suppressed while an unrelated app is frontmost")
+    func suppressionPolicy() {
+        let settingsBundleID = AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID
+        let muesliBundleID = "com.muesli.dev.b"
+
+        #expect(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: settingsBundleID,
+            muesliBundleID: muesliBundleID,
+            isCurrentlySuppressed: false
+        ))
+        #expect(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: "com.apple.finder",
+            muesliBundleID: muesliBundleID,
+            isCurrentlySuppressed: true
+        ))
+        #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: muesliBundleID,
+            muesliBundleID: muesliBundleID,
+            isCurrentlySuppressed: true
+        ))
+        #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+            isRequested: true,
+            isGranted: true,
+            frontmostBundleID: settingsBundleID,
+            muesliBundleID: muesliBundleID,
+            isCurrentlySuppressed: true
         ))
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -236,6 +236,13 @@ struct AccessibilityPermissionGuideTests {
         #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .inputMonitoring) == .guideControlled)
     }
 
+    @Test("maps both guided permission names to their guide type")
+    func guidedPermissionNameMapping() {
+        #expect(PermissionDragGuidePermission(permissionName: "Accessibility") == .accessibility)
+        #expect(PermissionDragGuidePermission(permissionName: "Input Monitoring") == .inputMonitoring)
+        #expect(PermissionDragGuidePermission(permissionName: "Microphone") == nil)
+    }
+
     @Test("converts Quartz window coordinates to AppKit coordinates")
     func convertsWindowCoordinates() {
         let converted = SystemSettingsWindowGeometry.appKitFrame(

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -127,7 +127,7 @@ struct AccessibilityPermissionGuideTests {
         ))
     }
 
-    @Test("keeps onboarding suppressed while an unrelated app is frontmost")
+    @Test("suppresses onboarding only while a usable System Settings guide is frontmost")
     func suppressionPolicy() {
         let settingsBundleID = AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID
         let muesliBundleID = "com.muesli.dev.b"
@@ -136,42 +136,61 @@ struct AccessibilityPermissionGuideTests {
             isRequested: true,
             isGranted: false,
             frontmostBundleID: settingsBundleID,
-            muesliBundleID: muesliBundleID,
-            hasUsableGuide: true,
-            isCurrentlySuppressed: false
+            hasUsableGuide: true
         ))
         #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: settingsBundleID,
-            muesliBundleID: muesliBundleID,
-            hasUsableGuide: false,
-            isCurrentlySuppressed: true
+            hasUsableGuide: false
         ))
-        #expect(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+        #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: "com.apple.finder",
-            muesliBundleID: muesliBundleID,
-            hasUsableGuide: false,
-            isCurrentlySuppressed: true
+            hasUsableGuide: false
         ))
         #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: muesliBundleID,
-            muesliBundleID: muesliBundleID,
-            hasUsableGuide: true,
-            isCurrentlySuppressed: true
+            hasUsableGuide: true
         ))
         #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
             isRequested: true,
             isGranted: true,
             frontmostBundleID: settingsBundleID,
-            muesliBundleID: muesliBundleID,
-            hasUsableGuide: true,
-            isCurrentlySuppressed: true
+            hasUsableGuide: true
         ))
+
+        #expect(AccessibilityPermissionGuideSuppressionPolicy.onboardingPresentation(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: settingsBundleID,
+            muesliBundleID: muesliBundleID,
+            hasUsableGuide: true
+        ) == .suppressed)
+        #expect(AccessibilityPermissionGuideSuppressionPolicy.onboardingPresentation(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: "com.apple.finder",
+            muesliBundleID: muesliBundleID,
+            hasUsableGuide: false
+        ) == .restoredWithoutActivation)
+        #expect(AccessibilityPermissionGuideSuppressionPolicy.onboardingPresentation(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: muesliBundleID,
+            muesliBundleID: muesliBundleID,
+            hasUsableGuide: false
+        ) == .restoredAndActive)
+        #expect(AccessibilityPermissionGuideSuppressionPolicy.onboardingPresentation(
+            isRequested: true,
+            isGranted: true,
+            frontmostBundleID: settingsBundleID,
+            muesliBundleID: muesliBundleID,
+            hasUsableGuide: true
+        ) == .restoredAndActive)
     }
 
     @Test("only drag-guide permissions let the guide control onboarding suppression")

--- a/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AccessibilityPermissionGuideTests.swift
@@ -11,7 +11,7 @@ struct AccessibilityPermissionGuideTests {
 
         #expect(settingsWindow.contains(frames.guide))
         #expect(frames.guide.contains(frames.dragSource))
-        #expect(frames.guide.contains(frames.completedGuide))
+        #expect(frames.guide.contains(frames.postDropGuide))
         #expect(settingsWindow.contains(frames.permissionListDropRegion))
         #expect(!frames.guide.intersects(frames.permissionListDropRegion))
         #expect(frames.permissionListDropRegion.height > frames.dragSource.height)
@@ -23,8 +23,8 @@ struct AccessibilityPermissionGuideTests {
         #expect(frames.dragDirection == .up)
     }
 
-    @Test("completes only for an accepted drop in the active System Settings permission list")
-    func validatesPermissionListDrop() throws {
+    @Test("recognizes only likely drop attempts in the active System Settings permission region")
+    func validatesLikelyPermissionListDropAttempt() throws {
         let settingsWindow = CGRect(x: 100, y: 80, width: 1_000, height: 800)
         let frames = try #require(AccessibilityPermissionGuideLayout.frames(for: settingsWindow))
         let targetPoint = CGPoint(
@@ -32,25 +32,25 @@ struct AccessibilityPermissionGuideTests {
             y: frames.permissionListDropRegion.midY
         )
 
-        #expect(AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+        #expect(AccessibilityPermissionGuideDropPolicy.isLikelyPermissionListDropAttempt(
             operationAccepted: true,
             dropPoint: targetPoint,
             frontmostBundleID: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
             settingsWindow: settingsWindow
         ))
-        #expect(!AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+        #expect(!AccessibilityPermissionGuideDropPolicy.isLikelyPermissionListDropAttempt(
             operationAccepted: false,
             dropPoint: targetPoint,
             frontmostBundleID: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
             settingsWindow: settingsWindow
         ))
-        #expect(!AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+        #expect(!AccessibilityPermissionGuideDropPolicy.isLikelyPermissionListDropAttempt(
             operationAccepted: true,
             dropPoint: CGPoint(x: frames.dragSource.midX, y: frames.dragSource.midY),
             frontmostBundleID: AccessibilityPermissionGuidePresentationPolicy.systemSettingsBundleID,
             settingsWindow: settingsWindow
         ))
-        #expect(!AccessibilityPermissionGuideDropPolicy.isPermissionListDrop(
+        #expect(!AccessibilityPermissionGuideDropPolicy.isLikelyPermissionListDropAttempt(
             operationAccepted: true,
             dropPoint: targetPoint,
             frontmostBundleID: "com.apple.finder",
@@ -58,24 +58,10 @@ struct AccessibilityPermissionGuideTests {
         ))
     }
 
-    @Test("preserves completion when reopening the same permission guide")
-    func invocationPolicy() {
-        let reopeningSamePermission = AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
-            previousPermission: .accessibility,
-            nextPermission: .accessibility
-        )
-        let changingPermission = AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
-            previousPermission: .accessibility,
-            nextPermission: .inputMonitoring
-        )
-        let firstInvocation = AccessibilityPermissionGuideInvocationPolicy.shouldResetDragCompletion(
-            previousPermission: nil,
-            nextPermission: .accessibility
-        )
-
-        #expect(!reopeningSamePermission)
-        #expect(changingPermission)
-        #expect(firstInvocation)
+    @Test("an accepted drop attempt does not claim that Muesli was added")
+    func attemptedDropCopyIsNonDefinitive() {
+        #expect(AccessibilityPermissionGuideCopy.attemptedDropTitle(appName: "MuesliDevB") == "Turn MuesliDevB on")
+        #expect(AccessibilityPermissionGuideCopy.attemptedDropDetail == "If it appears above, turn on its switch")
     }
 
     @Test("does not present when System Settings is too small")
@@ -134,13 +120,23 @@ struct AccessibilityPermissionGuideTests {
             isGranted: false,
             frontmostBundleID: settingsBundleID,
             muesliBundleID: muesliBundleID,
+            hasUsableGuide: true,
             isCurrentlySuppressed: false
+        ))
+        #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
+            isRequested: true,
+            isGranted: false,
+            frontmostBundleID: settingsBundleID,
+            muesliBundleID: muesliBundleID,
+            hasUsableGuide: false,
+            isCurrentlySuppressed: true
         ))
         #expect(AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
             isRequested: true,
             isGranted: false,
             frontmostBundleID: "com.apple.finder",
             muesliBundleID: muesliBundleID,
+            hasUsableGuide: false,
             isCurrentlySuppressed: true
         ))
         #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
@@ -148,6 +144,7 @@ struct AccessibilityPermissionGuideTests {
             isGranted: false,
             frontmostBundleID: muesliBundleID,
             muesliBundleID: muesliBundleID,
+            hasUsableGuide: true,
             isCurrentlySuppressed: true
         ))
         #expect(!AccessibilityPermissionGuideSuppressionPolicy.shouldSuppressOnboarding(
@@ -155,15 +152,16 @@ struct AccessibilityPermissionGuideTests {
             isGranted: true,
             frontmostBundleID: settingsBundleID,
             muesliBundleID: muesliBundleID,
+            hasUsableGuide: true,
             isCurrentlySuppressed: true
         ))
     }
 
-    @Test("only drag-guide permissions hide onboarding while keeping it mounted")
+    @Test("only drag-guide permissions let the guide control onboarding suppression")
     func onboardingSystemSettingsYieldPolicy() {
         #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: nil) == .orderedBehind)
-        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .accessibility) == .hiddenButMounted)
-        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .inputMonitoring) == .hiddenButMounted)
+        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .accessibility) == .guideControlled)
+        #expect(OnboardingSystemSettingsYieldPolicy.behavior(for: .inputMonitoring) == .guideControlled)
     }
 
     @Test("converts Quartz window coordinates to AppKit coordinates")

--- a/native/MuesliNative/Tests/MuesliTests/DictationTestLifecycleTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationTestLifecycleTests.swift
@@ -26,7 +26,7 @@ struct DictationTestLifecycleTests {
             configStore: ConfigStore(supportDirectory: supportDirectory)
         )
 
-        #expect(!controller.transitionStoppedDictationTestToTranscribing())
+        #expect(!controller.stopDictationTestRecordingFeedback())
 
         var stopCallbackCount = 0
         controller.dictationTestCallback = { _ in }
@@ -37,9 +37,9 @@ struct DictationTestLifecycleTests {
         controller.dictationTestCohereLanguage = .defaultLanguage
 
         #expect(controller.isDictationTestMode)
-        #expect(controller.transitionStoppedDictationTestToTranscribing())
+        #expect(controller.stopDictationTestRecordingFeedback())
         #expect(stopCallbackCount == 1)
-        #expect(controller.appState.dictationState == .transcribing)
+        #expect(controller.appState.dictationState == .idle)
 
         controller.clearDictationTestLifecycle()
 

--- a/native/MuesliNative/Tests/MuesliTests/DictationTestLifecycleTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationTestLifecycleTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Dictation test lifecycle")
+@MainActor
+struct DictationTestLifecycleTests {
+    @Test("hotkey release transitions test feedback and cleanup clears every callback")
+    func stopAndCleanupLifecycle() throws {
+        let supportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-dictation-test-lifecycle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: supportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: supportDirectory) }
+
+        let store = DictationStore(databaseURL: supportDirectory.appendingPathComponent("muesli.db"))
+        try store.migrateIfNeeded()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: supportDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store,
+            configStore: ConfigStore(supportDirectory: supportDirectory)
+        )
+
+        #expect(!controller.transitionStoppedDictationTestToTranscribing())
+
+        var stopCallbackCount = 0
+        controller.dictationTestCallback = { _ in }
+        controller.dictationTestFailureCallback = { _ in }
+        controller.dictationTestRecordingStarted = {}
+        controller.dictationTestRecordingStopped = { stopCallbackCount += 1 }
+        controller.dictationTestBackend = .onboardingDefault
+        controller.dictationTestCohereLanguage = .defaultLanguage
+
+        #expect(controller.isDictationTestMode)
+        #expect(controller.transitionStoppedDictationTestToTranscribing())
+        #expect(stopCallbackCount == 1)
+        #expect(controller.appState.dictationState == .transcribing)
+
+        controller.clearDictationTestLifecycle()
+
+        #expect(!controller.isDictationTestMode)
+        #expect(controller.dictationTestCallback == nil)
+        #expect(controller.dictationTestFailureCallback == nil)
+        #expect(controller.dictationTestRecordingStarted == nil)
+        #expect(controller.dictationTestRecordingStopped == nil)
+        #expect(controller.dictationTestBackend == nil)
+        #expect(controller.dictationTestCohereLanguage == nil)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1873,12 +1873,29 @@ struct AppConfigTests {
         #expect(!OnboardingUseCase.voiceNotes.includesMeetings)
     }
 
-    @Test("voice notes escape hatch is dictation-only")
-    func voiceNotesEscapeHatchIsDictationOnly() {
+    @Test("voice notes escape hatch is available for every dictation selection")
+    func voiceNotesEscapeHatchPreservesOtherCapabilities() {
         #expect(OnboardingUseCase.dictation.canSwitchToVoiceNotesOnly)
-        #expect(!OnboardingUseCase.dictationAndMeetings.canSwitchToVoiceNotesOnly)
+        #expect(OnboardingUseCase.dictationAndMeetings.canSwitchToVoiceNotesOnly)
         #expect(!OnboardingUseCase.meetings.canSwitchToVoiceNotesOnly)
         #expect(!OnboardingUseCase.voiceNotes.canSwitchToVoiceNotesOnly)
+        #expect(OnboardingUseCase.dictationAndMeetings.replacingDictationWithVoiceNotes == .voiceNotesAndMeetings)
+    }
+
+    @Test("onboarding use cases preserve the union of selected capabilities")
+    func onboardingUseCaseCapabilityUnion() {
+        let voiceAndMeetings = OnboardingUseCase.voiceNotes.toggling(.meetings)
+        #expect(voiceAndMeetings == .voiceNotesAndMeetings)
+        #expect(voiceAndMeetings.includesVoiceNotes)
+        #expect(!voiceAndMeetings.includesDictation)
+        #expect(voiceAndMeetings.includesMeetings)
+
+        let everything = voiceAndMeetings.toggling(.dictation)
+        #expect(everything == .everything)
+        #expect(everything.capabilities == OnboardingUseCase.allCapabilities)
+
+        #expect(everything.toggling(.voiceNotes) == .dictationAndMeetings)
+        #expect(OnboardingUseCase.dictation.toggling(.dictation) == .dictation)
     }
 
     @Test("scheduled meeting notifications inherit legacy detection opt-out")

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
@@ -126,6 +126,39 @@ struct OnboardingFlowTests {
             currentStepIndex: 2,
             orderedStepCount: 5
         ) == .next)
+        #expect(OnboardingFlow.permissionAdvanceAction(
+            for: .dictation,
+            currentStepIndex: 3,
+            orderedStepCount: 5,
+            hasCompletedPermissionsStep: true
+        ) == .next)
+    }
+
+    @Test("completed permission steps do not auto-advance again on re-entry")
+    func completedPermissionStepDoesNotAutoAdvanceAgain() {
+        let resumedAfterPermissions = OnboardingFlow.hasCompletedPermissionsStep(
+            resumingAt: OnboardingFlow.Step.dictationTest.rawValue
+        )
+        let resumedAtPermissions = OnboardingFlow.hasCompletedPermissionsStep(
+            resumingAt: OnboardingFlow.Step.permissions.rawValue
+        )
+        let schedulesAfterCompletion = OnboardingFlow.shouldSchedulePermissionAdvance(
+            currentStep: OnboardingFlow.Step.permissions.rawValue,
+            requiredPermissionsGranted: true,
+            hasCompletedPermissionsStep: true,
+            hasScheduledTask: false
+        )
+        let schedulesInitialCompletion = OnboardingFlow.shouldSchedulePermissionAdvance(
+            currentStep: OnboardingFlow.Step.permissions.rawValue,
+            requiredPermissionsGranted: true,
+            hasCompletedPermissionsStep: false,
+            hasScheduledTask: false
+        )
+
+        #expect(resumedAfterPermissions)
+        #expect(!resumedAtPermissions)
+        #expect(!schedulesAfterCompletion)
+        #expect(schedulesInitialCompletion)
     }
 
     @Test("automatic dictation reclassification applies only to legacy Voice Notes")

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
@@ -3,6 +3,41 @@ import Testing
 
 @Suite("OnboardingFlow")
 struct OnboardingFlowTests {
+    @Test("Everything restores the prior capability union when toggled off")
+    func everythingRestoresPriorSelection() {
+        let prior = OnboardingFlow.UseCaseSelectionState(
+            selectedUseCase: .voiceNotesAndMeetings,
+            selectionBeforeEverything: nil
+        )
+        let everything = OnboardingFlow.togglingEverything(in: prior)
+
+        #expect(everything.selectedUseCase == .everything)
+        #expect(everything.selectionBeforeEverything == .voiceNotesAndMeetings)
+        #expect(OnboardingFlow.togglingEverything(in: everything) == prior)
+    }
+
+    @Test("Everything remains selected after resume without an in-memory prior selection")
+    func resumedEverythingDoesNotDiscardCapabilities() {
+        let resumed = OnboardingFlow.UseCaseSelectionState(
+            selectedUseCase: .everything,
+            selectionBeforeEverything: nil
+        )
+
+        #expect(OnboardingFlow.togglingEverything(in: resumed) == resumed)
+    }
+
+    @Test("Individual capability changes clear the Everything restoration state")
+    func capabilityToggleClearsEverythingHistory() {
+        let everything = OnboardingFlow.UseCaseSelectionState(
+            selectedUseCase: .everything,
+            selectionBeforeEverything: .voiceNotesAndMeetings
+        )
+        let updated = OnboardingFlow.toggling(.voiceNotes, in: everything)
+
+        #expect(updated.selectedUseCase == .dictationAndMeetings)
+        #expect(updated.selectionBeforeEverything == nil)
+    }
+
     @Test("voice notes orders push-to-talk steps without paste permission")
     func voiceNotesOrderedSteps() {
         #expect(OnboardingFlow.orderedSteps(for: .voiceNotes) == [0, 1, 2, 3, 4])
@@ -72,6 +107,52 @@ struct OnboardingFlowTests {
         #expect(OnboardingFlow.completionTab(for: .voiceNotes) == .dictations)
         #expect(OnboardingFlow.completionTab(for: .dictation) == .dictations)
         #expect(OnboardingFlow.completionTab(for: .dictationAndMeetings) == .dictations)
+    }
+
+    @Test("permission advancement has one capability-derived destination")
+    func permissionAdvanceAction() {
+        #expect(OnboardingFlow.permissionAdvanceAction(
+            for: .dictation,
+            currentStepIndex: 3,
+            orderedStepCount: 5
+        ) == .restartForDictationTest)
+        #expect(OnboardingFlow.permissionAdvanceAction(
+            for: .meetings,
+            currentStepIndex: 2,
+            orderedStepCount: 3
+        ) == .finish)
+        #expect(OnboardingFlow.permissionAdvanceAction(
+            for: .meetings,
+            currentStepIndex: 2,
+            orderedStepCount: 5
+        ) == .next)
+    }
+
+    @Test("automatic dictation reclassification applies only to legacy Voice Notes")
+    func voiceNoteReclassificationPolicy() {
+        let granted = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: true,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+
+        #expect(OnboardingFlow.shouldReclassifyVoiceNotesAsDictation(
+            previousUseCase: .voiceNotes,
+            permissions: granted
+        ))
+        #expect(!OnboardingFlow.shouldReclassifyVoiceNotesAsDictation(
+            previousUseCase: .voiceNotesAndMeetings,
+            permissions: granted
+        ))
+
+        var missingAccessibility = granted
+        missingAccessibility.accessibility = false
+        #expect(!OnboardingFlow.shouldReclassifyVoiceNotesAsDictation(
+            previousUseCase: .voiceNotes,
+            permissions: missingAccessibility
+        ))
     }
 
     @Test("dictation monitor stops and cancels active testing when readiness is lost")

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
@@ -23,6 +23,13 @@ struct OnboardingFlowTests {
         #expect(OnboardingFlow.orderedSteps(for: .dictationAndMeetings) == [0, 1, 2, 3, 4, 5, 6])
     }
 
+    @Test("multi-select unions include every required workflow step")
+    func multiSelectUnionOrderedSteps() {
+        #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndMeetings) == [0, 1, 2, 3, 4, 5, 6])
+        #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndDictation) == [0, 1, 2, 3, 4])
+        #expect(OnboardingFlow.orderedSteps(for: .everything) == [0, 1, 2, 3, 4, 5, 6])
+    }
+
     @Test("normalized step advances over skipped steps")
     func normalizedStepAdvancesOverSkippedSteps() {
         #expect(OnboardingFlow.normalizedStep(2, for: .meetings) == 3)

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
@@ -278,4 +278,29 @@ struct OnboardingProgressTests {
         #expect(!OnboardingPermissionGate.hasRequiredVoiceNotesPermissions(permissions))
         #expect(step == 3)
     }
+
+    @Test("multi-select permission requirements use the strictest capability union")
+    func multiSelectPermissionUnion() {
+        let voiceAndMeetings = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+        #expect(OnboardingPermissionGate.hasRequiredPermissions(voiceAndMeetings, for: .voiceNotesAndMeetings))
+
+        let everythingWithoutAccessibility = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+        #expect(!OnboardingPermissionGate.hasRequiredPermissions(everythingWithoutAccessibility, for: .everything))
+
+        var everythingGranted = everythingWithoutAccessibility
+        everythingGranted.accessibility = true
+        #expect(OnboardingPermissionGate.hasRequiredPermissions(everythingGranted, for: .everything))
+    }
 }

--- a/scripts/ci_unsharded_test_suites.txt
+++ b/scripts/ci_unsharded_test_suites.txt
@@ -64,8 +64,6 @@ MenuBarIconRendererTests
 MicTurnNormalizerTests
 MuesliBridgeDeviceIdentityTests
 MuesliBridgeDeviceRefreshPolicyTests
-OnboardingFlowTests
-OnboardingProgressTests
 PCMChunkRecorderTests
 PostProcessorOptionTests
 Qwen3PostProcessingOutputCleanerTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -28,6 +28,8 @@ case "${shard}" in
       SettingsPermissionRefreshReasonTests
       AccessibilityPermissionGuideTests
       DictationTestLifecycleTests
+      OnboardingFlowTests
+      OnboardingProgressTests
       FloatingIndicatorVisibilityTests
       IndicatorFrameSizeTests
       WindowAppearanceTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -26,6 +26,7 @@ case "${shard}" in
       ChatGPTTokenStorageTests
       OpenRouterAuthTests
       SettingsPermissionRefreshReasonTests
+      AccessibilityPermissionGuideTests
       FloatingIndicatorVisibilityTests
       IndicatorFrameSizeTests
       WindowAppearanceTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -27,6 +27,7 @@ case "${shard}" in
       OpenRouterAuthTests
       SettingsPermissionRefreshReasonTests
       AccessibilityPermissionGuideTests
+      DictationTestLifecycleTests
       FloatingIndicatorVisibilityTests
       IndicatorFrameSizeTests
       WindowAppearanceTests


### PR DESCRIPTION
## Summary

- add compact, dynamically positioned drag guides for Accessibility and Input Monitoring with the bundled Muesli icon, native grab cursor, and directional motion
- make onboarding workflows multi-select and derive steps, permissions, output behavior, and completion routing from the capability union
- use the bundled app logo on welcome, auto-advance after required permissions, and keep the mic-test floating waveform live through hotkey release
- cover guide layout, multi-select persistence, permission unions, and onboarding routes with focused tests

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/worktrees/muesli-2471716039/test --filter "OnboardingFlowTests|OnboardingProgressTests"` — 33 tests in 2 suites passed
- `MUESLI_SWIFTPM_SCRATCH_PATH=/Users/pranavhari/Library/Caches/muesli-spm/worktrees/muesli-2471716039/test ./scripts/run_ci_test_shard.sh core` — 476 tests in 29 suites passed
- `./scripts/test_classify_changed_files.sh` and `./scripts/test_ci_test_shards.sh`
- built and launched `/Applications/MuesliDevB.app` with the shared SwiftPM cache and complete LocalVQE runtime
- reset `com.muesli.dev.b` TCC state and manually completed the fresh onboarding flow on macOS
- `git diff --check`

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli’s
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex assisted with implementation, test coverage, and local build verification. The resulting flow was reviewed and manually exercised in MuesliDevB.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858150&installation_model_id=422865&pr_number=492&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F492&signature=19d0820aa6783a52b78153c1944db3b034a2bffcdb894a9385cda43ad59b8c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-app guide for granting macOS Accessibility and Input Monitoring permissions with visual drag-and-drop instructions.
  - Onboarding now supports selecting multiple workflows: voice notes, dictation, meetings, or all capabilities.
  - Onboarding advances automatically after required permissions are granted.
  - Improved onboarding visuals with app branding and selection indicators.
  - Dictation testing now provides the same floating waveform feedback as regular recording.

- **Bug Fixes**
  - Corrected dictation and voice-note instructions and output behavior.
  - Improved permission-window handling, drop validation, and dictation test-state cleanup.
  - Prevented onboarding from repeatedly advancing after completed permission steps.
  - Preserved other selected workflows when switching between capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->