### PR TITLE
fix: highlight Bodhan and re-summary in the 0.8.4 tour

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -38,6 +38,7 @@ enum FeatureTourTarget: String, Hashable {
     case quillSettings
     case dictationProviderSetting
     case parakeetFamilyCard
+    case bodhanFlexCard
     case timelineSidebar
     case timelineApplications
     case appleSpeechCard
@@ -68,7 +69,7 @@ enum FeatureTourTarget: String, Hashable {
             return .meetingsBrowser
         case .meetingPeople:
             return .meetingPeople
-        case .modelLibrary, .appleSpeechCard, .parakeetFamilyCard, .experimentalModels:
+        case .modelLibrary, .appleSpeechCard, .parakeetFamilyCard, .bodhanFlexCard, .experimentalModels:
             return .models(.dictation)
         case .streamingModels:
             return .models(.streaming)
@@ -155,6 +156,22 @@ enum FeatureTourCatalog {
                 message: "Parakeet Unified balances speed and accuracy for fast, reliable English transcription on your Mac. For other languages, choose multilingual Parakeet v3.",
                 systemImage: "waveform",
                 target: .parakeetFamilyCard
+            ),
+            FeatureTourStep(
+                id: "bodhan",
+                eyebrow: "BODHAN CORE & FLEX",
+                title: "Dictate across Indian languages and English",
+                message: "Use Bodhan Flex for Indian-accented English and code-switched speech that mixes Indic languages with English. Core favors native-script output. Download either model for private, on-device transcription. Requires macOS 15 or later.",
+                systemImage: "globe",
+                target: .bodhanFlexCard
+            ),
+            FeatureTourStep(
+                id: "resummarize",
+                eyebrow: "MEETING SUMMARIES",
+                title: "Choose a different model for your meeting summary",
+                message: "Open a saved meeting and pick a provider and model from Re-summarize or Apply Template to generate a fresh summary, without changing your default settings.",
+                systemImage: "arrow.clockwise",
+                target: nil
             ),
         ])
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -84,7 +84,7 @@ struct FeatureTourCalloutLayout {
         switch target {
         case .timelineSidebar, .meetingsSidebar:
             return [.trailing, .leading, .below, .above]
-        case .timelineApplications, .appleSpeechCard, .meetingPeople, .timelineFilters, .modelLibrary, .insightsEntry, .liveCaptionsSetting, .dictationProviderSetting, .parakeetFamilyCard:
+        case .timelineApplications, .appleSpeechCard, .meetingPeople, .timelineFilters, .modelLibrary, .insightsEntry, .liveCaptionsSetting, .dictationProviderSetting, .parakeetFamilyCard, .bodhanFlexCard:
             return [.below, .above, .trailing, .leading]
         case .dictionarySuggestions, .cloudCleanupSetting, .streamingModels, .experimentalModels, .quillSettings:
             return [.above, .below, .trailing, .leading]

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -102,11 +102,9 @@ struct ModelsView: View {
             .onAppear {
                 revealFeatureTourTargetIfNeeded(using: proxy)
             }
-            .onChange(of: activeFeatureTourTarget) { _, target in
-                guard target == .modelLibrary
-                        || target == .appleSpeechCard
-                        || target == .streamingModels
-                        || target == .experimentalModels else { return }
+            .onChange(of: activeFeatureTourTarget) { _, _ in
+                // The reveal helper owns target filtering. A second allowlist here
+                // can miss model-to-model transitions while this view stays mounted.
                 revealFeatureTourTargetIfNeeded(using: proxy)
             }
         }
@@ -225,6 +223,8 @@ struct ModelsView: View {
             modelCard(option: .cohereTranscribe, logo: "cohere-logo")
             bodhanCard(selection: $selectedBodhanCoreModel, isCore: true)
             bodhanCard(selection: $selectedBodhanFlexModel, isCore: false)
+                .id(FeatureTourTarget.bodhanFlexCard.rawValue)
+                .featureTourTarget(.bodhanFlexCard)
             experimentalSection
             comingSoonSection
         case .streaming:
@@ -269,6 +269,9 @@ struct ModelsView: View {
             appState.selectedModelsCategory = .dictation
         case .parakeetFamilyCard:
             target = .parakeetFamilyCard
+            appState.selectedModelsCategory = .dictation
+        case .bodhanFlexCard:
+            target = .bodhanFlexCard
             appState.selectedModelsCategory = .dictation
         case .streamingModels:
             target = .streamingModels

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -168,17 +168,20 @@ struct FeatureTourTests {
         ))
     }
 
-    @Test("0.8.4 catalog highlights four major product additions")
+    @Test("0.8.4 catalog retains existing highlights and adds Bodhan and re-summary")
     func catalogShape() {
         #expect(tour.version == "0.8.4")
-        #expect(tour.steps.count == 4)
+        #expect(tour.steps.count == 6)
         #expect(Set(tour.steps.map(\.id)).count == tour.steps.count)
-        #expect(Set(tour.steps.map(\.target)).count == tour.steps.count)
+        let targets = tour.steps.compactMap(\.target)
+        #expect(Set(targets).count == targets.count)
         #expect(tour.steps.map(\.target) == [
             .quillSettings,
             nil,
             .dictationProviderSetting,
             .parakeetFamilyCard,
+            .bodhanFlexCard,
+            nil,
         ])
 
         let quill = tour.steps[0]
@@ -210,6 +213,7 @@ struct FeatureTourTests {
     @Test("model feature-tour targets resolve routes without UI state")
     func modelNavigationRoutes() {
         #expect(FeatureTourTarget.parakeetFamilyCard.navigationRoute == .models(.dictation))
+        #expect(FeatureTourTarget.bodhanFlexCard.navigationRoute == .models(.dictation))
         #expect(FeatureTourTarget.streamingModels.navigationRoute == .models(.streaming))
         #expect(FeatureTourTarget.experimentalModels.navigationRoute == .models(.dictation))
     }


### PR DESCRIPTION
## Summary

The 0.8.4 What's New tour now introduces Bodhan Core & Flex and per-meeting re-summarization while retaining the four existing highlights.

Bodhan Flex is highlighted for Indian-accented English and code-switched Indic speech, with the macOS 15 requirement stated explicitly. Advancing from Parakeet now scrolls to and spotlights the Bodhan Flex card instead of leaving it offscreen. Re-summarization uses a central callout so the tour does not require a saved meeting.

This updates the existing pre-release tour only; Sparkle notes, release versioning, and Apple Speech meeting promotion are unchanged.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path <existing-test-cache> --filter FeatureTourTests`: all 12 tests passed, including catalog shape and model navigation routes.
- DevA rebuilt through Xcode using the existing cache and launched with local-only entitlements. Installed signature and functional LocalVQE checks passed; Shortcuts metadata was retained.
- Maintainer visually verified the tour and confirmed Bodhan scrolling/highlighting works after the fix.
- `git diff --check` passed.
- Local packaging required a temporary macOS Bash empty-array workaround and the inspected MLX package-plugin trust option. The workaround is not included in this PR.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [ ] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None introduced. The tour describes models and functionality already present on main.

### AI assistance

OpenAI Codex assisted with copy, SwiftUI tour targeting, tests, and DevA build verification. The maintainer reviewed the UI and confirmed the corrected Bodhan highlight.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791464338&installation_model_id=422865&pr_number=506&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F506&signature=9137dd49779b1eb683c0ca01dd8d6332e88251e729717f1e8570c35f2f092dcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature-tour guidance for Bodhan Core & Flex models.
  * Added a feature-tour step highlighting meeting-summary model selection.
  * Selecting the Bodhan Flex tour step now opens the Dictation models section and brings the relevant card into view.
  * Improved callout placement for the new feature-tour target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->