### PR TITLE
Prepare MuesliPreprod 0.8.4-preprod.1 and publish appcast

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -34,6 +34,23 @@
         <item>
             <title>0.8.2-preprod.3</title>
             <pubDate>Tue, 18 Aug 2026 09:23:48 +0530</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.8.2-preprod.3</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.8.2-preprod.3.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
             <sparkle:version>8002003</sparkle:version>
             <sparkle:shortVersionString>0.8.2-preprod.3</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
@@ -48,6 +65,32 @@
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.2/MuesliPreprod-0.8.2-preprod.2.dmg" length="98655352" type="application/octet-stream" sparkle:edSignature="DGy7uLrYvep5w3wsg5w3Z5Al/nAH2DE4TWiEFrXe/9s/PR2HQrgTesLOcupgDzdF3AXZm64E9tThd1IoMLxxBw=="/>
+        </item>
+        <item>
+            <title>0.8.2-preprod.1</title>
+            <pubDate>Sat, 15 Aug 2026 23:15:37 +0530</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.8.2-preprod.1</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.8.2-preprod.1.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>8002001</sparkle:version>
+            <sparkle:shortVersionString>0.8.2-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.1/MuesliPreprod-0.8.2-preprod.1.dmg" length="98286984" type="application/octet-stream" sparkle:edSignature="4ztiG5qcNscEGfVyg3HUUfHXyx6ZM7GS5z3gHbxxy126C+hRVwEer9pNHkXGoOhQg0NXoMgNSuw1qgvPk5L7Cw=="/>
         </item>
         <item>
             <title>0.7.0-preprod.1</title>

--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,14 +6,14 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
-            <title>0.8.2-preprod.3</title>
-            <pubDate>Tue, 18 Aug 2026 09:23:48 +0530</pubDate>
+            <title>0.8.4-preprod.1</title>
+            <pubDate>Wed, 09 Sep 2026 09:13:54 +0530</pubDate>
             <description><![CDATA[
-<h2>MuesliPreprod 0.8.2-preprod.3</h2>
+<h2>MuesliPreprod 0.8.4-preprod.1</h2>
 <p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
 <h3>Install</h3>
 <ul>
-<li>Download <code>MuesliPreprod-0.8.2-preprod.3.dmg</code></li>
+<li>Download <code>MuesliPreprod-0.8.4-preprod.1.dmg</code></li>
 <li>Open the DMG and drag MuesliPreprod to Applications</li>
 <li>Launch MuesliPreprod from Applications</li>
 </ul>
@@ -25,6 +25,15 @@
 <li>Does not update the production appcast, public download page, or Homebrew tap.</li>
 </ul>
 ]]></description>
+            <sparkle:version>8004001</sparkle:version>
+            <sparkle:shortVersionString>0.8.4-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.4-preprod.1/MuesliPreprod-0.8.4-preprod.1.dmg" length="102914619" type="application/octet-stream" sparkle:edSignature="qiftMV1W6TlvfegSMEw/bjmMnI+J8vOoTWEom21mQURBvCqQltaCmDaBomNSGiJUTJ4d+y1ImssKNjOUeLLiAg=="/>
+        </item>
+        <item>
+            <title>0.8.2-preprod.3</title>
+            <pubDate>Tue, 18 Aug 2026 09:23:48 +0530</pubDate>
             <sparkle:version>8002003</sparkle:version>
             <sparkle:shortVersionString>0.8.2-preprod.3</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
@@ -39,32 +48,6 @@
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.2/MuesliPreprod-0.8.2-preprod.2.dmg" length="98655352" type="application/octet-stream" sparkle:edSignature="DGy7uLrYvep5w3wsg5w3Z5Al/nAH2DE4TWiEFrXe/9s/PR2HQrgTesLOcupgDzdF3AXZm64E9tThd1IoMLxxBw=="/>
-        </item>
-        <item>
-            <title>0.8.2-preprod.1</title>
-            <pubDate>Sat, 15 Aug 2026 23:15:37 +0530</pubDate>
-            <description><![CDATA[
-<h2>MuesliPreprod 0.8.2-preprod.1</h2>
-<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
-<h3>Install</h3>
-<ul>
-<li>Download <code>MuesliPreprod-0.8.2-preprod.1.dmg</code></li>
-<li>Open the DMG and drag MuesliPreprod to Applications</li>
-<li>Launch MuesliPreprod from Applications</li>
-</ul>
-<h3>Notes</h3>
-<ul>
-<li>Installs alongside production Muesli.</li>
-<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
-<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
-<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
-</ul>
-]]></description>
-            <sparkle:version>8002001</sparkle:version>
-            <sparkle:shortVersionString>0.8.2-preprod.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.1/MuesliPreprod-0.8.2-preprod.1.dmg" length="98286984" type="application/octet-stream" sparkle:edSignature="4ztiG5qcNscEGfVyg3HUUfHXyx6ZM7GS5z3gHbxxy126C+hRVwEer9pNHkXGoOhQg0NXoMgNSuw1qgvPk5L7Cw=="/>
         </item>
         <item>
             <title>0.7.0-preprod.1</title>

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -6,7 +6,7 @@ import TelemetryDeck
 import MuesliCore
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var controller: MuesliController?
     private var terminationTask: Task<Void, Never>?
     private(set) var updaterController: SPUStandardUpdaterController?
@@ -111,6 +111,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller?.showWhatsNew()
     }
 
+    @objc func checkForUpdates(_ sender: Any?) {
+        controller?.checkForUpdates()
+    }
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(AppDelegate.checkForUpdates(_:)) {
+            return updaterController != nil
+        }
+        return true
+    }
+
     @objc func showDictations(_ sender: Any?) {
         controller?.openHistoryWindow(tab: .dictations)
     }
@@ -144,6 +155,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         whatsNewItem.target = self
         appMenu.addItem(whatsNewItem)
+        let updatesItem = NSMenuItem(
+            title: "Check for Updates…",
+            action: #selector(AppDelegate.checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        updatesItem.target = self
+        appMenu.addItem(updatesItem)
         appMenu.addItem(.separator())
         appMenu.addItem(
             withTitle: "Hide \(AppIdentity.displayName)",

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -134,7 +134,7 @@ if [[ "$USE_XCODE_BUILD" == "1" ]]; then
   if [[ "${MUESLI_PROFILE_OPTIMIZED:-0}" == "1" ]]; then
     performance_args=(SWIFT_OPTIMIZATION_LEVEL=-O GCC_OPTIMIZATION_LEVEL=3)
   fi
-  xcodebuild build "${plugin_validation_args[@]}" "${performance_args[@]}" \
+  xcodebuild build ${plugin_validation_args[@]+"${plugin_validation_args[@]}"} ${performance_args[@]+"${performance_args[@]}"} \
     -project "$XCODE_PROJECT_DIR/MuesliXcode.xcodeproj" \
     -scheme Muesli \
     -configuration "$XCODE_CONFIG" \

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -444,7 +444,7 @@ git add "$APPCAST_PATH"
 if git diff --cached --quiet; then
   echo "  No preprod appcast changes to commit."
 else
-  git commit -m "Update preprod appcast for v${VERSION}"
+  git commit --signoff -m "Update preprod appcast for v${VERSION}"
   git push origin HEAD
   echo "  Pushed preprod appcast update."
 fi


### PR DESCRIPTION
## Summary

Prepare MuesliPreprod 0.8.4-preprod.1 and publish its Sparkle appcast through this PR. Fixes empty optional Xcode argument arrays under macOS Bash 3.2 `set -u`, and adds DCO sign-off to generated preprod appcast commits. Also adds “Check for Updates…” to the application-name menu, forwarding to the existing updater action and disabling it when the build has no updater.

Published [v0.8.4-preprod.1](https://github.com/Muesli-HQ/muesli/releases/tag/v0.8.4-preprod.1) from source commit 9cc4ed29, with Sparkle build 8004001. This PR adds its verified appcast entry while preserving every existing entry and release note. The app-name dropdown now includes “Check for Updates…” beneath What's New, using the existing updater action; builds without an updater show it disabled.

DMG SHA-256: `920d1519418192e1c7e7d2a2c9fbac89620f310c73ea9a6cf87eca33bca6c264`. Local and re-downloaded hosted artifacts match. App and DMG notarization were accepted, staples validated, and Gatekeeper accepted the downloaded artifact.

## Validation

- Full native suite: 2,099 tests across 190 suites passed, including after the application-menu change.
- Release-config Xcode app and packaged CLI built successfully.
- Signed bundle: deep strict verification and Production CloudKit/APNs profile contract passed for com.muesli.preprod.
- Packaged LocalVQE: CPU/BLAS backends loaded and model context created successfully at 16 kHz / 256 samples.
- App Intents metadata present; packaged CLI help passed.
- All four optional-array combinations passed under macOS Bash 3.2; shell syntax and diff checks passed.
- MuesliDev build/launch previously passed with the Bash fix.
- Final appcast passed `verify_update_flow.sh` for build 8004001 / 0.8.4-preprod.1 with required release notes and notarization.
- App notarization: 6fd808e6-dc00-4959-ba3b-44ca3a116707; DMG: 2e8c89c3-a82f-46f2-8df7-0c9d1d9564f7.
- Pending after merge: live preprod feed deployment and a real Sparkle upgrade from installed 0.8.2-preprod.3.
- Stable appcast, website, and Homebrew remain unchanged.

## Contribution certification

- [x] Every non-merge commit has its author's Signed-off-by trailer under the Developer Certificate of Origin.
- [x] These script edits were created for this contribution under Muesli's MIT License.
- [ ] Maintainer confirmation of any employer, client, institution, or other rights-holder permissions, if applicable.
- [x] Third-party materials introduced by this PR are identified below.
- [x] Material AI assistance is disclosed; the changes were reviewed and tested as described above.

### Third-party materials

None introduced. Release packaging uses the repository's existing pinned dependencies and models.

### AI assistance

OpenAI Codex implemented the shell compatibility and sign-off fixes, ran validation and the preprod pipeline, and prepared this description at the maintainer's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Check for Updates…” option to the application menu.
  * The option is available when update checking is configured.

* **Updates**
  * Added pre-production release information for version 0.8.4-preprod.1.
  * Expanded release notes and installation guidance for earlier pre-production versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->