### PR TITLE
Use stable OpenRouter defaults and choose re-summary models

### DIFF
--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -1175,8 +1175,12 @@ enum CLISummaryError: LocalizedError {
 
 enum CLISummaryClient {
     private static let defaultOpenAIModel = "gpt-5.4-mini"
-    private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
+    private static let defaultOpenRouterModel = "openrouter/free"
     private static let defaultSummaryMaxOutputTokens = 2500
+
+    static func resolvedOpenRouterModel(_ configuredModel: String) -> String {
+        configuredModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? defaultOpenRouterModel : configuredModel
+    }
 
     static func summarize(transcript: String, title: String, config: CLISummaryConfig) async throws -> String {
         let backend = config.meetingSummaryBackend.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -1203,7 +1207,7 @@ enum CLISummaryClient {
                 backend: "OpenRouter",
                 url: URL(string: "https://openrouter.ai/api/v1/chat/completions")!,
                 apiKey: key,
-                model: config.openRouterModel.isEmpty ? defaultOpenRouterModel : config.openRouterModel,
+                model: resolvedOpenRouterModel(config.openRouterModel),
                 transcript: transcript,
                 title: title
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -151,6 +151,9 @@ struct MeetingDetailView: View {
                 .background(MuesliTheme.backgroundBase)
                 .onAppear {
                     threadContext = controller.meetingThreadContext(for: meeting.id)
+                    if controller.canUseSummaryProvider(.openRouter) {
+                        controller.loadOpenRouterModels(.text)
+                    }
                 }
                 .onChange(of: meeting.id) { _, _ in
                     syncLocalState(with: meeting)
@@ -732,7 +735,7 @@ struct MeetingDetailView: View {
         }
     }
 
-    private func beginSummary(for meeting: MeetingRecord) {
+    private func beginSummary(for meeting: MeetingRecord, summaryConfig: AppConfig? = nil) {
         guard !isSummarizing else { return }
         isSummarizing = true
         let completion: (Result<Void, Error>) -> Void = { [meeting] result in
@@ -750,9 +753,9 @@ struct MeetingDetailView: View {
             }
         }
         if hasPendingTemplateChange(for: meeting) {
-            controller.applyMeetingTemplate(id: pendingTemplateID, to: meeting, completion: completion)
+            controller.applyMeetingTemplate(id: pendingTemplateID, to: meeting, summaryConfig: summaryConfig, completion: completion)
         } else {
-            controller.resummarize(meeting: meeting, completion: completion)
+            controller.resummarize(meeting: meeting, summaryConfig: summaryConfig, completion: completion)
         }
     }
 
@@ -1115,8 +1118,34 @@ struct MeetingDetailView: View {
                 )
             }
 
-            Button {
-                beginSummary(for: meeting)
+            Menu {
+                Button("Use Settings (\(appState.selectedMeetingSummaryBackend.label))") {
+                    beginSummary(for: meeting)
+                }
+                Divider()
+                ForEach(MeetingSummaryBackendOption.all, id: \.backend) { provider in
+                    if controller.canUseSummaryProvider(provider) {
+                        Menu(provider.label) {
+                            ForEach(provider.summaryModels(config: appState.config,
+                                openRouterModels: appState.openRouterSummaryModels
+                            ), id: \.id) { model in
+                                Button(model.label) {
+                                    beginSummary(for: meeting, summaryConfig: provider.summaryConfiguration(from: appState.config, model: model.id))
+                                }
+                            }
+                            if provider == .openRouter {
+                                if case .failed = appState.openRouterSummaryCatalogState {
+                                    Divider()
+                                    Button("Retry Loading Models") {
+                                        controller.loadOpenRouterModels(.text, force: true)
+                                    }
+                                } else if appState.openRouterSummaryCatalogState == .loading {
+                                    Text("Loading models…")
+                                }
+                            }
+                        }
+                    }
+                }
             } label: {
                 Label(primarySummaryActionLabel(for: meeting), systemImage: "sparkles")
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -125,7 +125,7 @@ enum MeetingSummaryClient {
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
     private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
-    private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
+    private static let defaultOpenRouterModel = "openrouter/free"
     private static let defaultChatGPTModel = "gpt-5.4-mini"
     private static let defaultOllamaModel = "qwen3.5"
     private static let defaultSummaryMaxOutputTokens = 2500

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -718,6 +718,7 @@ struct SummaryModelPreset {
     ]
 
     static let openRouterModels: [SummaryModelPreset] = [
+        SummaryModelPreset(id: "openrouter/free", label: "OpenRouter Free (default)"),
         SummaryModelPreset(id: "stepfun/step-3.5-flash:free", label: "Step 3.5 Flash (256k ctx)"),
         SummaryModelPreset(id: "nvidia/nemotron-3-super-120b-a12b:free", label: "Nemotron 3 Super 120B (262k ctx)"),
         SummaryModelPreset(id: "nvidia/nemotron-3-nano-30b-a3b:free", label: "Nemotron 3 Nano 30B (256k ctx)"),
@@ -877,6 +878,41 @@ enum OpenRouterModelCatalogFilter {
                 return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
             }
             .map { SummaryModelPreset(id: $0.id, label: $0.transcriptionPresetLabel) }
+    }
+}
+
+extension MeetingSummaryBackendOption {
+    var modelKeyPath: WritableKeyPath<AppConfig, String> {
+        switch self {
+        case .chatGPT: return \.chatGPTModel
+        case .openAI: return \.openAIModel
+        case .openRouter: return \.openRouterModel
+        case .ollama: return \.ollamaModel
+        case .lmStudio: return \.lmStudioModel
+        default: return \.customLLMModel
+        }
+    }
+
+    /// Copies the settings for one request without persisting a new default.
+    func summaryConfiguration(from config: AppConfig, model: String) -> AppConfig {
+        var snapshot = config
+        snapshot.meetingSummaryBackend = backend
+        snapshot[keyPath: modelKeyPath] = model
+        return snapshot
+    }
+
+    func summaryModels(config: AppConfig, openRouterModels: [SummaryModelPreset]) -> [SummaryModelPreset] {
+        let presets: [SummaryModelPreset]
+        switch self {
+        case .chatGPT: presets = SummaryModelPreset.chatGPTModels
+        case .openAI: presets = SummaryModelPreset.openAIModels
+        case .openRouter:
+            presets = [SummaryModelPreset.openRouterModels[0]]
+                + openRouterModels.filter { $0.id != "openrouter/free" }
+        case .ollama: presets = [SummaryModelPreset(id: "qwen3.5", label: "qwen3.5 (default)")]
+        default: presets = []
+        }
+        return SummaryModelPreset.menuPresets(presets, currentModel: config[keyPath: modelKeyPath])
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5528,12 +5528,25 @@ public final class MuesliController: NSObject {
         selectMeetingSummaryBackend(option)
     }
 
-    func resummarize(meeting: MeetingRecord, completion: @escaping (Result<Void, Error>) -> Void) {
-        let templateSnapshot = meetingTemplateSnapshot(for: meeting)
-        resummarize(meeting: meeting, using: templateSnapshot, completion: completion)
+    func canUseSummaryProvider(_ provider: MeetingSummaryBackendOption) -> Bool {
+        switch provider {
+        case .chatGPT: return appState.isChatGPTAuthenticated
+        case .openAI: return !resolvedOpenAIAPIKey().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .openRouter:
+            return appState.isOpenRouterAuthenticated || !config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .ollama: return true
+        case .lmStudio: return MeetingSummaryClient.lmStudioHasRequiredSettings(config: config)
+        case .customLLM: return MeetingSummaryClient.customLLMHasRequiredSettings(config: config)
+        default: return false
+        }
     }
 
-    func applyMeetingTemplate(id: String, to meeting: MeetingRecord, completion: @escaping (Result<Void, Error>) -> Void) {
+    func resummarize(meeting: MeetingRecord, summaryConfig: AppConfig? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
+        let templateSnapshot = meetingTemplateSnapshot(for: meeting)
+        resummarize(meeting: meeting, using: templateSnapshot, summaryConfig: summaryConfig, completion: completion)
+    }
+
+    func applyMeetingTemplate(id: String, to meeting: MeetingRecord, summaryConfig: AppConfig? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let templateSnapshot = MeetingTemplates.resolveExactSnapshot(
             id: id,
             customTemplates: config.customMeetingTemplates
@@ -5541,14 +5554,17 @@ public final class MuesliController: NSObject {
             completion(.failure(MeetingTemplateSelectionError.templateNoLongerExists))
             return
         }
-        resummarize(meeting: meeting, using: templateSnapshot, completion: completion)
+        resummarize(meeting: meeting, using: templateSnapshot, summaryConfig: summaryConfig, completion: completion)
     }
 
     private func resummarize(
         meeting: MeetingRecord,
         using templateSnapshot: MeetingTemplateSnapshot,
+        summaryConfig: AppConfig?,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
+        let summaryConfig = summaryConfig ?? config
+        let openRouterKey = openRouterAuth.resolvedAPIKey(legacyAPIKey: summaryConfig.openRouterAPIKey)
         Task { [weak self] in
             guard let self else { return }
             let plan = MeetingResummarizationPolicy.plan(for: meeting)
@@ -5556,10 +5572,11 @@ public final class MuesliController: NSObject {
                 let notes = try await MeetingSummaryClient.summarize(
                     transcript: meeting.rawTranscript,
                     meetingTitle: plan.promptTitle,
-                    config: self.config,
+                    config: summaryConfig,
                     template: templateSnapshot,
                     existingNotes: self.notesContextForResummary(meeting),
-                    manualNotesToRetain: meeting.manualNotes
+                    manualNotesToRetain: meeting.manualNotes,
+                    openRouterAPIKeyOverride: openRouterKey
                 )
                 try self.dictationStore.updateMeetingSummary(
                     id: meeting.id,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -44,7 +44,7 @@ enum TranscriptCleanupClient {
         case .some(.openAI):
             return SummaryModelPreset.openAIModels.first?.id ?? "gpt-5.4-mini"
         case .some(.openRouter):
-            return SummaryModelPreset.openRouterModels.first?.id ?? "stepfun/step-3.5-flash:free"
+            return SummaryModelPreset.openRouterModels.first?.id ?? "openrouter/free"
         case .some(.ollama):
             return "qwen3.5"
         case .some(.lmStudio), .some(.customLLM):

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -5,6 +5,31 @@ import MuesliCore
 
 @Suite("MeetingSummaryClient")
 struct MeetingSummaryClientTests {
+    @Test("one-request choices preserve settings and route each provider's model",
+          arguments: MeetingSummaryBackendOption.all)
+    func oneRequestSummarySelection(provider: MeetingSummaryBackendOption) throws {
+        let config = AppConfig()
+        let selected = provider.summaryConfiguration(from: config, model: "chosen/model")
+        let fields = ["chatgpt": "chatgpt_model", "openai": "openai_model",
+                      "openrouter": "openrouter_model", "ollama": "ollama_model",
+                      "lmstudio": "lmstudio_model", "custom_llm": "custom_llm_model"]
+        var original = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(config)) as? [String: Any])
+        let encoded = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(selected)) as? [String: Any])
+        original["meeting_summary_backend"] = provider.backend
+        original[try #require(fields[provider.backend])] = "chosen/model"
+        #expect(NSDictionary(dictionary: original).isEqual(to: encoded))
+        #expect(provider.summaryModels(config: selected, openRouterModels: []).contains { $0.id == "chosen/model" })
+    }
+
+    @Test("re-summary catalog retains stable router and custom model with or without cached results",
+          arguments: [[], [SummaryModelPreset(id: "openrouter/free", label: "Router")]])
+    func resummaryCatalogRetention(catalog: [SummaryModelPreset]) {
+        var config = AppConfig()
+        config.openRouterModel = "custom/model"
+        let models = MeetingSummaryBackendOption.openRouter.summaryModels(config: config, openRouterModels: catalog)
+        #expect(models.map(\.id) == ["openrouter/free", "custom/model"])
+    }
+
     private let customTemplate = MeetingTemplateSnapshot(
         id: "custom-follow-up",
         name: "Customer Follow-Up",

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1468,10 +1468,13 @@ struct MeetingsNavigationTests {
 
         let unauthenticatedRequestCount = await probe.requestCount
         #expect(unauthenticatedRequestCount == 0)
+        #expect(!controller.canUseSummaryProvider(.openRouter))
         #expect(controller.appState.openRouterTranscriptionModels.isEmpty)
         #expect(controller.appState.openRouterTranscriptionCatalogState == .idle)
 
         try openRouterAuth.storeManualAPIKey("sk-or-v1-test")
+        controller.updateConfig { _ in }
+        #expect(controller.canUseSummaryProvider(.openRouter))
         controller.loadOpenRouterModels(.transcription, force: true)
         await probe.waitForRequest()
         for _ in 0..<100 where controller.appState.openRouterTranscriptionCatalogState != .loaded {
@@ -1508,6 +1511,7 @@ struct MeetingsNavigationTests {
 
         #expect(!openRouterAuth.isAuthenticated)
         #expect(controller.hostedDictationModelVisibility.shows(.openRouter))
+        #expect(controller.canUseSummaryProvider(.openRouter))
     }
 
     @Test("an older cancelled catalog request cannot overwrite a newer reload")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -700,13 +700,19 @@ struct SummaryModelPresetTests {
         #expect(TranscriptCleanupClient.configuredModel(for: backend, config: AppConfig()) == "gpt-5.6-terra")
     }
 
-    @Test("OpenRouter presets have valid model IDs")
+    @Test("OpenRouter presets default to the provider-managed free router")
     func openRouterModels() {
         #expect(!SummaryModelPreset.openRouterModels.isEmpty)
+        #expect(SummaryModelPreset.openRouterModels.first?.id == "openrouter/free")
+
         for preset in SummaryModelPreset.openRouterModels {
             #expect(!preset.id.isEmpty)
             #expect(!preset.label.isEmpty)
         }
+
+        let backend = TranscriptCleanupBackendOption.hosted(.openRouter)
+        #expect(TranscriptCleanupClient.defaultModel(for: backend) == "openrouter/free")
+        #expect(TranscriptCleanupClient.configuredModel(for: backend, config: AppConfig()) == "openrouter/free")
     }
 
     @Test("Computer use planner presets use GPT-5.6 Sol by default")

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
@@ -73,6 +73,13 @@ struct MuesliCLITests {
         #expect(config.openRouterAPIKey == "sk-or-cli-test")
     }
 
+    @Test("CLI OpenRouter summaries use the free router when no model is configured")
+    func cliOpenRouterUsesProviderManagedDefaultModel() {
+        #expect(CLISummaryClient.resolvedOpenRouterModel("") == "openrouter/free")
+        #expect(CLISummaryClient.resolvedOpenRouterModel("  \n") == "openrouter/free")
+        #expect(CLISummaryClient.resolvedOpenRouterModel("custom/model") == "custom/model")
+    }
+
     @Test("migration runs before a read so a legacy database gains new columns")
     func migrationWarningsUpgradesLegacyDatabase() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary

Supersedes #494. Fixes #473.

- Use `openrouter/free` as the empty-model default for meeting summaries, titles, transcript cleanup, and CLI summaries. Explicit model selections remain unchanged; this is not error-triggered failover.
- Choose a provider/model directly from the meeting's Re-summarize or Apply Template menu: ChatGPT, OpenAI, OpenRouter, Ollama, LM Studio, and Custom LLM. Hosted providers require credentials; local/custom providers reuse existing configuration rules.
- Keep each choice local to that request with a copied configuration; do not change Settings. Reuse native menus, existing model presets/custom-ID retention, and the shared OpenRouter text catalog with retry.
- Reduce #494 from **+226 / −21** to **+144 / −16**, including tests. Reuse the existing backend type instead of adding a selection wrapper, remove repeated model-field switches and unrelated whitespace behavior, and use published authentication state rather than credential-file reads during menu rendering.

Credit: Matt Van Horn (@mvanhorn) proposed the stable OpenRouter default in #494, commit `a1c168c252deb5585bd0255cadf95573b06d5fb5`. This is a maintainer-authored, signed-off consolidation with his contribution attributed; it does not claim or manufacture a DCO sign-off from Matt.

## Validation

- Focused native suite: 158 tests across 5 suites passed, using the existing shared SwiftPM cache.
- Full native suite: 2,032 tests across 185 suites passed on rerun. The first run terminated with signal 11 in the unchanged `RouteAwareMeetingMicRecorderTests.activeFailureRebuildsSameRoute` array comparison (crash report points to line 271); no audio code or tests were changed here.
- Changed-file classifier, CI shard assignments, update-flow verification (`--skip-dmg`), and `git diff --check` passed.
- Tests cover all six provider/model mappings, preservation of other settings, custom model retention, stable-router deduplication, credential gating, and empty/default/explicit model behavior.
- The prior UI version from #494 was built and tested in Dev B. This lean revision has native test coverage but has not yet replaced that installed bundle.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] This maintainer consolidation uses Muesli's existing MIT-licensed code and the attributed contribution from #494.
- [ ] Maintainer to confirm any employer/client/institution permissions, if applicable.
- [x] Third-party sources and material AI assistance are disclosed below.

### Third-party materials

No new dependencies, models, datasets, or assets. Incorporates the attributed OpenRouter default fix from Matt Van Horn's Muesli contribution in #494; repository license: MIT.

### AI assistance

OpenAI Codex assisted with consolidation, implementation review, tests, and this description. Native validation results are listed above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791364002&installation_model_id=422865&pr_number=501&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F501&signature=ec3427fab31cbd9a2f241ee28b82dc1722efc8dfc90b5dd7041fe6dbc238af78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Re-summarize meetings using the configured settings or a selected summary provider and model.
  - OpenRouter models load automatically when available, with clearer loading and retry states.
  - Added an OpenRouter Free option using the provider-managed default model.

- **Improvements**
  - Explicit model selections are preserved when generating or re-generating summaries.
  - OpenRouter availability now reflects authentication status, including legacy credentials.

- **Tests**
  - Expanded coverage for provider selection, model retention, authentication, and OpenRouter defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->