### PR TITLE
fix: separate successive dictation pastes

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationPasteSpacing.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationPasteSpacing.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Presentation-only spacing for dictation paste. Recognition and saved text
+/// remain unchanged, as do Quill and other verbatim paste callers.
+enum DictationPasteSpacing {
+    static func trailingSeparator(after text: String) -> String {
+        guard let last = text.last, !last.isWhitespace else { return "" }
+        var ending = text[...]
+        while let character = ending.last, isClosingPunctuation(character) {
+            ending.removeLast()
+        }
+        let content = ending.dropLast()
+        guard let terminal = ending.last, matches(sentenceTerminal, terminal),
+              let content = content.last(where: \.isLetter) ?? content.last(where: \.isNumber),
+              !matches(unspacedScript, content) else { return "" }
+        return " "
+    }
+
+    private static func isClosingPunctuation(_ character: Character) -> Bool {
+        character == "\"" || character == "'" || character.unicodeScalars.allSatisfy {
+            $0.properties.generalCategory == .closePunctuation || $0.properties.generalCategory == .finalPunctuation
+        }
+    }
+
+    // Unicode properties cover Arabic question marks, Indic danda, etc. without
+    // a model/language setting. Chinese/Japanese endings keep their native spacing.
+    private static let sentenceTerminal = try! NSRegularExpression(pattern: #"[\p{Sentence_Terminal}…]"#)
+    private static let unspacedScript = try! NSRegularExpression(pattern: #"[\p{Han}\p{Hiragana}\p{Katakana}\p{Bopomofo}]"#)
+
+    private static func matches(_ expression: NSRegularExpression, _ character: Character) -> Bool {
+        let text = String(character)
+        return expression.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -11194,6 +11194,7 @@ public final class MuesliController: NSObject {
                         var completionTargetApp: DictationCorrectionTargetApp?
                         PasteController.paste(
                             text: text,
+                            appendDictationSentenceSpace: true,
                             requireStagedClipboardOwnership: true,
                             onPasteFinished: { [weak self] targetApplication in
                                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -71,6 +71,7 @@ enum PasteController {
     @MainActor
     static func paste(
         text: String,
+        appendDictationSentenceSpace: Bool = false,
         pasteboard: NSPasteboard = .general,
         requireStagedClipboardOwnership: Bool = false,
         targetApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
@@ -94,7 +95,12 @@ enum PasteController {
         let savedItems = saveClipboard(pasteboard)
 
         let clearedChangeCount = pasteboard.clearContents()
-        let didStageText = pasteboard.setString(text, forType: .string)
+        // Only live dictation opts in. Quill, history copy, and other paste uses
+        // keep their exact text; stored transcripts are never padded.
+        let pastedText = appendDictationSentenceSpace
+            ? text + DictationPasteSpacing.trailingSeparator(after: text)
+            : text
+        let didStageText = pasteboard.setString(pastedText, forType: .string)
         let pasteChangeCount = pasteboard.changeCount
         onLifecycleEvent(didStageText ? .clipboardStaged : .clipboardStageFailed)
 

--- a/native/MuesliNative/Tests/MuesliTests/DictationPasteSpacingPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationPasteSpacingPolicyTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Dictation paste spacing policy")
+struct DictationPasteSpacingPolicyTests {
+    @Test("separate dictations leave sentence spacing at the cursor", arguments: [
+        ("Okay, transcribing whether this adds a space after the punctuation or not.", " "),
+        ("So that we can start immediately.", " "),
+        ("Yeah, it is not seeming to add any punctuation after the full stop.", " "),
+        ("¿Qué pasa?", " "), ("Ça va!", " "), ("Да.", " "), ("Ναι.", " "),
+        ("حقاً؟", " "), ("ہاں۔", " "), ("כן.", " "), ("है।", " "),
+        ("है॥", " "), ("হয়।", " "), ("ஆம்.", " "), ("จบ!", " "),
+        ("끝.", " "), ("He said “yes.”", " "), ("(Done.)", " "),
+        ("Fin…", " "), ("Fin...", " "), ("U.S.", " "),
+        ("结束。", ""), ("終わり！", ""), ("「次です。」", ""), ("中文.", ""),
+        ("中文2026。", ""), ("끝2026.", " "),
+        ("Done. ", ""), ("Done.\n", ""), ("Done.\u{00A0}", ""),
+        ("3.14", ""), ("example.com", ""), ("unfinished", ""),
+        ("", ""), (".", ""), ("?!", ""),
+    ])
+    func trailingSentenceSpace(text: String, expected: String) {
+        #expect(DictationPasteSpacing.trailingSeparator(after: text) == expected)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictationPasteSpacingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationPasteSpacingTests.swift
@@ -1,0 +1,57 @@
+import AppKit
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Dictation paste spacing")
+@MainActor
+struct DictationPasteSpacingTests {
+    @Test("successive dictations are separated without changing their raw text")
+    func successiveDictations() async {
+        let chunks = [
+            "Okay, transcribing whether this adds a space after the punctuation or not.",
+            "So that we can start immediately.",
+            "Yeah, it is not seeming to add any punctuation after the full stop.",
+        ]
+        var inserted = ""
+        for text in chunks {
+            inserted += await paste(text, dictation: true)
+        }
+        #expect(inserted == chunks.joined(separator: " ") + " ")
+        #expect(chunks.allSatisfy { $0.last == "." })
+    }
+
+    @Test("normal paste remains verbatim")
+    func verbatimPaste() async {
+        #expect(await paste("Quill output.", dictation: false) == "Quill output.")
+    }
+
+    @Test("dictation does not double existing spacing or pad CJK", arguments: ["Done. ", "Done.\n", "结束。", "終わり。"])
+    func preserveFormatting(text: String) async {
+        #expect(await paste(text, dictation: true) == text)
+    }
+
+    /// A private pasteboard and injected dispatcher exercise production staging
+    /// and restoration without sending keystrokes or touching the real clipboard.
+    private func paste(_ text: String, dictation: Bool) async -> String {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("muesli-spacing-test-\(UUID().uuidString)"))
+        defer { pasteboard.releaseGlobally() }
+        pasteboard.setString("original clipboard", forType: .string)
+        var delivered = ""
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            PasteController.paste(
+                text: text,
+                appendDictationSentenceSpace: dictation,
+                pasteboard: pasteboard,
+                requireStagedClipboardOwnership: true,
+                targetApplicationProvider: { nil },
+                simulatePasteAction: {
+                    delivered = pasteboard.string(forType: .string) ?? ""
+                    return true
+                },
+                onClipboardSettled: { continuation.resume() }
+            )
+        }
+        #expect(pasteboard.string(forType: .string) == "original clipboard")
+        return delivered
+    }
+}

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -73,6 +73,8 @@ case "${shard}" in
       DiarizerPreloadDiagnosticsTests
       DiarizerPreloadCoordinationTests
       PasteControllerTests
+      DictationPasteSpacingPolicyTests
+      DictationPasteSpacingTests
       QuilTransformationTests
       BackendOptionTests
       OpenAIDictationProviderTests


### PR DESCRIPTION
## Summary

Successive dictations now leave a space after sentence-ending punctuation when pasted, so `not.So` becomes `not. So`. The change is applied only at paste time, regardless of the recognition model.

Existing whitespace and Chinese/Japanese endings remain unchanged. Recognition, saved transcripts, meetings, Quill, and other verbatim paste callers are unchanged. This does not repair missing spaces between ASR chunks within a single transcript.

Related: #462

## Validation

- 48 tests in 5 suites passed on the final source, covering multilingual sentence endings, successive clipboard delivery, clipboard restoration, and unchanged Apple Speech/meeting formatting behavior:
  ```sh
  swift test --package-path native/MuesliNative \
    --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/muesli-2471716039/test" \
    --filter 'DictationPasteSpacingPolicyTests|DictationPasteSpacingTests|AppleSpeechAnalyzerBackendTests|TranscriptFormatterTests|TranscriptReconcilerTests'
  ```
- The maintainer verified successive dictation spacing with Parakeet in MuesliDevA. The subsequent removal-only cleanup of Apple Speech/streaming interventions passed the tests above but has not been reinstalled into DevA.
- `git diff --check` passed.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex assisted with implementation, tests, cleanup, and PR preparation. The maintainer directed the paste-only scope and manually verified the spacing behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791399111&installation_model_id=422865&pr_number=502&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F502&signature=2cf34184762b826c02dd690643b279424f5cab6c4273c7659d2c1f5ce27ee11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dictated text now automatically adds a space after sentence-ending punctuation when appropriate.
  - Consecutive dictation chunks are separated cleanly without changing their original wording.
  - Spacing is avoided when text already ends with whitespace or uses scripts where spaces are not typically used.

- **Improvements**
  - Regular paste operations continue to preserve text exactly as provided.
  - Dictation paste handling now supports punctuation, quotations, abbreviations, and multilingual text more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->