### PR TITLE
Fix Quill ChatGPT requests and local model setup prompts

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -47,6 +47,7 @@ enum ModelsCategory: String, CaseIterable, Identifiable {
     case dictation
     case streaming
     case postProcessing
+    case quill
 
     var id: String { rawValue }
 
@@ -55,6 +56,7 @@ enum ModelsCategory: String, CaseIterable, Identifiable {
         case .dictation: return "Dictation"
         case .streaming: return "Live Meetings"
         case .postProcessing: return "Cleanup"
+        case .quill: return "Quill"
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -69,7 +69,12 @@ enum ChatGPTResponsesTransport {
             request.setValue("Muesli/\(appVersion)", forHTTPHeaderField: "User-Agent")
             request.setValue(sessionID.uuidString.lowercased(), forHTTPHeaderField: "session_id")
         }
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        var supportedBody = body
+        if backend == .codex {
+            // ChatGPT's Codex endpoint rejects this public Responses API field.
+            supportedBody.removeValue(forKey: "max_output_tokens")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: supportedBody)
         return request
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -213,7 +213,6 @@ final class FloatingIndicatorController: NSObject {
     var isToggleDictation = false
     private var stopLayer: CALayer?
     private var transcribingTitle = "Transcribing"
-    private var completedQuilDisplayID: UUID?
     private var instructionTranscriptText: String?
     private var instructionTranscriptShowsProgress = false
     private var loadingSpinner: NSProgressIndicator?
@@ -465,17 +464,6 @@ final class FloatingIndicatorController: NSObject {
         )
     }
 
-    func showCompletedQuilInstruction(_ instruction: String, config: AppConfig) {
-        guard state == .idle else { return }
-        showInstructionTranscript(instruction, fallbackTitle: "Quill complete", showsProgress: false, config: config)
-        let displayID = UUID()
-        completedQuilDisplayID = displayID
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-            guard let self, self.completedQuilDisplayID == displayID else { return }
-            self.setState(.idle, config: self.configStore.load())
-        }
-    }
-
     private func showInstructionTranscript(
         _ transcript: String,
         fallbackTitle: String,
@@ -490,7 +478,6 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func setState(_ state: DictationState, config: AppConfig) {
-        completedQuilDisplayID = nil
         lastLoadedConfig = config
         let previousState = self.state
         let previousHover = isHovered

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -213,6 +213,7 @@ final class FloatingIndicatorController: NSObject {
     var isToggleDictation = false
     private var stopLayer: CALayer?
     private var transcribingTitle = "Transcribing"
+    private var completedQuilDisplayID: UUID?
     private var instructionTranscriptText: String?
     private var instructionTranscriptShowsProgress = false
     private var loadingSpinner: NSProgressIndicator?
@@ -464,6 +465,17 @@ final class FloatingIndicatorController: NSObject {
         )
     }
 
+    func showCompletedQuilInstruction(_ instruction: String, config: AppConfig) {
+        guard state == .idle else { return }
+        showInstructionTranscript(instruction, fallbackTitle: "Quill complete", showsProgress: false, config: config)
+        let displayID = UUID()
+        completedQuilDisplayID = displayID
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            guard let self, self.completedQuilDisplayID == displayID else { return }
+            self.setState(.idle, config: self.configStore.load())
+        }
+    }
+
     private func showInstructionTranscript(
         _ transcript: String,
         fallbackTitle: String,
@@ -478,6 +490,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func setState(_ state: DictationState, config: AppConfig) {
+        completedQuilDisplayID = nil
         lastLoadedConfig = config
         let previousState = self.state
         let previousHover = isHovered

--- a/native/MuesliNative/Sources/MuesliNativeApp/Gemma4LiteRTBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Gemma4LiteRTBackend.swift
@@ -659,6 +659,23 @@ actor Gemma4LiteRTTranscriber {
         return (trimmed, rawOutput, elapsed)
     }
 
+    /// Interpret an audio instruction and generate the requested text in one conversation call.
+    func generateFromAudio(
+        wavURL: URL, systemPrompt: String, userPrompt: String,
+        model: Gemma4LiteRTModel, maxOutputTokens: Int32
+    ) async throws -> String {
+        await acquireOperation()
+        defer { releaseOperation() }
+        try Task.checkCancellation()
+        try Self.validateAudioDuration(wavURL: wavURL)
+        try await prepareEngine(model: model)
+        try Task.checkCancellation()
+        return try generateTextPrepared(
+            systemPrompt: systemPrompt, userPrompt: userPrompt,
+            maxOutputTokens: maxOutputTokens, audioURL: wavURL
+        )
+    }
+
     func generateText(
         systemPrompt: String,
         userPrompt: String,
@@ -678,7 +695,8 @@ actor Gemma4LiteRTTranscriber {
     private func generateTextPrepared(
         systemPrompt: String,
         userPrompt: String,
-        maxOutputTokens: Int32
+        maxOutputTokens: Int32,
+        audioURL: URL? = nil
     ) throws -> String {
         guard let engine else { throw TranscriberError.notLoaded }
         guard let sessionConfig = litert_lm_session_config_create() else {
@@ -713,10 +731,7 @@ actor Gemma4LiteRTTranscriber {
             throw TranscriberError.failedToCreateOptionalArgs
         }
         defer { litert_lm_conversation_optional_args_delete(optionalArgs) }
-        let userMessageJSON = try Self.messageJSONString(
-            role: "user",
-            contents: [["type": "text", "text": userPrompt]]
-        )
+        let userMessageJSON = try Self.generationMessageJSONString(userPrompt: userPrompt, audioURL: audioURL)
         guard let jsonResponse = litert_lm_conversation_send_message(
             conversation,
             userMessageJSON,
@@ -884,6 +899,12 @@ actor Gemma4LiteRTTranscriber {
             throw TranscriberError.failedToCreateMessage
         }
         return string
+    }
+
+    static func generationMessageJSONString(userPrompt: String, audioURL: URL?) throws -> String {
+        var contents = [["type": "text", "text": userPrompt]]
+        if let audioURL { contents.append(["type": "audio", "path": audioURL.path]) }
+        return try messageJSONString(role: "user", contents: contents)
     }
 
     static func userMessageJSONString(wavURL: URL) throws -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -78,7 +78,7 @@ struct ModelsView: View {
                         .font(MuesliTheme.title1())
                         .foregroundStyle(MuesliTheme.textPrimary)
 
-                    Text("Choose the transcription and cleanup models that fit how you speak and work.")
+                    Text("Choose the dictation, live meeting, cleanup, and Quill models that fit how you speak and work.")
                         .font(MuesliTheme.body())
                         .foregroundStyle(MuesliTheme.textSecondary)
 
@@ -88,7 +88,9 @@ struct ModelsView: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .frame(maxWidth: 520)
+                    .labelsHidden()
+                    .frame(maxWidth: 600)
+                    .frame(maxWidth: .infinity, alignment: .center)
                     .id(FeatureTourTarget.modelLibrary.rawValue)
                     .featureTourTarget(.modelLibrary)
 
@@ -231,6 +233,8 @@ struct ModelsView: View {
             streamingSection
         case .postProcessing:
             postProcessorSection
+        case .quill:
+            quillSection
         }
     }
 
@@ -692,34 +696,71 @@ struct ModelsView: View {
         }
     }
 
-    private func gemmaCleanupModelCard(_ model: Gemma4LiteRTModel) -> some View {
+    private var quillSection: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            Text("QUILL")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textTertiary)
+            Text("Rewrite selected text or generate text at the cursor with a local model. Download a model, choose Use for Quill, then enable Quill in Settings. These downloads are shared with cleanup.")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MuesliTheme.textSecondary)
+            ForEach(Gemma4LiteRTModel.allCases) { model in
+                gemmaCleanupModelCard(model, forQuill: true)
+            }
+            ForEach(displayedPostProcessorOptions.filter(\.supportsQuil)) { option in
+                postProcModelCard(option, forQuill: true)
+            }
+        }
+        .padding(.top, MuesliTheme.spacing8)
+    }
+
+    private func selectQuillModel(backend: TranscriptCleanupBackendOption, model: String) {
+        controller.updateConfig {
+            $0.quilBackend = backend.backend
+            $0.quilModel = model
+        }
+        if appState.config.enableQuilMode {
+            _ = controller.ensureQuilModelIsAvailable()
+        }
+    }
+
+    private func gemmaCleanupModelCard(_ model: Gemma4LiteRTModel, forQuill: Bool = false) -> some View {
         let option = BackendOption.gemma4LiteRT(model)
         let isDownloaded = downloadedModels.contains(option.model)
-        let isCompatible = TranscriptCleanupBackendOption.gemma4LiteRT
+        let isCompatible = forQuill || TranscriptCleanupBackendOption.gemma4LiteRT
             .isCompatible(with: appState.selectedBackend)
 
         return modelCard(
             option: option,
             logo: "google-logo",
             isActive: isDownloaded
-                && appState.selectedPostProcessorBackend == .gemma4LiteRT
-                && appState.config.postProcessorGemmaModel == model.repoID,
+                && (forQuill
+                    ? appState.config.quilBackend == TranscriptCleanupBackendOption.gemma4LiteRT.backend && appState.config.quilModel == model.repoID
+                    : appState.selectedPostProcessorBackend == .gemma4LiteRT && appState.config.postProcessorGemmaModel == model.repoID),
             onSetActive: {
-                controller.selectGemma4PostProcessor(model)
+                if forQuill {
+                    selectQuillModel(backend: .gemma4LiteRT, model: model.repoID)
+                } else {
+                    controller.selectGemma4PostProcessor(model)
+                }
             },
-            description: "An experimental local option for filler removal, formatting, and obvious transcript errors. It shares the \(model.label) download with dictation and Quill.",
-            activeLabel: "Cleanup Active",
+            description: forQuill
+                ? "An experimental local model for rewriting and generating text with Quill. Shares its download with dictation and cleanup."
+                : "An experimental local option for filler removal, formatting, and obvious transcript errors. It shares the \(model.label) download with dictation and Quill.",
+            activeLabel: forQuill ? "Quill Selected" : "Cleanup Active",
             downloadedLabel: isCompatible ? "Downloaded" : "Used for Dictation",
-            actionTitle: "Use for Cleanup",
+            actionTitle: forQuill ? "Use for Quill" : "Use for Cleanup",
             activationDisabledReason: isCompatible
                 ? nil
                 : "Unavailable while Gemma 4 is selected for dictation. Choose another dictation model first."
         )
     }
 
-    private func postProcModelCard(_ option: PostProcessorOption) -> some View {
+    private func postProcModelCard(_ option: PostProcessorOption, forQuill: Bool = false) -> some View {
         let isDownloaded = downloadedPostProcModels.contains(option.id)
-        let isActive = appState.activePostProcessor.id == option.id && isDownloaded
+        let isActive = isDownloaded && (forQuill
+            ? appState.config.quilBackend == TranscriptCleanupBackendOption.local.backend && appState.config.quilModel == option.id
+            : appState.activePostProcessor.id == option.id)
         let isDownloading = downloadingPostProcModels.contains(option.id)
         let progress = downloadProgressPostProc[option.id] ?? 0
         let showsDownloadStatus = shouldShowDownloadStatus(for: option.id, isDownloading: isDownloading)
@@ -738,7 +779,7 @@ struct ModelsView: View {
                             .foregroundStyle(MuesliTheme.textTertiary)
                     }
 
-                    Text(option.description)
+                    Text(forQuill ? "A local model for rewriting selected text and generating text at the cursor. Shares its download with cleanup." : option.description)
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }
@@ -746,7 +787,7 @@ struct ModelsView: View {
                 Spacer()
 
                 if isActive {
-                    Text("Active")
+                    Text(forQuill ? "Quill Selected" : "Active")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(MuesliTheme.success)
                         .padding(.horizontal, 8)
@@ -787,8 +828,12 @@ struct ModelsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 } else if isDownloaded {
                     if !isActive {
-                        Button("Set Active") {
-                            controller.selectPostProcessor(option)
+                        Button(forQuill ? "Use for Quill" : "Set Active") {
+                            if forQuill {
+                                selectQuillModel(backend: .local, model: option.id)
+                            } else {
+                                controller.selectPostProcessor(option)
+                            }
                         }
                         .buttonStyle(.plain)
                         .font(.system(size: 12, weight: .medium))
@@ -810,7 +855,7 @@ struct ModelsView: View {
                     .buttonStyle(.plain)
                 } else if option.isDownloadable {
                     Button("Download") {
-                        startPostProcDownload(option)
+                        startPostProcDownload(option, forQuill: forQuill)
                     }
                     .buttonStyle(.plain)
                     .font(.system(size: 12, weight: .medium))
@@ -1522,7 +1567,7 @@ struct ModelsView: View {
 
     // MARK: - Post-Processor Actions
 
-    private func startPostProcDownload(_ option: PostProcessorOption) {
+    private func startPostProcDownload(_ option: PostProcessorOption, forQuill: Bool = false) {
         guard option.isDownloadable else { return }
         withAnimation { _ = downloadingPostProcModels.insert(option.id) }
         downloadProgressPostProc[option.id] = 0.02
@@ -1552,7 +1597,7 @@ struct ModelsView: View {
                         }
                         downloadTasksPostProc.removeValue(forKey: option.id)
                     }
-                    if appState.config.enablePostProcessor && !appState.activePostProcessor.isDownloaded {
+                    if !forQuill && appState.config.enablePostProcessor && !appState.activePostProcessor.isDownloaded {
                         controller.selectPostProcessor(option)
                         controller.preloadExperimentalTranscriptionFeatures()
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -9275,9 +9275,9 @@ public final class MuesliController: NSObject {
             guard let self else { return }
             defer { try? FileManager.default.removeItem(at: wavURL) }
             do {
-                var instruction: String
+                let instruction: String
                 if directAudio {
-                    instruction = ""
+                    instruction = "Audio instruction"
                     await MainActor.run {
                         guard self.quilTaskID == taskID else { return }
                         self.indicator.setTranscribingTitle("Applying audio instruction", config: self.config)
@@ -9297,13 +9297,12 @@ public final class MuesliController: NSObject {
                         appContext: nil
                     )
                     try Task.checkCancellation()
-                    let recognizedInstruction = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !recognizedInstruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
-                    instruction = recognizedInstruction
+                    instruction = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !instruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
                     await MainActor.run {
                         guard self.quilTaskID == taskID else { return }
                         self.statusBarController?.setStatus("Rewriting selection")
-                        self.indicator.showQuilInstruction(recognizedInstruction, config: self.config)
+                        self.indicator.showQuilInstruction(instruction, config: self.config)
                     }
                 }
                 let capturedContext: DictationContext?
@@ -9322,15 +9321,9 @@ public final class MuesliController: NSObject {
                 let promptContext = capturedContext.map { DictationContextCapture.formatForPrompt($0) }
                 let replacement: String
                 if directAudio {
-                    let result = try await self.transcriptionCoordinator.transformAudioForQuil(
+                    replacement = try await self.transcriptionCoordinator.transformAudioForQuil(
                         wavURL: wavURL, selectedText: snapshot.text, appContext: promptContext, model: model
                     )
-                    instruction = result.instruction
-                    replacement = result.replacement
-                    await MainActor.run {
-                        guard self.quilTaskID == taskID else { return }
-                        self.indicator.showQuilInstruction(result.instruction, config: self.config)
-                    }
                 } else {
                     replacement = try await self.transcriptionCoordinator.transformSelectedTextForQuil(
                         selectedText: snapshot.text,
@@ -9348,14 +9341,13 @@ public final class MuesliController: NSObject {
                 guard selectionStillCurrent else {
                     throw QuilTransformationError.selectionChanged
                 }
-                let completedInstruction = instruction
                 await MainActor.run {
                     guard self.quilTaskID == taskID else { return }
                     guard replacement != snapshot.text else {
                         let saved = self.persistQuilTransformation(
                             outputText: replacement,
                             originalText: snapshot.text,
-                            instruction: completedInstruction,
+                            instruction: instruction,
                             backend: backend,
                             model: model,
                             duration: duration,
@@ -9364,8 +9356,7 @@ public final class MuesliController: NSObject {
                         )
                         self.finishQuilTask(
                             taskID: taskID,
-                            message: saved ? "No changes needed" : "No changes needed; Quill history was not saved",
-                            completedInstruction: directAudio && saved ? completedInstruction : nil
+                            message: saved ? "No changes needed" : "No changes needed; Quill history was not saved"
                         )
                         return
                     }
@@ -9419,7 +9410,7 @@ public final class MuesliController: NSObject {
                             let saved = self.persistQuilTransformation(
                                 outputText: replacement,
                                 originalText: snapshot.text,
-                                instruction: completedInstruction,
+                                instruction: instruction,
                                 backend: backend,
                                 model: model,
                                 duration: duration,
@@ -9437,8 +9428,7 @@ public final class MuesliController: NSObject {
                                 ])
                                 self.finishQuilTask(
                                     taskID: taskID,
-                                    message: saved ? nil : "Reformatted, but could not save Quill history",
-                                    completedInstruction: directAudio && saved ? completedInstruction : nil
+                                    message: saved ? nil : "Reformatted, but could not save Quill history"
                                 )
                             } else {
                                 TelemetryDeck.signal("quil.paste_fallback", parameters: [
@@ -9547,15 +9537,11 @@ public final class MuesliController: NSObject {
     }
 
     @MainActor
-    private func finishQuilTask(taskID: UUID, message: String?, completedInstruction: String? = nil) {
+    private func finishQuilTask(taskID: UUID, message: String?) {
         guard quilTaskID == taskID else { return }
         clearQuilSession()
+        if let message { indicator.showWarning(message, icon: "", duration: 2.0) }
         resumeAfterQuil()
-        if let completedInstruction {
-            indicator.showCompletedQuilInstruction(completedInstruction, config: config)
-        } else if let message {
-            indicator.showWarning(message, icon: "", duration: 2.0)
-        }
     }
 
     @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -9275,9 +9275,9 @@ public final class MuesliController: NSObject {
             guard let self else { return }
             defer { try? FileManager.default.removeItem(at: wavURL) }
             do {
-                let instruction: String
+                var instruction: String
                 if directAudio {
-                    instruction = "Audio instruction"
+                    instruction = ""
                     await MainActor.run {
                         guard self.quilTaskID == taskID else { return }
                         self.indicator.setTranscribingTitle("Applying audio instruction", config: self.config)
@@ -9297,12 +9297,13 @@ public final class MuesliController: NSObject {
                         appContext: nil
                     )
                     try Task.checkCancellation()
-                    instruction = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !instruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
+                    let recognizedInstruction = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !recognizedInstruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
+                    instruction = recognizedInstruction
                     await MainActor.run {
                         guard self.quilTaskID == taskID else { return }
                         self.statusBarController?.setStatus("Rewriting selection")
-                        self.indicator.showQuilInstruction(instruction, config: self.config)
+                        self.indicator.showQuilInstruction(recognizedInstruction, config: self.config)
                     }
                 }
                 let capturedContext: DictationContext?
@@ -9321,9 +9322,15 @@ public final class MuesliController: NSObject {
                 let promptContext = capturedContext.map { DictationContextCapture.formatForPrompt($0) }
                 let replacement: String
                 if directAudio {
-                    replacement = try await self.transcriptionCoordinator.transformAudioForQuil(
+                    let result = try await self.transcriptionCoordinator.transformAudioForQuil(
                         wavURL: wavURL, selectedText: snapshot.text, appContext: promptContext, model: model
                     )
+                    instruction = result.instruction
+                    replacement = result.replacement
+                    await MainActor.run {
+                        guard self.quilTaskID == taskID else { return }
+                        self.indicator.showQuilInstruction(result.instruction, config: self.config)
+                    }
                 } else {
                     replacement = try await self.transcriptionCoordinator.transformSelectedTextForQuil(
                         selectedText: snapshot.text,
@@ -9341,13 +9348,14 @@ public final class MuesliController: NSObject {
                 guard selectionStillCurrent else {
                     throw QuilTransformationError.selectionChanged
                 }
+                let completedInstruction = instruction
                 await MainActor.run {
                     guard self.quilTaskID == taskID else { return }
                     guard replacement != snapshot.text else {
                         let saved = self.persistQuilTransformation(
                             outputText: replacement,
                             originalText: snapshot.text,
-                            instruction: instruction,
+                            instruction: completedInstruction,
                             backend: backend,
                             model: model,
                             duration: duration,
@@ -9356,7 +9364,8 @@ public final class MuesliController: NSObject {
                         )
                         self.finishQuilTask(
                             taskID: taskID,
-                            message: saved ? "No changes needed" : "No changes needed; Quill history was not saved"
+                            message: saved ? "No changes needed" : "No changes needed; Quill history was not saved",
+                            completedInstruction: directAudio && saved ? completedInstruction : nil
                         )
                         return
                     }
@@ -9410,7 +9419,7 @@ public final class MuesliController: NSObject {
                             let saved = self.persistQuilTransformation(
                                 outputText: replacement,
                                 originalText: snapshot.text,
-                                instruction: instruction,
+                                instruction: completedInstruction,
                                 backend: backend,
                                 model: model,
                                 duration: duration,
@@ -9428,7 +9437,8 @@ public final class MuesliController: NSObject {
                                 ])
                                 self.finishQuilTask(
                                     taskID: taskID,
-                                    message: saved ? nil : "Reformatted, but could not save Quill history"
+                                    message: saved ? nil : "Reformatted, but could not save Quill history",
+                                    completedInstruction: directAudio && saved ? completedInstruction : nil
                                 )
                             } else {
                                 TelemetryDeck.signal("quil.paste_fallback", parameters: [
@@ -9537,11 +9547,15 @@ public final class MuesliController: NSObject {
     }
 
     @MainActor
-    private func finishQuilTask(taskID: UUID, message: String?) {
+    private func finishQuilTask(taskID: UUID, message: String?, completedInstruction: String? = nil) {
         guard quilTaskID == taskID else { return }
         clearQuilSession()
-        if let message { indicator.showWarning(message, icon: "", duration: 2.0) }
         resumeAfterQuil()
+        if let completedInstruction {
+            indicator.showCompletedQuilInstruction(completedInstruction, config: config)
+        } else if let message {
+            indicator.showWarning(message, icon: "", duration: 2.0)
+        }
     }
 
     @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -9267,32 +9267,43 @@ public final class MuesliController: NSObject {
                 ? PostProcessorOption.defaultQuilOption.id
                 : TranscriptCleanupClient.defaultModel(for: backend))
             : configuredModel
+        let dictationBackend = selectedBackend
+        let directAudio = QuilModelPolicy.usesDirectAudio(dictation: dictationBackend, backend: backend, model: model)
         let configSnapshot = config
         let contextCaptureTask = quilContextCaptureTask
         quilTask = Task { [weak self] in
             guard let self else { return }
             defer { try? FileManager.default.removeItem(at: wavURL) }
             do {
-                let result = try await self.transcriptionCoordinator.transcribeDictation(
-                    at: wavURL,
-                    backend: self.selectedBackend,
-                    cohereLanguage: configSnapshot.resolvedCohereLanguage,
-                    bodhanLanguage: configSnapshot.resolvedBodhanLanguage,
-                    whisperLanguage: configSnapshot.resolvedWhisperLanguage,
-                    qwen3AsrLanguage: configSnapshot.resolvedQwen3AsrLanguage,
-                    parakeetLanguage: configSnapshot.resolvedParakeetLanguage,
-                    appleSpeechLanguage: configSnapshot.resolvedAppleSpeechLanguage,
-                    enablePostProcessor: false,
-                    customWords: self.serializedCustomWords(),
-                    appContext: nil
-                )
-                try Task.checkCancellation()
-                let instruction = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !instruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
-                await MainActor.run {
-                    guard self.quilTaskID == taskID else { return }
-                    self.statusBarController?.setStatus("Rewriting selection")
-                    self.indicator.showQuilInstruction(instruction, config: self.config)
+                let instruction: String
+                if directAudio {
+                    instruction = "Audio instruction"
+                    await MainActor.run {
+                        guard self.quilTaskID == taskID else { return }
+                        self.indicator.setTranscribingTitle("Applying audio instruction", config: self.config)
+                    }
+                } else {
+                    let result = try await self.transcriptionCoordinator.transcribeDictation(
+                        at: wavURL,
+                        backend: dictationBackend,
+                        cohereLanguage: configSnapshot.resolvedCohereLanguage,
+                        bodhanLanguage: configSnapshot.resolvedBodhanLanguage,
+                        whisperLanguage: configSnapshot.resolvedWhisperLanguage,
+                        qwen3AsrLanguage: configSnapshot.resolvedQwen3AsrLanguage,
+                        parakeetLanguage: configSnapshot.resolvedParakeetLanguage,
+                        appleSpeechLanguage: configSnapshot.resolvedAppleSpeechLanguage,
+                        enablePostProcessor: false,
+                        customWords: self.serializedCustomWords(),
+                        appContext: nil
+                    )
+                    try Task.checkCancellation()
+                    instruction = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !instruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
+                    await MainActor.run {
+                        guard self.quilTaskID == taskID else { return }
+                        self.statusBarController?.setStatus("Rewriting selection")
+                        self.indicator.showQuilInstruction(instruction, config: self.config)
+                    }
                 }
                 let capturedContext: DictationContext?
                 if let contextCaptureTask {
@@ -9308,14 +9319,21 @@ public final class MuesliController: NSObject {
                     throw QuilTransformationError.selectionChanged
                 }
                 let promptContext = capturedContext.map { DictationContextCapture.formatForPrompt($0) }
-                let replacement = try await self.transcriptionCoordinator.transformSelectedTextForQuil(
-                    selectedText: snapshot.text,
-                    instruction: instruction,
-                    appContext: promptContext,
-                    backend: backend,
-                    model: model,
-                    config: configSnapshot
-                )
+                let replacement: String
+                if directAudio {
+                    replacement = try await self.transcriptionCoordinator.transformAudioForQuil(
+                        wavURL: wavURL, selectedText: snapshot.text, appContext: promptContext, model: model
+                    )
+                } else {
+                    replacement = try await self.transcriptionCoordinator.transformSelectedTextForQuil(
+                        selectedText: snapshot.text,
+                        instruction: instruction,
+                        appContext: promptContext,
+                        backend: backend,
+                        model: model,
+                        config: configSnapshot
+                    )
+                }
                 try Task.checkCancellation()
                 let selectionStillCurrent = await MainActor.run {
                     snapshot.isStillCurrentForReplacement()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3221,7 +3221,8 @@ public final class MuesliController: NSObject {
         }
     }
 
-    func ensureQuilModelIsAvailable() -> Bool {
+    func ensureQuilModelIsAvailable(forEnablement: Bool = false) -> Bool {
+        guard forEnablement || config.enableQuilMode else { return false }
         let backend = TranscriptCleanupBackendOption.resolved(config.quilBackend)
         let available: Bool
         switch backend {
@@ -3234,15 +3235,57 @@ public final class MuesliController: NSObject {
                 model: Gemma4LiteRTModel.resolved(config.quilModel)
             )
         default:
-            return true
+            available = !config.quilModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && TranscriptCleanupClient.hasRequiredSettings(
+                    for: backend, config: config,
+                    isChatGPTAuthenticated: chatGPTAuth.isAuthenticated,
+                    modelOverride: config.quilModel
+                )
         }
-        guard available else {
-            updateConfig { $0.enableQuilMode = false }
-            configureQuilHotkeyMonitor()
-            presentLocalModelSetupPrompt(forQuill: true)
-            return false
+        return QuilAvailabilityGate.allow(
+            isEnabled: forEnablement || config.enableQuilMode,
+            isAvailable: { available },
+            onUnavailable: {
+                updateConfig { $0.enableQuilMode = false }
+                configureQuilHotkeyMonitor()
+                if backend.isOnDevice {
+                    presentLocalModelSetupPrompt(forQuill: true)
+                } else {
+                    presentQuilAccountSetupPrompt(backend: backend)
+                }
+            }
+        )
+    }
+
+    private func presentQuilAccountSetupPrompt(backend: TranscriptCleanupBackendOption) {
+        let needsChatGPTSignIn = backend == .hosted(.chatGPT) && !chatGPTAuth.isAuthenticated
+        let needsOpenRouterSignIn = backend == .hosted(.openRouter)
+            && TranscriptCleanupClient.resolvedOpenRouterAPIKey(config: config).isEmpty
+        let action = needsChatGPTSignIn ? "Sign in with ChatGPT"
+            : needsOpenRouterSignIn ? "Connect OpenRouter" : "Open Quill Settings"
+        let alert = NSAlert()
+        alert.messageText = "Set up \(backend.label) for Quill"
+        alert.informativeText = needsChatGPTSignIn
+            ? "Sign in with ChatGPT before enabling Quill. After signing in, enable Quill again."
+            : needsOpenRouterSignIn
+                ? "Connect OpenRouter before enabling Quill. After connecting, enable Quill again."
+                : "Complete the model and connection settings for \(backend.label) before enabling Quill."
+        alert.addButton(withTitle: action)
+        alert.addButton(withTitle: "Cancel")
+        presentAlert(alert, fallbackLogContext: "Quill account setup") { [weak self] response in
+            guard response == .alertFirstButtonReturn, let self else { return }
+            self.appState.selectedSettingsPane = .dictation
+            self.openSettingsTab()
+            guard needsChatGPTSignIn || needsOpenRouterSignIn else { return }
+            Task { @MainActor in
+                let error = needsChatGPTSignIn
+                    ? await self.signInWithChatGPT(selectMeetingSummaryBackend: false)
+                    : await self.signInWithOpenRouter(selectMeetingSummaryBackend: false)
+                if let error {
+                    self.presentErrorAlert(title: "Quill connection failed", message: error)
+                }
+            }
         }
-        return true
     }
 
     func preloadExperimentalTranscriptionFeatures() {
@@ -4604,8 +4647,8 @@ public final class MuesliController: NSObject {
             guard result.didUpdate else { return result }
             validationResult = result
         }
-        if enabled, !ensureQuilModelIsAvailable() {
-            return .unavailable(message: "Choose and download a local model before enabling Quill.")
+        if enabled, !ensureQuilModelIsAvailable(forEnablement: true) {
+            return .unavailable(message: "Complete Quill setup before enabling it.")
         }
         updateConfig { $0.enableQuilMode = enabled }
         configureQuilHotkeyMonitor()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3190,6 +3190,7 @@ public final class MuesliController: NSObject {
             guard let option = normalizePostProcessorSelectionForAvailability(),
                   option.isCompatible(with: selectedBackend) else {
                 updateConfig { $0.enablePostProcessor = false }
+                presentLocalModelSetupPrompt(forQuill: false)
                 return
             }
         }
@@ -3198,11 +3199,50 @@ public final class MuesliController: NSObject {
                model: Gemma4LiteRTModel.resolved(config.postProcessorGemmaModel)
            ) {
             updateConfig { $0.enablePostProcessor = false }
-            showModels(category: .postProcessing)
+            presentLocalModelSetupPrompt(forQuill: false)
             return
         }
         updateConfig { $0.enablePostProcessor = enabled }
         preloadExperimentalTranscriptionFeatures()
+    }
+
+    private func presentLocalModelSetupPrompt(forQuill: Bool) {
+        let feature = forQuill ? "Quill" : "Local cleanup"
+        let alert = NSAlert()
+        alert.messageText = "\(feature) needs a model"
+        alert.informativeText = forQuill
+            ? "Choose a Quill-compatible model in Models and download it if needed. Then select it in Quill settings and enable Quill again. Download sizes and progress are shown in Models."
+            : "Choose a compatible cleanup model in Models and download it if needed. Then return to Settings and enable AI transcript cleanup. Download sizes and progress are shown in Models."
+        alert.addButton(withTitle: "Choose Model…")
+        alert.addButton(withTitle: "Cancel")
+        presentAlert(alert, fallbackLogContext: "local model setup") { [weak self] response in
+            guard response == .alertFirstButtonReturn else { return }
+            self?.showModels(category: .postProcessing)
+        }
+    }
+
+    func ensureQuilModelIsAvailable() -> Bool {
+        let backend = TranscriptCleanupBackendOption.resolved(config.quilBackend)
+        let available: Bool
+        switch backend {
+        case .local:
+            let model = PostProcessorOption.resolve(id: config.quilModel)
+            available = model.supportsQuil
+                && (model.isDownloaded || Qwen3PostProcessorConfig.devOverrideURL() != nil)
+        case .gemma4LiteRT:
+            available = Gemma4LiteRTModelStore.isAvailableLocally(
+                model: Gemma4LiteRTModel.resolved(config.quilModel)
+            )
+        default:
+            return true
+        }
+        guard available else {
+            updateConfig { $0.enableQuilMode = false }
+            configureQuilHotkeyMonitor()
+            presentLocalModelSetupPrompt(forQuill: true)
+            return false
+        }
+        return true
     }
 
     func preloadExperimentalTranscriptionFeatures() {
@@ -3254,7 +3294,7 @@ public final class MuesliController: NSObject {
         if option == .local, config.enablePostProcessor {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
-                showModels(category: .postProcessing)
+                presentLocalModelSetupPrompt(forQuill: false)
                 return
             }
         }
@@ -3263,7 +3303,7 @@ public final class MuesliController: NSObject {
                model: Gemma4LiteRTModel.resolved(config.postProcessorGemmaModel)
            ) {
             updateConfig { $0.enablePostProcessor = false }
-            showModels(category: .postProcessing)
+            presentLocalModelSetupPrompt(forQuill: false)
             return
         }
         preloadExperimentalTranscriptionFeatures()
@@ -3286,7 +3326,7 @@ public final class MuesliController: NSObject {
         if config.enablePostProcessor,
            !Gemma4LiteRTModelStore.isAvailableLocally(model: model) {
             updateConfig { $0.enablePostProcessor = false }
-            showModels(category: .postProcessing)
+            presentLocalModelSetupPrompt(forQuill: false)
             return
         }
         preloadExperimentalTranscriptionFeatures()
@@ -4563,6 +4603,9 @@ public final class MuesliController: NSObject {
             )
             guard result.didUpdate else { return result }
             validationResult = result
+        }
+        if enabled, !ensureQuilModelIsAvailable() {
+            return .unavailable(message: "Choose and download a local model before enabling Quill.")
         }
         updateConfig { $0.enableQuilMode = enabled }
         configureQuilHotkeyMonitor()
@@ -9071,6 +9114,7 @@ public final class MuesliController: NSObject {
 
     private func handleQuilPrepare() {
         guard canPrepareQuil else { return }
+        guard ensureQuilModelIsAvailable() else { return }
         quilSelectionSnapshot = nil
         quilTargetCaptureError = nil
         meetingMonitor.suppressWhileActive()
@@ -9111,6 +9155,10 @@ public final class MuesliController: NSObject {
 
     private func handleQuilToggleStart() {
         guard canStartQuil else {
+            quilHotkeyMonitor.cancelToggleMode()
+            return
+        }
+        guard ensureQuilModelIsAvailable() else {
             quilHotkeyMonitor.cancelToggleMode()
             return
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3211,13 +3211,13 @@ public final class MuesliController: NSObject {
         let alert = NSAlert()
         alert.messageText = "\(feature) needs a model"
         alert.informativeText = forQuill
-            ? "Choose a Quill-compatible model in Models and download it if needed. Then select it in Quill settings and enable Quill again. Download sizes and progress are shown in Models."
+            ? "Choose a Quill-compatible model in Models and download it if needed. Then choose Use for Quill and enable Quill in Settings. Download sizes and progress are shown in Models."
             : "Choose a compatible cleanup model in Models and download it if needed. Then return to Settings and enable AI transcript cleanup. Download sizes and progress are shown in Models."
         alert.addButton(withTitle: "Choose Model…")
         alert.addButton(withTitle: "Cancel")
         presentAlert(alert, fallbackLogContext: "local model setup") { [weak self] response in
             guard response == .alertFirstButtonReturn else { return }
-            self?.showModels(category: .postProcessing)
+            self?.showModels(category: forQuill ? .quill : .postProcessing)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
@@ -154,3 +154,19 @@ enum QuilModelPolicy {
         guard selectedText.count <= limit else { throw QuilTransformationError.selectionTooLong(limit) }
     }
 }
+
+/// Checks readiness before enablement or recording, ignoring callbacks after Quill is disabled.
+enum QuilAvailabilityGate {
+    static func allow(
+        isEnabled: Bool,
+        isAvailable: () -> Bool,
+        onUnavailable: () -> Void
+    ) -> Bool {
+        guard isEnabled else { return false }
+        guard isAvailable() else {
+            onUnavailable()
+            return false
+        }
+        return true
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
@@ -39,6 +39,10 @@ enum QuilTransformationError: LocalizedError, Equatable {
 }
 
 enum QuilTransformationPrompt {
+    static var audioSystem: String {
+        system + "\nThe attached audio contains the spoken instruction. Understand that instruction and carry it out directly. Do not return a transcript of the audio or describe the instruction. Return only the requested final text."
+    }
+
     static let system = """
     You primarily rewrite highlighted text according to spoken instructions. When highlighted text is supplied, transform it according to the spoken instruction. When no highlighted text is supplied, create the content requested by the spoken instruction for insertion at the cursor.
 
@@ -133,6 +137,13 @@ enum QuilTransformationOutput {
 }
 
 enum QuilModelPolicy {
+    static func usesDirectAudio(dictation: BackendOption, backend: TranscriptCleanupBackendOption, model: String) -> Bool {
+        backend == .gemma4LiteRT
+            && dictation.backend == BackendOption.gemma4E2BLiteRT.backend
+            && dictation.model == model
+            && Gemma4LiteRTModel.allCases.contains { $0.repoID == model }
+    }
+
     static let localMaximumInputCharacters = 2_500
     static let remoteMaximumInputCharacters = 20_000
     static let localAppContextCharacterLimit = 1_200

--- a/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
@@ -40,16 +40,7 @@ enum QuilTransformationError: LocalizedError, Equatable {
 
 enum QuilTransformationPrompt {
     static var audioSystem: String {
-        let rules = system.components(separatedBy: "Your entire response is pasted")[0]
-        return rules + """
-        The attached audio contains the spoken instruction. Return exactly one JSON object with two string fields, in this order: "instruction" and "replacement". The instruction field must faithfully transcribe the spoken command, not the highlighted text. The replacement field must contain only the final paste-ready text produced by following that command. Never put explanations, alternatives, or labels in replacement. Do not wrap the JSON in Markdown fences or add commentary.
-        """
-    }
-
-    static func audioUserPrompt(selectedText: String, appContext: String?) -> String {
-        let prompt = userPrompt(selectedText: selectedText, instruction: "Use the command spoken in the attached audio.", appContext: appContext)
-        return prompt.components(separatedBy: "\nReturn exactly one final paste-ready output")[0]
-            + "\nReturn the instruction and replacement JSON object specified in the system prompt."
+        system + "\nThe attached audio contains the spoken instruction. Understand that instruction and carry it out directly. Do not return a transcript of the audio or describe the instruction. Return only the requested final text."
     }
 
     static let system = """
@@ -188,24 +179,5 @@ enum QuilAvailabilityGate {
             return false
         }
         return true
-    }
-}
-
-/// One audio generation returns the command for display separately from the text to paste.
-struct QuilAudioResult: Decodable, Equatable {
-    let instruction: String
-    let replacement: String
-
-    static func validated(_ raw: String) throws -> QuilAudioResult {
-        guard let data = raw.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode(QuilAudioResult.self, from: data) else {
-            throw QuilTransformationError.nonReplacementResponse
-        }
-        let instruction = decoded.instruction.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !instruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
-        guard instruction.count <= QuilModelPolicy.remoteMaximumInputCharacters else {
-            throw QuilTransformationError.nonReplacementResponse
-        }
-        return QuilAudioResult(instruction: instruction, replacement: try QuilTransformationOutput.validated(decoded.replacement))
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/QuilTransformation.swift
@@ -40,7 +40,16 @@ enum QuilTransformationError: LocalizedError, Equatable {
 
 enum QuilTransformationPrompt {
     static var audioSystem: String {
-        system + "\nThe attached audio contains the spoken instruction. Understand that instruction and carry it out directly. Do not return a transcript of the audio or describe the instruction. Return only the requested final text."
+        let rules = system.components(separatedBy: "Your entire response is pasted")[0]
+        return rules + """
+        The attached audio contains the spoken instruction. Return exactly one JSON object with two string fields, in this order: "instruction" and "replacement". The instruction field must faithfully transcribe the spoken command, not the highlighted text. The replacement field must contain only the final paste-ready text produced by following that command. Never put explanations, alternatives, or labels in replacement. Do not wrap the JSON in Markdown fences or add commentary.
+        """
+    }
+
+    static func audioUserPrompt(selectedText: String, appContext: String?) -> String {
+        let prompt = userPrompt(selectedText: selectedText, instruction: "Use the command spoken in the attached audio.", appContext: appContext)
+        return prompt.components(separatedBy: "\nReturn exactly one final paste-ready output")[0]
+            + "\nReturn the instruction and replacement JSON object specified in the system prompt."
     }
 
     static let system = """
@@ -179,5 +188,24 @@ enum QuilAvailabilityGate {
             return false
         }
         return true
+    }
+}
+
+/// One audio generation returns the command for display separately from the text to paste.
+struct QuilAudioResult: Decodable, Equatable {
+    let instruction: String
+    let replacement: String
+
+    static func validated(_ raw: String) throws -> QuilAudioResult {
+        guard let data = raw.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(QuilAudioResult.self, from: data) else {
+            throw QuilTransformationError.nonReplacementResponse
+        }
+        let instruction = decoded.instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !instruction.isEmpty else { throw QuilTransformationError.emptyInstruction }
+        guard instruction.count <= QuilModelPolicy.remoteMaximumInputCharacters else {
+            throw QuilTransformationError.nonReplacementResponse
+        }
+        return QuilAudioResult(instruction: instruction, replacement: try QuilTransformationOutput.validated(decoded.replacement))
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1403,7 +1403,7 @@ struct SettingsView: View {
                     .foregroundStyle(MuesliTheme.transcribing)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            if appState.config.enableQuilMode {
+            Group {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(
                     "Play Quill sounds",
@@ -1468,6 +1468,9 @@ struct SettingsView: View {
             let resolved = model ?? .gguf(PostProcessorOption.defaultQuilOption)
             $0.quilBackend = resolved.quilBackend.backend
             $0.quilModel = resolved.quilModelID
+        }
+        if appState.config.enableQuilMode {
+            _ = controller.ensureQuilModelIsAvailable()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1439,7 +1439,7 @@ struct SettingsView: View {
                     settingsRow("Quill model", controlWidth: meetingControlWidth) {
                         if quilLocalModels.isEmpty {
                             compactActionButton("View local models", systemImage: "arrow.right") {
-                                controller.showModels(category: .postProcessing)
+                                controller.showModels(category: .quill)
                             }
                             .frame(width: meetingControlWidth, alignment: .trailing)
                         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
@@ -3,12 +3,13 @@ import AppKit
 enum ShortcutHotkeyUpdateResult: Equatable {
     case updated(notice: String?)
     case conflict(message: String)
+    case unavailable(message: String)
 
     var message: String? {
         switch self {
         case .updated(let notice):
             return notice
-        case .conflict(let message):
+        case .conflict(let message), .unavailable(let message):
             return message
         }
     }
@@ -17,7 +18,7 @@ enum ShortcutHotkeyUpdateResult: Equatable {
         switch self {
         case .updated:
             return true
-        case .conflict:
+        case .conflict, .unavailable:
             return false
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -83,7 +83,7 @@ enum TranscriptCleanupClient {
         return trimmed.isEmpty ? defaultModel(for: backend) : trimmed
     }
 
-    static func hasRequiredSettings(for backend: TranscriptCleanupBackendOption, config: AppConfig, isChatGPTAuthenticated: Bool) -> Bool {
+    static func hasRequiredSettings(for backend: TranscriptCleanupBackendOption, config: AppConfig, isChatGPTAuthenticated: Bool, modelOverride: String? = nil) -> Bool {
         if backend == .gemma4LiteRT {
             let model = Gemma4LiteRTModel.resolved(config.postProcessorGemmaModel)
             return Gemma4LiteRTModelStore.isAvailableLocally(model: model)
@@ -99,11 +99,11 @@ enum TranscriptCleanupClient {
         case .some(.ollama):
             return resolveConfiguredOllamaURL(config: config) != nil
         case .some(.lmStudio):
-            let model = configuredModel(for: backend, config: config)
+            let model = modelOverride ?? configuredModel(for: backend, config: config)
             return !model.isEmpty
                 && MeetingSummaryClient.resolveLMStudioURL(config: cleanupConfig(config, model: model)) != nil
         case .some(.customLLM):
-            let model = configuredModel(for: backend, config: config)
+            let model = modelOverride ?? configuredModel(for: backend, config: config)
             let format = CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI
             let key = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
             return !model.isEmpty

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -320,6 +320,30 @@ actor TranscriptionCoordinator {
         }
     }
 
+    func transformAudioForQuil(
+        wavURL: URL, selectedText: String, appContext: String?, model: String
+    ) async throws -> String {
+        guard #available(macOS 15, *) else { throw QuilTransformationError.unsupportedModel }
+        let gemmaModel = Gemma4LiteRTModel.resolved(model)
+        guard Gemma4LiteRTModelStore.isAvailableLocally(model: gemmaModel) else {
+            throw QuilTransformationError.modelUnavailable
+        }
+        try QuilModelPolicy.validate(selectedText: selectedText, backend: .gemma4LiteRT, model: model)
+        let prompt = QuilTransformationPrompt.userPrompt(
+            selectedText: selectedText,
+            instruction: "Carry out the spoken instruction in the attached audio.",
+            appContext: appContext
+        )
+        let raw = try await gemma4LiteRTTranscriber.generateFromAudio(
+            wavURL: wavURL, systemPrompt: QuilTransformationPrompt.audioSystem,
+            userPrompt: prompt, model: gemmaModel,
+            maxOutputTokens: QuilModelPolicy.gemmaMaximumOutputTokens
+        )
+        try Task.checkCancellation()
+        // Do not run an ASR fallback or corrective second generation on this path.
+        return try QuilTransformationOutput.validated(raw)
+    }
+
     func transformSelectedTextForQuil(
         selectedText: String,
         instruction: String,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -322,15 +322,16 @@ actor TranscriptionCoordinator {
 
     func transformAudioForQuil(
         wavURL: URL, selectedText: String, appContext: String?, model: String
-    ) async throws -> QuilAudioResult {
+    ) async throws -> String {
         guard #available(macOS 15, *) else { throw QuilTransformationError.unsupportedModel }
         let gemmaModel = Gemma4LiteRTModel.resolved(model)
         guard Gemma4LiteRTModelStore.isAvailableLocally(model: gemmaModel) else {
             throw QuilTransformationError.modelUnavailable
         }
         try QuilModelPolicy.validate(selectedText: selectedText, backend: .gemma4LiteRT, model: model)
-        let prompt = QuilTransformationPrompt.audioUserPrompt(
+        let prompt = QuilTransformationPrompt.userPrompt(
             selectedText: selectedText,
+            instruction: "Carry out the spoken instruction in the attached audio.",
             appContext: appContext
         )
         let raw = try await gemma4LiteRTTranscriber.generateFromAudio(
@@ -340,7 +341,7 @@ actor TranscriptionCoordinator {
         )
         try Task.checkCancellation()
         // Do not run an ASR fallback or corrective second generation on this path.
-        return try QuilAudioResult.validated(raw)
+        return try QuilTransformationOutput.validated(raw)
     }
 
     func transformSelectedTextForQuil(

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -322,16 +322,15 @@ actor TranscriptionCoordinator {
 
     func transformAudioForQuil(
         wavURL: URL, selectedText: String, appContext: String?, model: String
-    ) async throws -> String {
+    ) async throws -> QuilAudioResult {
         guard #available(macOS 15, *) else { throw QuilTransformationError.unsupportedModel }
         let gemmaModel = Gemma4LiteRTModel.resolved(model)
         guard Gemma4LiteRTModelStore.isAvailableLocally(model: gemmaModel) else {
             throw QuilTransformationError.modelUnavailable
         }
         try QuilModelPolicy.validate(selectedText: selectedText, backend: .gemma4LiteRT, model: model)
-        let prompt = QuilTransformationPrompt.userPrompt(
+        let prompt = QuilTransformationPrompt.audioUserPrompt(
             selectedText: selectedText,
-            instruction: "Carry out the spoken instruction in the attached audio.",
             appContext: appContext
         )
         let raw = try await gemma4LiteRTTranscriber.generateFromAudio(
@@ -341,7 +340,7 @@ actor TranscriptionCoordinator {
         )
         try Task.checkCancellation()
         // Do not run an ASR fallback or corrective second generation on this path.
-        return try QuilTransformationOutput.validated(raw)
+        return try QuilAudioResult.validated(raw)
     }
 
     func transformSelectedTextForQuil(

--- a/native/MuesliNative/Tests/MuesliTests/ChatGPTCodexTransportTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ChatGPTCodexTransportTests.swift
@@ -4,6 +4,33 @@ import Testing
 
 @Suite("ChatGPT Responses transport")
 struct ChatGPTResponsesTransportTests {
+    @Test("Quill token limits are omitted from Codex requests but retained for WHAM")
+    func quillTokenLimitRespectsTransport() throws {
+        let body = ChatGPTResponsesClient.requestBody(
+            systemPrompt: "Rewrite the selected text",
+            userPrompt: "Make this concise",
+            model: "gpt-5.6-sol",
+            maxOutputTokens: QuilModelPolicy.remoteMaximumOutputTokens
+        )
+        for backend in ["codex", "wham"] {
+            let request = try ChatGPTResponsesTransport.makeRequest(
+                body: body,
+                token: "test-token",
+                accountId: "test-account",
+                environment: [ChatGPTResponsesTransport.environmentKey: backend]
+            )
+            let data = try #require(request.httpBody)
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            if backend == "codex" {
+                #expect(json["max_output_tokens"] == nil)
+            } else {
+                #expect(json["max_output_tokens"] as? Int == QuilModelPolicy.remoteMaximumOutputTokens)
+            }
+            #expect(json["instructions"] as? String == "Rewrite the selected text")
+            #expect(json["stream"] as? Bool == true)
+        }
+    }
+
     @Test("builds Codex Responses requests with honest Muesli identity")
     func buildsCodexRequest() throws {
         let sessionID = UUID(uuidString: "8AF070D8-956D-4706-9FF8-8140CE7F6B2D")!

--- a/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
@@ -315,35 +315,10 @@ struct QuilDirectAudioTests {
         #expect(content.count == 2)
         #expect(content[0]["text"] == prompt)
         #expect(content[1] == ["type": "audio", "path": url.path])
-        #expect(QuilTransformationPrompt.audioSystem.contains("Follow only the spoken instruction"))
-        #expect(QuilTransformationPrompt.audioSystem.contains("faithfully transcribe the spoken command"))
+        #expect(QuilTransformationPrompt.audioSystem.contains(QuilTransformationPrompt.system))
+        #expect(QuilTransformationPrompt.audioSystem.contains("Do not return a transcript"))
         let textOnly = try Gemma4LiteRTTranscriber.generationMessageJSONString(userPrompt: "Text request", audioURL: nil)
         let textJSON = try #require(JSONSerialization.jsonObject(with: Data(textOnly.utf8)) as? [String: Any])
         #expect((textJSON["content"] as? [[String: String]])?.count == 1)
-    }
-}
-
-@Suite("Quill audio response")
-struct QuilAudioResponseTests {
-    @Test("preserves the spoken question separately from the paste payload")
-    func separatesInstructionAndReplacement() throws {
-        let result = try QuilAudioResult.validated(#"{"instruction":"  Can you make this shorter?  ","replacement":"Short version."}"#)
-        #expect(result.instruction == "Can you make this shorter?")
-        #expect(result.replacement == "Short version.")
-    }
-
-    @Test("malformed responses cannot paste an envelope or lose the question")
-    func rejectsMalformedResponses() {
-        for raw in ["Plain text", #"{"replacement":"Text"}"#, #"{"instruction":"","replacement":"Text"}"#, #"{"instruction":"Rewrite","replacement":""}"#] {
-            #expect(throws: (any Error).self) { try QuilAudioResult.validated(raw) }
-        }
-    }
-
-    @Test("audio prompt requests structured output without conflicting paste-only instructions")
-    func audioPromptContract() {
-        let prompt = QuilTransformationPrompt.audioUserPrompt(selectedText: "Text", appContext: nil)
-        #expect(prompt.contains("instruction and replacement JSON object"))
-        #expect(!prompt.contains("Return exactly one final paste-ready output"))
-        #expect(!QuilTransformationPrompt.audioSystem.contains("Every character in your response must belong"))
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
@@ -315,10 +315,35 @@ struct QuilDirectAudioTests {
         #expect(content.count == 2)
         #expect(content[0]["text"] == prompt)
         #expect(content[1] == ["type": "audio", "path": url.path])
-        #expect(QuilTransformationPrompt.audioSystem.contains(QuilTransformationPrompt.system))
-        #expect(QuilTransformationPrompt.audioSystem.contains("Do not return a transcript"))
+        #expect(QuilTransformationPrompt.audioSystem.contains("Follow only the spoken instruction"))
+        #expect(QuilTransformationPrompt.audioSystem.contains("faithfully transcribe the spoken command"))
         let textOnly = try Gemma4LiteRTTranscriber.generationMessageJSONString(userPrompt: "Text request", audioURL: nil)
         let textJSON = try #require(JSONSerialization.jsonObject(with: Data(textOnly.utf8)) as? [String: Any])
         #expect((textJSON["content"] as? [[String: String]])?.count == 1)
+    }
+}
+
+@Suite("Quill audio response")
+struct QuilAudioResponseTests {
+    @Test("preserves the spoken question separately from the paste payload")
+    func separatesInstructionAndReplacement() throws {
+        let result = try QuilAudioResult.validated(#"{"instruction":"  Can you make this shorter?  ","replacement":"Short version."}"#)
+        #expect(result.instruction == "Can you make this shorter?")
+        #expect(result.replacement == "Short version.")
+    }
+
+    @Test("malformed responses cannot paste an envelope or lose the question")
+    func rejectsMalformedResponses() {
+        for raw in ["Plain text", #"{"replacement":"Text"}"#, #"{"instruction":"","replacement":"Text"}"#, #"{"instruction":"Rewrite","replacement":""}"#] {
+            #expect(throws: (any Error).self) { try QuilAudioResult.validated(raw) }
+        }
+    }
+
+    @Test("audio prompt requests structured output without conflicting paste-only instructions")
+    func audioPromptContract() {
+        let prompt = QuilTransformationPrompt.audioUserPrompt(selectedText: "Text", appContext: nil)
+        #expect(prompt.contains("instruction and replacement JSON object"))
+        #expect(!prompt.contains("Return exactly one final paste-ready output"))
+        #expect(!QuilTransformationPrompt.audioSystem.contains("Every character in your response must belong"))
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
@@ -290,3 +290,35 @@ struct QuilAvailabilityGateTests {
         ))
     }
 }
+
+@Suite("Quill direct audio")
+struct QuilDirectAudioTests {
+    @Test("direct audio requires the exact same Gemma model for both features")
+    func exactModelMatch() {
+        for model in Gemma4LiteRTModel.allCases {
+            #expect(QuilModelPolicy.usesDirectAudio(dictation: .gemma4LiteRT(model), backend: .gemma4LiteRT, model: model.repoID))
+        }
+        #expect(!QuilModelPolicy.usesDirectAudio(dictation: .gemma4E2BLiteRT, backend: .gemma4LiteRT, model: Gemma4LiteRTModel.e4b.repoID))
+        #expect(!QuilModelPolicy.usesDirectAudio(dictation: .parakeetUnified, backend: .gemma4LiteRT, model: Gemma4LiteRTModel.e2b.repoID))
+        #expect(!QuilModelPolicy.usesDirectAudio(dictation: .gemma4E2BLiteRT, backend: .hosted(.chatGPT), model: Gemma4LiteRTModel.e2b.repoID))
+        #expect(!QuilModelPolicy.usesDirectAudio(dictation: .gemma4E2BLiteRT, backend: .gemma4LiteRT, model: "unknown"))
+    }
+
+    @Test("one generation message contains context and the instruction audio")
+    func audioMessage() throws {
+        guard #available(macOS 15, *) else { return }
+        let url = URL(fileURLWithPath: "/tmp/quill-command.wav")
+        let prompt = QuilTransformationPrompt.userPrompt(selectedText: "Original text", instruction: "Use attached audio", appContext: "Document context")
+        let raw = try Gemma4LiteRTTranscriber.generationMessageJSONString(userPrompt: prompt, audioURL: url)
+        let json = try #require(JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any])
+        let content = try #require(json["content"] as? [[String: String]])
+        #expect(content.count == 2)
+        #expect(content[0]["text"] == prompt)
+        #expect(content[1] == ["type": "audio", "path": url.path])
+        #expect(QuilTransformationPrompt.audioSystem.contains(QuilTransformationPrompt.system))
+        #expect(QuilTransformationPrompt.audioSystem.contains("Do not return a transcript"))
+        let textOnly = try Gemma4LiteRTTranscriber.generationMessageJSONString(userPrompt: "Text request", audioURL: nil)
+        let textJSON = try #require(JSONSerialization.jsonObject(with: Data(textOnly.utf8)) as? [String: Any])
+        #expect((textJSON["content"] as? [[String: String]])?.count == 1)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QuilTransformationTests.swift
@@ -227,3 +227,66 @@ struct QuilTransformationTests {
         ))
     }
 }
+
+@Suite("Quill availability gate")
+struct QuilAvailabilityGateTests {
+    @Test("missing setup disables Quill and prompts once across later callbacks")
+    func missingSetupStopsSubsequentCallbacks() {
+        var enabled = true
+        var prompts = 0
+        var hotkeyReconfigurations = 0
+        func attempt() -> Bool {
+            QuilAvailabilityGate.allow(isEnabled: enabled, isAvailable: { false }) {
+                enabled = false
+                prompts += 1
+                hotkeyReconfigurations += 1
+            }
+        }
+        #expect(!attempt())
+        #expect(!enabled)
+        #expect(!attempt()) // A queued prepare or toggle callback after disablement.
+        #expect(prompts == 1)
+        #expect(hotkeyReconfigurations == 1)
+    }
+
+    @Test("ready models allow recording and removed models block the next start")
+    func readinessIsRechecked() {
+        var available = true
+        var prompts = 0
+        #expect(QuilAvailabilityGate.allow(isEnabled: true, isAvailable: { available }) { prompts += 1 })
+        available = false
+        #expect(!QuilAvailabilityGate.allow(isEnabled: true, isAvailable: { available }) { prompts += 1 })
+        #expect(prompts == 1)
+        #expect(!QuilAvailabilityGate.allow(isEnabled: false, isAvailable: { true }) { prompts += 1 })
+        #expect(prompts == 1)
+    }
+
+    @Test("Quill readiness uses its own model rather than the cleanup model")
+    func quillModelOverride() {
+        var config = AppConfig()
+        config.lmStudioURL = "http://localhost:1234"
+        config.postProcessorLMStudioModel = ""
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: .hosted(.lmStudio), config: config, isChatGPTAuthenticated: false,
+            modelOverride: "quill-model"
+        ))
+        config.postProcessorLMStudioModel = "cleanup-model"
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: .hosted(.lmStudio), config: config, isChatGPTAuthenticated: false,
+            modelOverride: ""
+        ))
+    }
+
+    @Test("ChatGPT requires sign-in for Quill readiness")
+    func chatGPTRequiresSignIn() {
+        let config = AppConfig()
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: .hosted(.chatGPT), config: config, isChatGPTAuthenticated: false,
+            modelOverride: "gpt-5.6-terra"
+        ))
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: .hosted(.chatGPT), config: config, isChatGPTAuthenticated: true,
+            modelOverride: "gpt-5.6-terra"
+        ))
+    }
+}

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -79,6 +79,8 @@ case "${shard}" in
       DictationPasteSpacingPolicyTests
       DictationPasteSpacingTests
       QuilTransformationTests
+      QuilAvailabilityGateTests
+      QuilDirectAudioTests
       BackendOptionTests
       OpenAIDictationProviderTests
       OpenRouterTranscriptionClientTests


### PR DESCRIPTION
## Summary

Quill requests through the ChatGPT Codex endpoint failed because Quill supplied `max_output_tokens`, which that endpoint rejects. Remove the field when serializing Codex requests while preserving it for the other transport.

When Quill or local transcript cleanup has no usable local model, show an explanatory prompt with a Choose Model action that opens the existing model download library. Keep Quill settings visible while disabled so users can select a model or cloud source before enabling it. Check availability before both held-key and toggle recording paths, including when a previously selected model has been removed. Downloads remain explicit; users select their downloaded model and enable the feature afterward.

The Models screen now has a centered, label-free mode selector with a dedicated Quill tab. It lists compatible GGUF and Gemma models, shares existing downloads, and offers Use for Quill without changing cleanup selection. Quill setup links open this tab directly.

Hosted Quill setup is also checked before enablement or recording. Signed-out ChatGPT shows Sign in with ChatGPT; missing OpenRouter credentials show Connect OpenRouter. Each CTA starts the existing connection flow without changing the meeting-summary provider. Other incomplete provider settings open Settings. Quill stays disabled until the user finishes setup and enables it again.

When dictation and Quill use the exact same Gemma model ID, Quill now sends the audio command, selected text, and context in one generation request. Other model combinations retain transcription followed by rewriting. The direct-audio path returns only the final text, validates it without a corrective second generation, and displays Applying audio instruction in the pill. History uses Audio instruction because no separate transcript is produced.

Both new Quill test suites are explicitly assigned to the required dictation-transcription CI shard. The shard-registration failure was fixed by adding those entries; test assertions and the unassigned-suite guard were unchanged.

## Validation

- Native suite: 2,106 tests across 192 suites passed on the direct-audio implementation. The current tree exactly matches that tested implementation after reverting the structured question-display change.
- Direct-audio regression tests cover exact model matching and combined text/audio message serialization. Real-audio output quality and latency validation remain pending; no Gemma runtime model was found in the managed cache.
- Regression coverage includes Codex/WHAM token serialization, signed-out ChatGPT, Quill model selection independent of cleanup, model removal, and suppression of later callbacks after disablement.
- All checks in the classifier-tests job passed locally: changed-file classification, shard assignments, append-only appcast updates, and LocalVQE runtime validation.
- `git diff --check` passed.
- Pinned LocalVQE runtime passed functional context creation before packaging.
- MuesliDev built, installed, and launched. Installed bundle passed deep strict signature verification and functional LocalVQE context creation. Live ChatGPT and missing-model UI smoke tests remain pending; UI automation returned only an empty window after a prolonged response delay.

## Contribution certification

- [x] Every non-merge commit has an author Signed-off-by trailer.
- [x] This contribution was created for submission under Muesli's MIT License.
- [ ] Any required employer, client, institution, or other rights-holder permission is confirmed by the maintainer.
- [x] Third-party materials are identified below.
- [x] Material AI assistance is disclosed, and resulting changes were reviewed and tested.

### Third-party materials

None.

### AI assistance

OpenAI Codex investigated the failures, implemented the changes, reviewed the diff, and ran validation.
