### PR TITLE
Use macOS calendars exclusively and add account management

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Live transcription is off by default. Choose Apple Speech, or download Parakeet 
 - **Speaker diarization** — Identifies individual speakers in system audio (Speaker 1, Speaker 2, etc.) using FluidAudio's pyannote-based CoreML diarization model.
 - **Camera-based meeting detection** — Detects when your webcam + mic activate in a recognized meeting app (Zoom, Chrome, Teams, FaceTime, Slack, WhatsApp). Camera alone (e.g. Photo Booth) won't trigger false positives.
 - **Join & Transcribe** — Extracts meeting URLs from calendar events (Zoom, Google Meet, Teams, Webex, Chime, FaceTime). Split-button notification: "Join & Transcribe" opens the meeting + starts transcription, "Join Only" opens without transcribing, "Transcribe Only" starts transcription without joining. Platform icons (Zoom, Meet) in the notification panel.
-- **Google Calendar integration** — Connect your Google Calendar to see upcoming meetings in the Coming Up section and status bar. Choose whether Muesli watches today, two days, or three days of upcoming events. Event-driven notifications via `EKEventStoreChangedNotification` for instant calendar change detection. Pre-meeting countdowns via Marauder's Map easter egg.
+- **macOS Calendar integration** — See upcoming meetings from calendars connected to your Mac, including iCloud, Google, and Exchange, in the Coming Up section and status bar. Choose whether Muesli watches today, two days, or three days of upcoming events. Event-driven notifications via `EKEventStoreChangedNotification` for instant calendar change detection. Pre-meeting countdowns via Marauder's Map easter egg.
 - **Import Audio** — Import m4a, mp4, wav, or mp3 files for offline transcription, speaker diarization, title generation, summaries, and saved meeting history.
 - **Meeting export** — Export meeting notes or transcripts as PDF (paginated US Letter) or Markdown. Format picker in the save panel, auto-opens the exported file.
 - **Meeting templates** — Built-in and custom templates for meeting notes. Choose a template before or after recording — re-summarize any meeting with a different template.
@@ -402,7 +402,19 @@ Muesli needs these macOS permissions (guided during onboarding):
 | **Accessibility** | Simulate Cmd+V to paste transcribed text |
 | **Input Monitoring** | Detect hotkey presses globally |
 | **Camera** *(implicit)* | Detect webcam activation for meeting detection |
-| **Calendar** *(optional)* | Show upcoming meetings from Google Calendar |
+| **Calendar** *(optional)* | Read calendars connected to macOS to show upcoming meetings and reminders |
+
+---
+
+## Calendar setup and management
+
+Muesli uses macOS Calendar through EventKit. A direct Google Calendar sign-in is not currently available in Muesli.
+
+1. In **System Settings → Internet Accounts**, add your Google, Exchange, or other calendar account and enable **Calendars**. Accounts already available in Apple Calendar can be used by Muesli.
+2. Allow Muesli full Calendar access during onboarding or from **Settings → Meetings → Calendars**. If access was denied, use **Open Calendar Privacy Settings…** to enable it in macOS. Calendar access is optional; you can choose **Not now** during onboarding.
+3. In Muesli's **Settings → Meetings → Calendars**, select which calendars to include. Unchecking a calendar hides its meetings and notifications in Muesli without deleting calendar data.
+
+**Manage accounts…** opens macOS Internet Accounts, where you can add or remove accounts. Account changes there also affect other apps on your Mac. **Open Calendar…** opens Apple Calendar, where you can create or delete individual calendars and manage subscriptions. Muesli refreshes its calendar list when you return from macOS settings.
 
 ---
 
@@ -421,7 +433,7 @@ Muesli needs these macOS permissions (guided during onboarding):
 | Camera detection | CoreMediaIO property listeners (event-driven) |
 | System audio | CoreAudio process tap by default; ScreenCaptureKit (`SCStream`) fallback |
 | Meeting notes | OpenAI / OpenRouter (BYOK), ChatGPT subscription (OAuth), or Ollama |
-| Calendar | Google Calendar API (OAuth 2.0) |
+| Calendar | Apple EventKit (macOS Calendar accounts) |
 | Sync | CloudKit private database for text-only iCloud sync |
 | Automation | Computer Use planner and post-meeting executable hooks |
 | Export | PDF (NSPrintOperation, paginated US Letter) + Markdown |
@@ -443,7 +455,7 @@ swift test --package-path native/MuesliNative
 ./scripts/test_packaged_cli.sh
 ```
 
-1,148 tests covering model configuration, custom word and phrase matching, filler removal, transcription routing, data persistence, CLI contract/path-resolution logic, speaker diarization alignment, token consolidation, camera-based meeting detection, CoreAudio system capture, ChatGPT OAuth logic, Ollama summaries, update-flow policy, launch at login, paste/clipboard safety, meeting export, meeting navigation, upcoming-meeting window behavior, and Google Calendar URL extraction.
+1,148 tests covering model configuration, custom word and phrase matching, filler removal, transcription routing, data persistence, CLI contract/path-resolution logic, speaker diarization alignment, token consolidation, camera-based meeting detection, CoreAudio system capture, ChatGPT OAuth logic, Ollama summaries, update-flow policy, launch at login, paste/clipboard safety, meeting export, meeting navigation, upcoming-meeting window behavior, and calendar meeting URL extraction.
 
 Current test scope:
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -120,13 +120,6 @@ enum SparkleUpdateStatus: Equatable {
     case failed(message: String)
 }
 
-enum GoogleCalendarListLoadState: Equatable {
-    case idle
-    case loading
-    case loaded
-    case failed(String)
-}
-
 enum ICloudBridgeState: Equatable {
     case notConfigured
     case checkingICloud
@@ -217,14 +210,9 @@ final class AppState {
     var openRouterSummaryCatalogState: OpenRouterModelCatalogLoadState = .idle
     var openRouterTranscriptionModels: [SummaryModelPreset] = []
     var openRouterTranscriptionCatalogState: OpenRouterModelCatalogLoadState = .idle
-    var isGoogleCalendarAvailable: Bool = false
-    var isGoogleCalendarVerified: Bool = false
-    var isGoogleCalendarAuthenticated: Bool = false
     var upcomingCalendarEvents: [UnifiedCalendarEvent] = []
     var hiddenCalendarEventIDs: Set<String> = []
     var availableEventKitCalendars: [AvailableCalendar] = []
-    var availableGoogleCalendars: [GoogleCalendarSummary] = []
-    var googleCalendarListLoadState: GoogleCalendarListLoadState = .idle
     var sparkleUpdateStatus: SparkleUpdateStatus = .idle
     var sparkleLastCheckedAt: Date?
     var iCloudSyncStatus: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarEventQuery.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarEventQuery.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Runs synchronous calendar reads off the main actor and only returns the latest result.
+@MainActor
+final class CalendarEventQuery {
+    struct Result {
+        let events: [UnifiedCalendarEvent]
+        fileprivate let generation: UInt64
+    }
+
+    private var generation: UInt64 = 0
+    private var pending: Task<[UnifiedCalendarEvent], Never>?
+
+    func load(_ read: @escaping @Sendable () -> [UnifiedCalendarEvent]) async -> Result? {
+        invalidate()
+        let token = generation
+        guard !Task.isCancelled else { return nil }
+        let task = Task.detached(priority: .utility) {
+            guard !Task.isCancelled else { return [UnifiedCalendarEvent]() }
+            return read()
+        }
+        pending = task
+        let events = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        guard token == generation else { return nil }
+        pending = nil
+        guard !Task.isCancelled, !task.isCancelled else { return nil }
+        return Result(events: events, generation: token)
+    }
+
+    /// Recheck at the publication site after crossing an async boundary.
+    func isCurrent(_ result: Result) -> Bool {
+        result.generation == generation
+    }
+
+    /// Invalidates in-flight results; EventKit's synchronous call itself cannot be interrupted.
+    func invalidate() {
+        generation &+= 1
+        pending?.cancel()
+        pending = nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarIntegrationViews.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarIntegrationViews.swift
@@ -1,0 +1,85 @@
+import AppKit
+import EventKit
+import SwiftUI
+
+/// Calendar accounts remain owned by macOS; Muesli only selects which calendars to use.
+@MainActor
+enum CalendarIntegration {
+    static let calendarIcon: NSImage = {
+        let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.iCal")
+        return NSWorkspace.shared.icon(forFile: url?.path ?? "/System/Applications/Calendar.app")
+    }()
+
+    static func openAccounts() {
+        openSettings("com.apple.Internet-Accounts-Settings.extension")
+    }
+
+    static func openPrivacy() {
+        openSettings("com.apple.preference.security?Privacy_Calendars")
+    }
+
+    private static func openSettings(_ pane: String) {
+        guard let url = URL(string: "x-apple.systempreferences:\(pane)") else { return }
+        if !NSWorkspace.shared.open(url),
+           let fallback = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.systempreferences") {
+            NSWorkspace.shared.open(fallback)
+        }
+    }
+
+    static func openCalendar() {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.iCal") else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+struct CalendarAccessControl: View {
+    var onGranted: () async -> Void
+    @State private var status = EKEventStore.authorizationStatus(for: .event)
+    @State private var requesting = false
+    @State private var errorMessage: String?
+
+    private var granted: Bool { status == .fullAccess || status == .authorized }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if granted {
+                Label("Calendar access allowed", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(MuesliTheme.success)
+            } else {
+                Button(requesting ? "Requesting access…" : (status == .notDetermined ? "Allow Calendar Access" : "Open Calendar Privacy Settings…")) {
+                    guard status == .notDetermined else {
+                        CalendarIntegration.openPrivacy()
+                        return
+                    }
+                    requesting = true
+                    errorMessage = nil
+                    Task { @MainActor in
+                        do {
+                            let store = EKEventStore()
+                            _ = try await store.requestFullAccessToEvents()
+                            status = EKEventStore.authorizationStatus(for: .event)
+                            if granted { await onGranted() }
+                        } catch {
+                            errorMessage = error.localizedDescription
+                        }
+                        requesting = false
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(requesting)
+                if status != .notDetermined {
+                    Text("Allow Muesli full Calendar access in Privacy & Security to show your meetings.")
+                        .font(.caption)
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+            }
+            if let errorMessage {
+                Text(errorMessage).font(.caption).foregroundStyle(MuesliTheme.recording)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            status = EKEventStore.authorizationStatus(for: .event)
+            if granted { Task { await onGranted() } }
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarIntegrationViews.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarIntegrationViews.swift
@@ -33,6 +33,9 @@ enum CalendarIntegration {
 }
 
 struct CalendarAccessControl: View {
+    // Settings owns activation refreshes for the whole pane, including existing calendars.
+    // Onboarding uses this control's handler because it has no equivalent parent refresh.
+    var refreshOnActivation = true
     var onGranted: () async -> Void
     @State private var status = EKEventStore.authorizationStatus(for: .event)
     @State private var requesting = false
@@ -79,7 +82,7 @@ struct CalendarAccessControl: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             status = EKEventStore.authorizationStatus(for: .event)
-            if granted { Task { await onGranted() } }
+            if granted && refreshOnActivation && !requesting { Task { await onGranted() } }
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -229,7 +229,7 @@ final class CalendarMonitor {
     /// Returns upcoming timed events from the local macOS calendar (EventKit) for the selected calendar-day window.
     /// All-day events are excluded — they're not useful for meeting recording.
     /// Events from calendars listed in `disabledCalendarIDs` are filtered out.
-    func upcomingEvents(
+    static func upcomingEvents(
         daysAhead: Int = UpcomingMeetingsWindow.defaultDayCount,
         disabledCalendarIDs: Set<String> = [],
         now: Date = Date()

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -74,7 +74,22 @@ final class CalendarMonitor {
         case running(Int)
     }
 
-    private let store = EKEventStore()
+    private let store: EKEventStore
+    private let authorizationStatus: () -> EKAuthorizationStatus
+    private let requestAccess: (@escaping @Sendable (Bool, Error?) -> Void) -> Void
+    private let notificationCenter: NotificationCenter
+
+    init(
+        store: EKEventStore = EKEventStore(),
+        authorizationStatus: @escaping () -> EKAuthorizationStatus = { EKEventStore.authorizationStatus(for: .event) },
+        requestAccess: ((@escaping @Sendable (Bool, Error?) -> Void) -> Void)? = nil,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.store = store
+        self.authorizationStatus = authorizationStatus
+        self.requestAccess = requestAccess ?? { completion in store.requestFullAccessToEvents(completion: completion) }
+        self.notificationCenter = notificationCenter
+    }
     private var changeObserver: NSObjectProtocol?
     private var generation = 0
     private var state: State = .stopped
@@ -93,12 +108,12 @@ final class CalendarMonitor {
         let token = generation
         state = .requesting(token)
 
-        store.requestFullAccessToEvents { [weak self] granted, error in
+        requestAccess { [weak self] granted, error in
             DispatchQueue.main.async {
                 guard let self else { return }
                 guard case .requesting(let activeToken) = self.state, activeToken == token else { return }
 
-                if !granted {
+                if !granted || !self.canConfirmMissingEvents {
                     self.state = .stopped
                     fputs("[calendar] calendar access denied: \(error?.localizedDescription ?? "none")\n", stderr)
                     return
@@ -117,7 +132,7 @@ final class CalendarMonitor {
     }
 
     var canConfirmMissingEvents: Bool {
-        switch EKEventStore.authorizationStatus(for: .event) {
+        switch authorizationStatus() {
         case .fullAccess, .authorized:
             return true
         case .notDetermined, .restricted, .denied, .writeOnly:
@@ -135,7 +150,7 @@ final class CalendarMonitor {
         // is added, modified, or deleted — including synced changes from
         // Google Calendar, iCloud, Exchange, etc. This is push-based and
         // works regardless of App Nap or LSUIElement status.
-        changeObserver = NotificationCenter.default.addObserver(
+        changeObserver = notificationCenter.addObserver(
             forName: .EKEventStoreChanged,
             object: store,
             queue: .main
@@ -146,7 +161,7 @@ final class CalendarMonitor {
 
     private func removeObserver() {
         if let changeObserver {
-            NotificationCenter.default.removeObserver(changeObserver)
+            notificationCenter.removeObserver(changeObserver)
             self.changeObserver = nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -84,6 +84,9 @@ final class CalendarMonitor {
     var onCalendarChanged: (() -> Void)?
 
     func start() {
+        // Permission is requested explicitly by onboarding or Settings. In particular,
+        // choosing “Not now” must not trigger a prompt from the background monitor.
+        guard canConfirmMissingEvents else { return }
         guard case .stopped = state else { return }
 
         generation += 1

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -3,7 +3,7 @@ import MuesliCore
 
 // MARK: - Shared Calendar Event Model
 
-struct UnifiedCalendarEvent: Identifiable, Equatable {
+struct UnifiedCalendarEvent: Identifiable, Equatable, Sendable {
     let id: String
     let title: String
     let startDate: Date
@@ -18,7 +18,7 @@ struct UnifiedCalendarEvent: Identifiable, Equatable {
     var meetingURL: URL? = nil
     var attendees: [CalendarAttendee] = []
 
-    enum CalendarSource: String {
+    enum CalendarSource: String, Sendable {
         case eventKit
         case googleCalendar
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -407,22 +407,6 @@ struct MeetingsView: View {
                     .font(.custom("Cormorant Garamond", size: 22).weight(.medium))
                     .foregroundStyle(MuesliTheme.textPrimary)
 
-                if appState.isGoogleCalendarAuthenticated {
-                    Button {
-                        if let url = URL(string: "x-apple.systempreferences:com.apple.Internet-Accounts-Settings.extension") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "arrow.triangle.2.circlepath")
-                                .font(.system(size: 9))
-                            Text("Add Google to macOS Calendar for real-time sync")
-                                .font(.system(size: 11))
-                        }
-                        .foregroundStyle(MuesliTheme.accent)
-                    }
-                    .buttonStyle(.plain)
-                }
             }
             .padding(.bottom, 4)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -424,6 +424,7 @@ public final class MuesliController: NSObject {
     private let dictationLatencyTimestampFormatter = ISO8601DateFormatter()
     private let indicator: FloatingIndicatorController
     private let calendarMonitor = CalendarMonitor()
+    private let calendarEventQuery = CalendarEventQuery()
     private let meetingMonitor = MeetingMonitor()
     private let meetingNotification = MeetingNotificationController()
     private let meetingSourceWindowLocator = MeetingSourceWindowLocator()
@@ -1052,6 +1053,7 @@ public final class MuesliController: NSObject {
         for task in attendeePersistenceTasks {
             _ = await task.value
         }
+        calendarEventQuery.invalidate()
         calendarMonitor.stop()
         calendarCheckTimer?.invalidate()
         calendarCheckTimer = nil
@@ -3715,11 +3717,14 @@ public final class MuesliController: NSObject {
         let refreshStartOfDay = Calendar.current.startOfDay(for: refreshNow)
         let disabledIDs = Set(config.disabledCalendarIDs)
         let dayCount = UpcomingMeetingsWindow.resolve(dayCount: config.upcomingMeetingsDayCount).dayCount
-        let ekEvents = calendarMonitor.upcomingEvents(
-            daysAhead: dayCount,
-            disabledCalendarIDs: disabledIDs,
-            now: refreshNow
-        )
+        guard let result = await calendarEventQuery.load({
+            CalendarMonitor.upcomingEvents(
+                daysAhead: dayCount,
+                disabledCalendarIDs: disabledIDs,
+                now: refreshNow
+            )
+        }), !Task.isCancelled, calendarEventQuery.isCurrent(result) else { return false }
+        let ekEvents = result.events
         let observedEventIDs = Set(ekEvents.map(\.id))
         let currentDisabledIDs = Set(config.disabledCalendarIDs)
         let currentDayCount = UpcomingMeetingsWindow.resolve(dayCount: config.upcomingMeetingsDayCount).dayCount
@@ -3868,6 +3873,7 @@ public final class MuesliController: NSObject {
                 calendarMonitoringStarted = true
             }
         } else if !shouldRun && calendarMonitoringStarted {
+            calendarEventQuery.invalidate()
             calendarMonitor.stop()
             calendarCheckTimer?.invalidate()
             calendarCheckTimer = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -431,8 +431,6 @@ public final class MuesliController: NSObject {
     private let chatGPTAuth = ChatGPTAuthManager.shared
     private let openRouterAuth: OpenRouterAuthManager
     private let openRouterModelCatalogClient: OpenRouterModelCatalogClient
-    private let googleCalAuth = GoogleCalendarAuthManager.shared
-    private let googleCalClient = GoogleCalendarClient()
     private var calendarCheckTimer: Timer?
     private var calendarMonitoringStarted = false
     private var meetingStartingNowTimers = [String: Timer]()
@@ -1417,9 +1415,6 @@ public final class MuesliController: NSObject {
         appState.isOpenRouterAuthenticated = openRouterAuth.isAuthenticated
         appState.isOpenRouterEnvironmentManaged = openRouterAuth.hasEnvironmentCredential
         appState.hasStoredOpenRouterCredential = openRouterAuth.hasStoredCredential
-        appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
-        appState.isGoogleCalendarVerified = googleCalAuth.isVerified
-        appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
         refreshICloudBridgeDeviceState()
         refreshICloudBridgeStateForConfig()
         // Keep appState in sync with persisted hidden event IDs
@@ -3704,36 +3699,6 @@ public final class MuesliController: NSObject {
         appState.openRouterTranscriptionCatalogState = .idle
     }
 
-    // MARK: - Google Calendar
-
-    func signInWithGoogleCalendar() async -> String? {
-        do {
-            try await googleCalAuth.signIn()
-            syncAppState()
-            Task {
-                await refreshUpcomingCalendarEvents()
-                await refreshGoogleCalendarList()
-            }
-            return nil
-        } catch {
-            fputs("[muesli-native] Google Calendar sign-in failed: \(error)\n", stderr)
-            return error.localizedDescription
-        }
-    }
-
-    func signOutGoogleCalendar() {
-        invalidateGoogleCalendarAuth()
-        Task { await refreshUpcomingCalendarEvents() }
-    }
-
-    private func invalidateGoogleCalendarAuth() {
-        googleCalAuth.signOut()
-        googleCalClient.resetSync()
-        appState.availableGoogleCalendars = []
-        appState.googleCalendarListLoadState = .idle
-        syncAppState()
-    }
-
     /// Refresh the EventKit-available calendars list without making the main
     /// actor wait for EventKit's synchronous calendar-store enumeration.
     func refreshAvailableEventKitCalendars() async {
@@ -3744,67 +3709,18 @@ public final class MuesliController: NSObject {
         appState.availableEventKitCalendars = calendars
     }
 
-    /// Refresh the Google calendar list via the Calendar API. No-op when OAuth
-    /// is not available or the user is not authenticated.
-    func refreshGoogleCalendarList() async {
-        guard googleCalAuth.isAuthenticated else {
-            appState.availableGoogleCalendars = []
-            appState.googleCalendarListLoadState = .idle
-            return
-        }
-        appState.googleCalendarListLoadState = .loading
-        do {
-            let list = try await googleCalClient.fetchCalendarList()
-            appState.availableGoogleCalendars = list
-            appState.googleCalendarListLoadState = .loaded
-        } catch GoogleCalendarAuthError.notAuthenticated {
-            invalidateGoogleCalendarAuth()
-            fputs("[muesli-native] Google Calendar token invalid while loading calendar list, signed out\n", stderr)
-        } catch GoogleCalendarAuthError.refreshFailed(let message) {
-            fputs("[muesli-native] Google Calendar token refresh failed while loading calendar list: \(message)\n", stderr)
-            appState.googleCalendarListLoadState = .failed("Token refresh failed: \(message)")
-        } catch {
-            fputs("[muesli-native] Google calendarList fetch failed: \(error)\n", stderr)
-            appState.googleCalendarListLoadState = .failed(error.localizedDescription)
-        }
-    }
-
     @discardableResult
     func refreshUpcomingCalendarEvents() async -> Bool {
         let refreshNow = Date()
         let refreshStartOfDay = Calendar.current.startOfDay(for: refreshNow)
         let disabledIDs = Set(config.disabledCalendarIDs)
         let dayCount = UpcomingMeetingsWindow.resolve(dayCount: config.upcomingMeetingsDayCount).dayCount
-        var ekEvents = calendarMonitor.upcomingEvents(
+        let ekEvents = calendarMonitor.upcomingEvents(
             daysAhead: dayCount,
             disabledCalendarIDs: disabledIDs,
             now: refreshNow
         )
-        var observedEventIDs = Set(ekEvents.map(\.id))
-        var canConfirmMissingGoogleEvents = false
-
-        if googleCalAuth.isAuthenticated {
-            do {
-                let googleResult = try await googleCalClient.fetchUpcomingEvents(
-                    daysAhead: dayCount,
-                    disabledCalendarIDs: disabledIDs,
-                    now: refreshNow
-                )
-                canConfirmMissingGoogleEvents = googleResult.wasComplete
-                observedEventIDs.formUnion(googleResult.events.map(\.id))
-                ekEvents = GoogleCalendarClient.mergeEvents(eventKit: ekEvents, google: googleResult.events)
-            } catch GoogleCalendarAuthError.notAuthenticated {
-                invalidateGoogleCalendarAuth()
-                fputs("[muesli-native] Google Calendar token invalid, signed out\n", stderr)
-            } catch GoogleCalendarAuthError.refreshFailed(let message) {
-                fputs("[muesli-native] Google Calendar token refresh failed: \(message)\n", stderr)
-            } catch GoogleCalendarClientError.staleRequest {
-                return false
-            } catch {
-                fputs("[muesli-native] Google Calendar fetch failed: \(error)\n", stderr)
-            }
-        }
-
+        let observedEventIDs = Set(ekEvents.map(\.id))
         let currentDisabledIDs = Set(config.disabledCalendarIDs)
         let currentDayCount = UpcomingMeetingsWindow.resolve(dayCount: config.upcomingMeetingsDayCount).dayCount
         let currentStartOfDay = Calendar.current.startOfDay(for: Date())
@@ -3817,7 +3733,6 @@ public final class MuesliController: NSObject {
         appState.upcomingCalendarEvents = ekEvents
 
         // Prune hidden IDs only when the widest supported window still cannot see the event.
-        observedEventIDs.formUnion(ekEvents.map(\.id))
         let sourceHints = config.hiddenCalendarEventSourceHints
         let canConfirmMissingEventKitEvents = calendarMonitor.canConfirmMissingEvents
         let canPruneHiddenEvents = disabledIDs.isEmpty
@@ -3832,7 +3747,8 @@ public final class MuesliController: NSObject {
                 case .some(.eventKit):
                     return canConfirmMissingEventKitEvents
                 case .some(.googleCalendar):
-                    return canConfirmMissingGoogleEvents
+                    // Preserve historical Google-only hidden IDs while direct integration is unavailable.
+                    return false
                 case .none:
                     return false
                 }
@@ -3853,8 +3769,7 @@ public final class MuesliController: NSObject {
     }
 
     /// Reconciles only EventKit-backed meetings that have not started. This is
-    /// called from EKEventStoreChangedNotification, never from the Google
-    /// Calendar fallback timer, so participant freshness remains event-driven.
+    /// called from EKEventStoreChangedNotification so participant freshness remains event-driven.
     func reconcilePendingEventKitCalendarAttendees(
         events: [UnifiedCalendarEvent],
         now: Date = Date()
@@ -3907,13 +3822,8 @@ public final class MuesliController: NSObject {
             }
         }
 
-        // 60s fallback timer: polls Google Calendar API (sync token makes this
-        // efficient) and checks the notification window for time-based triggers.
-        // EKEventStoreChangedNotification handles EventKit reactively, but Google
-        // Calendar OAuth has no push mechanism — this timer is the only way to
-        // pick up new/moved events from the API. May be suspended by App Nap on
-        // macOS 26, but combined with the EventKit push path, most cases are covered.
         calendarCheckTimer?.invalidate()
+        // Refresh the date window and time-based notifications between EventKit changes.
         calendarCheckTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3850,12 +3850,23 @@ public final class MuesliController: NSObject {
         }
     }
 
+    /// Reconcile authorization immediately after an explicit grant or return from Settings.
+    func calendarAccessDidChange() async {
+        syncCalendarMonitor()
+        await refreshAvailableEventKitCalendars()
+        await refreshUpcomingCalendarEvents()
+    }
+
     private func syncCalendarMonitor() {
         let shouldRun = meetingFeatureMonitorsAllowed && shouldRunCalendarMonitor
-        if shouldRun && !calendarMonitoringStarted {
+        if shouldRun {
+            // start() is idempotent, including while an access callback is pending.
+            // A timer may already exist from before the user granted permission.
             calendarMonitor.start()
-            startCalendarMonitoring()
-            calendarMonitoringStarted = true
+            if !calendarMonitoringStarted {
+                startCalendarMonitoring()
+                calendarMonitoringStarted = true
+            }
         } else if !shouldRun && calendarMonitoringStarted {
             calendarMonitor.stop()
             calendarCheckTimer?.invalidate()

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
@@ -25,6 +25,7 @@ enum OnboardingFlow {
         case permissions = 3
         case dictationTest = 4
         case meetingSummary = 5
+        case calendarAccess = 6
     }
 
     static let dictationTestStep = Step.dictationTest.rawValue
@@ -138,7 +139,7 @@ enum OnboardingFlow {
             steps += [Step.permissions.rawValue]
         }
         if useCase.includesMeetings {
-            steps += [Step.meetingSummary.rawValue]
+            steps += [Step.meetingSummary.rawValue, Step.calendarAccess.rawValue]
         }
         return steps
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
@@ -25,7 +25,6 @@ enum OnboardingFlow {
         case permissions = 3
         case dictationTest = 4
         case meetingSummary = 5
-        case googleCalendar = 6
     }
 
     static let dictationTestStep = Step.dictationTest.rawValue
@@ -139,7 +138,7 @@ enum OnboardingFlow {
             steps += [Step.permissions.rawValue]
         }
         if useCase.includesMeetings {
-            steps += [Step.meetingSummary.rawValue, Step.googleCalendar.rawValue]
+            steps += [Step.meetingSummary.rawValue]
         }
         return steps
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -2255,8 +2255,7 @@ struct OnboardingView: View {
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textSecondary)
             CalendarAccessControl {
-                await controller.refreshAvailableEventKitCalendars()
-                await controller.refreshUpcomingCalendarEvents()
+                await controller.calendarAccessDidChange()
             }
             Button("Set up calendar accounts…", action: CalendarIntegration.openAccounts)
                 .buttonStyle(.link)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -318,8 +318,7 @@ struct OnboardingView: View {
             }
         case 6:
             HStack(spacing: MuesliTheme.spacing12) {
-                Button("Not now") { finishOnboarding(withKey: true) }
-                    .buttonStyle(.plain)
+                skipButton("Not now") { finishOnboarding(withKey: true) }
                 onboardingButton("Finish", enabled: true) {
                     finishOnboarding(withKey: true)
                 }
@@ -359,8 +358,8 @@ struct OnboardingView: View {
     }
 
     @ViewBuilder
-    private func skipButton(action: @escaping () -> Void) -> some View {
-        Button("Skip", action: action)
+    private func skipButton(_ title: String = "Skip", action: @escaping () -> Void) -> some View {
+        Button(title, action: action)
             .buttonStyle(.plain)
             .font(MuesliTheme.body())
             .foregroundStyle(MuesliTheme.textSecondary)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -176,6 +176,7 @@ struct OnboardingView: View {
                 case 3: permissionsStep
                 case 4: dictationTestStep
                 case 5: meetingSummaryStep
+                case 6: calendarAccessStep
                 default: EmptyView()
                 }
             }
@@ -312,7 +313,13 @@ struct OnboardingView: View {
             }
         case 5:
             HStack(spacing: MuesliTheme.spacing12) {
-                skipButton { finishOnboarding(withKey: true) }
+                skipButton { goToNextStep() }
+                onboardingButton("Continue", enabled: true) { goToNextStep() }
+            }
+        case 6:
+            HStack(spacing: MuesliTheme.spacing12) {
+                Button("Not now") { finishOnboarding(withKey: true) }
+                    .buttonStyle(.plain)
                 onboardingButton("Finish", enabled: true) {
                     finishOnboarding(withKey: true)
                 }
@@ -2232,6 +2239,35 @@ struct OnboardingView: View {
             }
             modelReadyIndicatorTask = nil
         }
+    }
+
+    private var calendarAccessStep: some View {
+        VStack(spacing: MuesliTheme.spacing24) {
+            Spacer()
+            Image(nsImage: CalendarIntegration.calendarIcon)
+                .resizable()
+                .frame(width: 80, height: 80)
+                .accessibilityHidden(true)
+            Text("Bring your meetings into Muesli")
+                .font(MuesliTheme.title1())
+                .foregroundStyle(MuesliTheme.textPrimary)
+            Text("Allow access to macOS Calendar to see upcoming meetings and get reminders.")
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            CalendarAccessControl {
+                await controller.refreshAvailableEventKitCalendars()
+                await controller.refreshUpcomingCalendarEvents()
+            }
+            Button("Set up calendar accounts…", action: CalendarIntegration.openAccounts)
+                .buttonStyle(.link)
+            Divider().background(MuesliTheme.surfaceBorder)
+            Text("Already use Google or Exchange? Add the account in macOS Internet Accounts and turn on Calendars.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            Spacer()
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, MuesliTheme.spacing32)
     }
 
     private func finishOnboarding(withKey: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -63,10 +63,6 @@ struct OnboardingView: View {
     @State private var modelReadyIndicatorBackend: BackendOption?
     @State private var modelReadyIndicatorTask: Task<Void, Never>?
 
-    // Google Calendar
-    @State private var isSigningInGoogleCal = false
-    @State private var googleCalSignInDone = false
-    @State private var googleCalSignInError: String?
     @State private var hasFinishedOnboarding = false
 
     static let permissionsStep = OnboardingFlow.Step.permissions.rawValue
@@ -180,7 +176,6 @@ struct OnboardingView: View {
                 case 3: permissionsStep
                 case 4: dictationTestStep
                 case 5: meetingSummaryStep
-                case 6: googleCalendarStep
                 default: EmptyView()
                 }
             }
@@ -316,13 +311,6 @@ struct OnboardingView: View {
                 }
             }
         case 5:
-            HStack(spacing: MuesliTheme.spacing12) {
-                skipButton { goToNextStep() }
-                onboardingButton("Continue", enabled: true) {
-                    goToNextStep()
-                }
-            }
-        case 6:
             HStack(spacing: MuesliTheme.spacing12) {
                 skipButton { finishOnboarding(withKey: true) }
                 onboardingButton("Finish", enabled: true) {
@@ -2244,102 +2232,6 @@ struct OnboardingView: View {
             }
             modelReadyIndicatorTask = nil
         }
-    }
-
-    private var googleCalendarStep: some View {
-        VStack(spacing: MuesliTheme.spacing24) {
-            Spacer()
-
-            VStack(spacing: MuesliTheme.spacing8) {
-                Text("Google Calendar")
-                    .font(MuesliTheme.title1())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-
-                Text("Connect Google Calendar to see upcoming meetings.\nYou can set this up later in Settings.")
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .multilineTextAlignment(.center)
-            }
-
-            VStack(spacing: MuesliTheme.spacing12) {
-                if googleCalSignInDone {
-                    HStack(spacing: 6) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(MuesliTheme.success)
-                        Text("Google Calendar connected")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                    }
-                } else if isSigningInGoogleCal {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Connecting...")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                    }
-                } else if appState.isGoogleCalendarAvailable && !appState.isGoogleCalendarVerified {
-                    VStack(spacing: 6) {
-                        HStack(spacing: 6) {
-                            Image(systemName: "calendar.badge.plus")
-                                .font(.system(size: 14))
-                            Text("Connect Google Calendar")
-                                .font(.system(size: 14, weight: .medium))
-                        }
-                        .foregroundStyle(.white.opacity(0.4))
-                        .padding(.horizontal, MuesliTheme.spacing16)
-                        .padding(.vertical, MuesliTheme.spacing8)
-                        .background(MuesliTheme.textTertiary.opacity(0.3))
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-
-                        Text("Google OAuth verification pending")
-                            .font(MuesliTheme.caption())
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                    }
-                } else if appState.isGoogleCalendarAvailable {
-                    Button {
-                        isSigningInGoogleCal = true
-                        googleCalSignInError = nil
-                        Task {
-                            let error = await controller.signInWithGoogleCalendar()
-                            isSigningInGoogleCal = false
-                            if let error {
-                                googleCalSignInError = error
-                            } else {
-                                googleCalSignInDone = true
-                            }
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "calendar.badge.plus")
-                                .font(.system(size: 14))
-                            Text("Connect Google Calendar")
-                                .font(.system(size: 14, weight: .medium))
-                        }
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, MuesliTheme.spacing16)
-                        .padding(.vertical, MuesliTheme.spacing8)
-                        .background(MuesliTheme.accent)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    }
-                    .buttonStyle(.plain)
-
-                    if let googleCalSignInError {
-                        Text(googleCalSignInError)
-                            .font(.system(size: 11))
-                            .foregroundStyle(.red)
-                            .multilineTextAlignment(.center)
-                    }
-                } else {
-                    Text("Google Calendar credentials not configured.")
-                        .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                }
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, MuesliTheme.spacing32)
     }
 
     private func finishOnboarding(withKey: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -509,6 +509,12 @@ struct SettingsView: View {
                 guard appState.selectedTab == .settings else { return }
                 refreshAudioInputDevices()
                 refreshPermissionStatuses(for: .appActivated)
+                if selectedPane == .meetings {
+                    Task {
+                        await controller.refreshAvailableEventKitCalendars()
+                        await controller.refreshUpcomingCalendarEvents()
+                    }
+                }
             }
             .onChange(of: appState.selectedBackend) { _, _ in
                 refreshDownloadedModelOptions()
@@ -2117,6 +2123,19 @@ struct SettingsView: View {
             }
 
             settingsSection("Calendars") {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Use calendars already connected to your Mac.")
+                            .font(MuesliTheme.body())
+                        Text("Add or remove accounts in macOS System Settings.")
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+                    Spacer()
+                    Button("Manage accounts…", action: CalendarIntegration.openAccounts)
+                        .buttonStyle(.borderedProminent)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Upcoming meetings", controlWidth: meetingControlWidth) {
                     settingsMenu(
                         selection: selectedUpcomingMeetingsWindow.label,
@@ -3163,7 +3182,6 @@ struct SettingsView: View {
         let id: String
         let title: String
         let subtitle: String
-        let iconName: String
         let items: [CalendarToggleItem]
     }
 
@@ -3187,7 +3205,6 @@ struct SettingsView: View {
                 id: "ek::\(sourceTitle)",
                 title: sourceTitle,
                 subtitle: calendarSourceSubtitle(for: sourceTitle),
-                iconName: calendarSourceIconName(for: sourceTitle),
                 items: items
             ))
         }
@@ -3198,13 +3215,12 @@ struct SettingsView: View {
     private var calendarSourcesControl: some View {
         let sourceGroups = calendarSourceGroups
         return VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-            Text("Calendar sources are listed first, with their calendars underneath. Disabled calendars are hidden from Muesli — no notifications, no Coming Up, no meeting detection.")
-                .font(MuesliTheme.caption())
-                .foregroundStyle(MuesliTheme.textTertiary)
-                .fixedSize(horizontal: false, vertical: true)
-
             if sourceGroups.isEmpty {
-                Text("No calendars detected. Make sure Calendar permission is granted in System Settings > Privacy & Security > Calendars.")
+                CalendarAccessControl {
+                    await controller.refreshAvailableEventKitCalendars()
+                    await controller.refreshUpcomingCalendarEvents()
+                }
+                Text("No calendars found. Add an account in macOS Internet Accounts and turn on Calendars, or open Calendar to manage local calendars and subscriptions.")
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -3213,7 +3229,18 @@ struct SettingsView: View {
                     calendarSourceGroupView(group)
                 }
             }
-
+            Divider().background(MuesliTheme.surfaceBorder)
+            HStack(alignment: .top) {
+                Text("Uncheck a calendar to hide its meetings and notifications in Muesli.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                Spacer()
+                Button("Open Calendar…", action: CalendarIntegration.openCalendar)
+                    .buttonStyle(.link)
+            }
+            Text("Manage accounts opens Internet Accounts. Changes there also affect other apps on this Mac.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
         }
     }
 
@@ -3221,10 +3248,10 @@ struct SettingsView: View {
     private func calendarSourceGroupView(_ group: CalendarSourceGroup) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
-                Image(systemName: group.iconName)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .frame(width: 18, height: 18)
+                Image(nsImage: CalendarIntegration.calendarIcon)
+                    .resizable()
+                    .frame(width: 32, height: 32)
+                    .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(group.title)
@@ -3249,9 +3276,12 @@ struct SettingsView: View {
                     calendarToggleButton(item)
                 }
             }
-            .padding(.leading, 28)
         }
-        .padding(.vertical, 2)
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
     }
 
     private func calendarSourceSubtitle(for sourceTitle: String) -> String {
@@ -3266,20 +3296,6 @@ struct SettingsView: View {
             return "System calendars from macOS"
         }
         return "Calendar account in macOS"
-    }
-
-    private func calendarSourceIconName(for sourceTitle: String) -> String {
-        let normalized = sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalized == "icloud" {
-            return "icloud"
-        }
-        if normalized == "subscribed calendars" {
-            return "calendar.badge.clock"
-        }
-        if normalized == "other" {
-            return "person.crop.circle.badge.clock"
-        }
-        return "calendar"
     }
 
     private func calendarToggleButton(_ item: CalendarToggleItem) -> some View {
@@ -3310,6 +3326,8 @@ struct SettingsView: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(item.title)
+        .accessibilityValue(item.isEnabled ? "Included" : "Hidden")
     }
 
     private func refreshMeetingCalendarSourcesIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -189,8 +189,6 @@ struct SettingsView: View {
     @State private var isSigningInOpenRouter = false
     @State private var isEnteringOpenRouterAPIKey = false
     @State private var manualOpenRouterAPIKey = ""
-    @State private var googleCalSignInError: String?
-    @State private var isSigningInGoogleCal = false
     @State private var pendingDataDestruction: PendingDataDestruction?
     @State private var isShowingDictionaryAccessibilityPrompt = false
     @State private var isPreviewingClip = false
@@ -2134,14 +2132,6 @@ struct SettingsView: View {
                     .padding(.bottom, MuesliTheme.spacing8)
             }
 
-            if appState.isGoogleCalendarAvailable {
-                settingsSection("Calendar") {
-                    settingsRow("Google Calendar") {
-                        googleCalendarControl
-                    }
-                }
-            }
-
             settingsSection("Advanced") {
                 settingsRow("Enable post-meeting hook", controlWidth: meetingControlWidth) {
                     settingsSwitch(isOn: appState.config.meetingHookEnabled) { newValue in
@@ -2560,94 +2550,6 @@ struct SettingsView: View {
         }
     }
 
-    @ViewBuilder
-    private var googleCalendarControl: some View {
-        if appState.isGoogleCalendarAuthenticated {
-            Button {
-                controller.signOutGoogleCalendar()
-            } label: {
-                HStack(spacing: 5) {
-                    Image(systemName: "calendar")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.white)
-                    Text("Connected · Disconnect")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.white)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 4)
-                .background(MuesliTheme.success)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            }
-            .buttonStyle(.plain)
-        } else if isSigningInGoogleCal {
-            HStack(spacing: 6) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Connecting...")
-                    .font(.system(size: 11))
-                    .foregroundStyle(MuesliTheme.textSecondary)
-            }
-        } else if !appState.isGoogleCalendarVerified {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 5) {
-                    Image(systemName: "calendar.badge.plus")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.white.opacity(0.4))
-                    Text("Connect Google Calendar")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.4))
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 4)
-                .background(MuesliTheme.textTertiary.opacity(0.3))
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-
-                Text("Google OAuth verification pending")
-                    .font(.system(size: 10))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-            }
-        } else {
-            VStack(alignment: .leading, spacing: 4) {
-                Button {
-                    isSigningInGoogleCal = true
-                    googleCalSignInError = nil
-                    Task {
-                        let error = await controller.signInWithGoogleCalendar()
-                        isSigningInGoogleCal = false
-                        googleCalSignInError = error
-                    }
-                } label: {
-                    HStack(spacing: 5) {
-                        Image(systemName: "calendar.badge.plus")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.white)
-                        Text("Connect Google Calendar")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.white)
-                            .lineLimit(1)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
-                    .background(MuesliTheme.accent)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-                .buttonStyle(.plain)
-
-                if let googleCalSignInError {
-                    Text(googleCalSignInError)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.red)
-                        .lineLimit(2)
-                }
-            }
-        }
-    }
 
     private var maraudersMapControl: some View {
         HStack(spacing: MuesliTheme.spacing8) {
@@ -3290,24 +3192,6 @@ struct SettingsView: View {
             ))
         }
 
-        if appState.isGoogleCalendarAuthenticated && !appState.availableGoogleCalendars.isEmpty {
-            let items = appState.availableGoogleCalendars.map { cal in
-                CalendarToggleItem(
-                    id: cal.id,
-                    title: cal.summary + (cal.isPrimary ? " (Primary)" : ""),
-                    colorHex: cal.colorHex,
-                    isEnabled: !disabled.contains(cal.id)
-                )
-            }
-            groups.append(CalendarSourceGroup(
-                id: "google_oauth",
-                title: "Google Calendar",
-                subtitle: "Connected directly to Muesli",
-                iconName: "calendar.badge.plus",
-                items: items
-            ))
-        }
-
         return groups
     }
 
@@ -3330,16 +3214,6 @@ struct SettingsView: View {
                 }
             }
 
-            if appState.isGoogleCalendarAuthenticated && !appState.availableEventKitCalendars.isEmpty {
-                Text("Google calendars may appear once from macOS Calendar and once from Muesli's Google connection. Turn off both copies to hide that calendar completely.")
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            if appState.isGoogleCalendarAuthenticated {
-                googleCalendarListLoadStateView
-            }
         }
     }
 
@@ -3438,36 +3312,11 @@ struct SettingsView: View {
         .buttonStyle(.plain)
     }
 
-    @ViewBuilder
-    private var googleCalendarListLoadStateView: some View {
-        switch appState.googleCalendarListLoadState {
-        case .loading:
-            Text("Loading Google calendars…")
-                .font(MuesliTheme.caption())
-                .foregroundStyle(MuesliTheme.textTertiary)
-        case .failed(let message):
-            HStack(spacing: 8) {
-                Text("Failed to load Google calendars: \(message)")
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                Button("Retry") {
-                    Task { await controller.refreshGoogleCalendarList() }
-                }
-                .buttonStyle(.link)
-                .font(MuesliTheme.caption())
-            }
-        case .idle, .loaded:
-            EmptyView()
-        }
-    }
-
     private func refreshMeetingCalendarSourcesIfNeeded() {
         guard !hasRefreshedMeetingCalendarSources else { return }
         hasRefreshedMeetingCalendarSources = true
         Task {
-            async let eventKitRefresh: Void = controller.refreshAvailableEventKitCalendars()
-            async let googleRefresh: Void = controller.refreshGoogleCalendarList()
-            _ = await (eventKitRefresh, googleRefresh)
+            await controller.refreshAvailableEventKitCalendars()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -511,8 +511,7 @@ struct SettingsView: View {
                 refreshPermissionStatuses(for: .appActivated)
                 if selectedPane == .meetings {
                     Task {
-                        await controller.refreshAvailableEventKitCalendars()
-                        await controller.refreshUpcomingCalendarEvents()
+                        await controller.calendarAccessDidChange()
                     }
                 }
             }
@@ -3217,8 +3216,7 @@ struct SettingsView: View {
         return VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
             if sourceGroups.isEmpty {
                 CalendarAccessControl {
-                    await controller.refreshAvailableEventKitCalendars()
-                    await controller.refreshUpcomingCalendarEvents()
+                    await controller.calendarAccessDidChange()
                 }
                 Text("No calendars found. Add an account in macOS Internet Accounts and turn on Calendars, or open Calendar to manage local calendars and subscriptions.")
                     .font(MuesliTheme.caption())

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -3215,7 +3215,7 @@ struct SettingsView: View {
         let sourceGroups = calendarSourceGroups
         return VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
             if sourceGroups.isEmpty {
-                CalendarAccessControl {
+                CalendarAccessControl(refreshOnActivation: false) {
                     await controller.calendarAccessDidChange()
                 }
                 Text("No calendars found. Add an account in macOS Internet Accounts and turn on Calendars, or open Calendar to manage local calendars and subscriptions.")

--- a/native/MuesliNative/Tests/MuesliTests/CalendarEventQueryTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CalendarEventQueryTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Calendar event background queries")
+@MainActor
+struct CalendarEventQueryTests {
+    /// A controllable synchronous query, independent of calendar accounts and permissions.
+    private final class Gate: @unchecked Sendable {
+        let started: AsyncStream<Void>
+        let signal: AsyncStream<Void>.Continuation
+        let release = DispatchSemaphore(value: 0)
+        init() {
+            (started, signal) = AsyncStream<Void>.makeStream()
+        }
+        func read() -> [UnifiedCalendarEvent] {
+            #expect(!Thread.isMainThread)
+            signal.yield(())
+            #expect(release.wait(timeout: .now() + 10) == .success)
+            return []
+        }
+        func waitUntilStarted() async {
+            var iterator = started.makeAsyncIterator()
+            _ = await iterator.next()
+        }
+    }
+
+    @Test("query work runs off the main thread and returns events")
+    func backgroundRead() async {
+        let query = CalendarEventQuery()
+        let result = await query.load {
+            #expect(!Thread.isMainThread)
+            return [UnifiedCalendarEvent(id: "new", title: "Meeting", startDate: .distantPast,
+                                         endDate: .distantFuture, isAllDay: false, source: .eventKit)]
+        }
+        #expect(result?.events.map(\.id) == ["new"])
+    }
+
+    @Test("an older overlapping query cannot replace the newest result")
+    func overlappingReads() async {
+        let query = CalendarEventQuery()
+        let gate = Gate()
+        let older = Task { await query.load { gate.read() } }
+        await gate.waitUntilStarted()
+        let latest = await query.load {
+            [UnifiedCalendarEvent(id: "latest", title: "Updated", startDate: .distantPast,
+                                  endDate: .distantFuture, isAllDay: false, source: .eventKit)]
+        }
+        gate.release.signal()
+        #expect(await older.value == nil)
+        #expect(latest?.events.map(\.id) == ["latest"])
+    }
+
+    @Test("a completed result becomes stale before delayed publication")
+    func delayedPublication() async throws {
+        let query = CalendarEventQuery()
+        let earlier = try #require(await query.load { [] })
+        #expect(query.isCurrent(earlier))
+        let latest = try #require(await query.load { [] })
+        #expect(!query.isCurrent(earlier))
+        #expect(query.isCurrent(latest))
+    }
+
+    @Test("cancelled or invalidated reads cannot publish their result", arguments: [false, true])
+    func cancelledReads(invalidate: Bool) async {
+        let query = CalendarEventQuery()
+        let gate = Gate()
+        let task = Task { await query.load { gate.read() } }
+        await gate.waitUntilStarted()
+        if invalidate { query.invalidate() } else { task.cancel() }
+        gate.release.signal()
+        #expect(await task.value == nil)
+        #expect(await query.load { [] } != nil)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/CalendarMonitorLifecycleTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CalendarMonitorLifecycleTests.swift
@@ -1,0 +1,108 @@
+import EventKit
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Calendar monitor authorization and lifecycle")
+@MainActor
+struct CalendarMonitorLifecycleTests {
+    @MainActor
+    private final class Harness {
+        let store = EKEventStore()
+        let center = NotificationCenter()
+        var status: EKAuthorizationStatus = .fullAccess
+        var callbacks: [@Sendable (Bool, Error?) -> Void] = []
+        var changes = 0
+        lazy var monitor = CalendarMonitor(
+            store: store,
+            authorizationStatus: { [weak self] in self?.status ?? .denied },
+            requestAccess: { [weak self] in self?.callbacks.append($0) },
+            notificationCenter: center
+        )
+        func postChange() { center.post(name: .EKEventStoreChanged, object: store) }
+        func drainCallbacks() async {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
+    }
+
+    @Test("without read access start never prompts and can start after a grant",
+          arguments: [EKAuthorizationStatus.notDetermined, .restricted, .denied, .writeOnly])
+    func deniedThenGranted(status: EKAuthorizationStatus) async {
+        let h = Harness()
+        h.status = status
+        h.monitor.onCalendarChanged = { [weak h] in h?.changes += 1 }
+        h.monitor.start()
+        h.monitor.start()
+        h.postChange()
+        #expect(h.callbacks.isEmpty)
+        #expect(h.changes == 0)
+        h.status = .fullAccess
+        h.monitor.start()
+        #expect(h.callbacks.count == 1)
+        h.callbacks[0](true, nil)
+        await h.drainCallbacks()
+        h.postChange()
+        #expect(h.changes == 1)
+        h.monitor.stop()
+    }
+
+    @Test("repeated starts do bounded work and stop removes the observer")
+    func repeatedStartAndStop() async {
+        let h = Harness()
+        h.monitor.onCalendarChanged = { [weak h] in h?.changes += 1 }
+        h.monitor.start()
+        h.monitor.start()
+        #expect(h.callbacks.count == 1)
+        h.callbacks[0](true, nil)
+        await h.drainCallbacks()
+        h.monitor.start()
+        h.postChange()
+        #expect(h.callbacks.count == 1)
+        #expect(h.changes == 1)
+        h.monitor.stop()
+        h.postChange()
+        #expect(h.changes == 1)
+    }
+
+    @Test("a stale callback cannot restart a stopped or newer monitor")
+    func staleCallback() async {
+        let h = Harness()
+        h.monitor.onCalendarChanged = { [weak h] in h?.changes += 1 }
+        h.monitor.start()
+        h.monitor.stop()
+        h.monitor.start()
+        #expect(h.callbacks.count == 2)
+        h.callbacks[0](true, nil)
+        await h.drainCallbacks()
+        h.postChange()
+        #expect(h.changes == 0)
+        h.callbacks[1](true, nil)
+        await h.drainCallbacks()
+        h.postChange()
+        #expect(h.changes == 1)
+        h.monitor.stop()
+    }
+
+    @Test("failed or revoked access does not register and permits a later retry",
+          arguments: [false, true])
+    func failedOrRevoked(revoked: Bool) async {
+        let h = Harness()
+        h.monitor.onCalendarChanged = { [weak h] in h?.changes += 1 }
+        h.monitor.start()
+        if revoked { h.status = .denied }
+        h.callbacks[0](revoked, nil)
+        await h.drainCallbacks()
+        h.postChange()
+        #expect(h.changes == 0)
+        h.status = .fullAccess
+        h.monitor.start()
+        #expect(h.callbacks.count == 2)
+        h.callbacks[1](true, nil)
+        await h.drainCallbacks()
+        h.postChange()
+        #expect(h.changes == 1)
+        h.monitor.stop()
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
@@ -86,19 +86,27 @@ struct OnboardingFlowTests {
 
     @Test("meetings orders meetings-only steps")
     func meetingsOrderedSteps() {
-        #expect(OnboardingFlow.orderedSteps(for: .meetings) == [0, 1, 3, 5, 6])
+        #expect(OnboardingFlow.orderedSteps(for: .meetings) == [0, 1, 3, 5])
     }
 
     @Test("dictation and meetings orders combined steps")
     func dictationAndMeetingsOrderedSteps() {
-        #expect(OnboardingFlow.orderedSteps(for: .dictationAndMeetings) == [0, 1, 2, 3, 4, 5, 6])
+        #expect(OnboardingFlow.orderedSteps(for: .dictationAndMeetings) == [0, 1, 2, 3, 4, 5])
     }
 
     @Test("multi-select unions include every required workflow step")
     func multiSelectUnionOrderedSteps() {
-        #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndMeetings) == [0, 1, 2, 3, 4, 5, 6])
+        #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndMeetings) == [0, 1, 2, 3, 4, 5])
         #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndDictation) == [0, 1, 2, 3, 4])
-        #expect(OnboardingFlow.orderedSteps(for: .everything) == [0, 1, 2, 3, 4, 5, 6])
+        #expect(OnboardingFlow.orderedSteps(for: .everything) == [0, 1, 2, 3, 4, 5])
+    }
+
+    @Test("restored Google calendar step returns to the final meeting setup step")
+    func restoredRemovedCalendarStep() {
+        for useCase: OnboardingUseCase in [.meetings, .dictationAndMeetings, .voiceNotesAndMeetings, .everything] {
+            #expect(OnboardingFlow.normalizedStep(6, for: useCase) == OnboardingFlow.Step.meetingSummary.rawValue)
+            #expect(OnboardingFlow.orderedSteps(for: useCase).last == OnboardingFlow.Step.meetingSummary.rawValue)
+        }
     }
 
     @Test("normalized step advances over skipped steps")

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
@@ -86,26 +86,26 @@ struct OnboardingFlowTests {
 
     @Test("meetings orders meetings-only steps")
     func meetingsOrderedSteps() {
-        #expect(OnboardingFlow.orderedSteps(for: .meetings) == [0, 1, 3, 5])
+        #expect(OnboardingFlow.orderedSteps(for: .meetings) == [0, 1, 3, 5, 6])
     }
 
     @Test("dictation and meetings orders combined steps")
     func dictationAndMeetingsOrderedSteps() {
-        #expect(OnboardingFlow.orderedSteps(for: .dictationAndMeetings) == [0, 1, 2, 3, 4, 5])
+        #expect(OnboardingFlow.orderedSteps(for: .dictationAndMeetings) == [0, 1, 2, 3, 4, 5, 6])
     }
 
     @Test("multi-select unions include every required workflow step")
     func multiSelectUnionOrderedSteps() {
-        #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndMeetings) == [0, 1, 2, 3, 4, 5])
+        #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndMeetings) == [0, 1, 2, 3, 4, 5, 6])
         #expect(OnboardingFlow.orderedSteps(for: .voiceNotesAndDictation) == [0, 1, 2, 3, 4])
-        #expect(OnboardingFlow.orderedSteps(for: .everything) == [0, 1, 2, 3, 4, 5])
+        #expect(OnboardingFlow.orderedSteps(for: .everything) == [0, 1, 2, 3, 4, 5, 6])
     }
 
-    @Test("restored Google calendar step returns to the final meeting setup step")
+    @Test("restored calendar step uses macOS calendar access")
     func restoredRemovedCalendarStep() {
         for useCase: OnboardingUseCase in [.meetings, .dictationAndMeetings, .voiceNotesAndMeetings, .everything] {
-            #expect(OnboardingFlow.normalizedStep(6, for: useCase) == OnboardingFlow.Step.meetingSummary.rawValue)
-            #expect(OnboardingFlow.orderedSteps(for: useCase).last == OnboardingFlow.Step.meetingSummary.rawValue)
+            #expect(OnboardingFlow.normalizedStep(6, for: useCase) == OnboardingFlow.Step.calendarAccess.rawValue)
+            #expect(OnboardingFlow.orderedSteps(for: useCase).last == OnboardingFlow.Step.calendarAccess.rawValue)
         }
     }
 

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -134,6 +134,7 @@ case "${shard}" in
       MeetingTemplateResolutionTests
       MeetingTemplatesDefaultFallbackTests
       RouteAwareMeetingMicRecorderTests
+      CalendarEventQueryTests
       CalendarMonitorLifecycleTests
       DisabledCalendarFilterTests
       GoogleCalendarTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -134,6 +134,7 @@ case "${shard}" in
       MeetingTemplateResolutionTests
       MeetingTemplatesDefaultFallbackTests
       RouteAwareMeetingMicRecorderTests
+      CalendarMonitorLifecycleTests
       DisabledCalendarFilterTests
       GoogleCalendarTests
     )


### PR DESCRIPTION
Muesli now uses macOS Calendar accounts exclusively. Direct Google Calendar sign-in, settings controls, and background API fetching are removed; Google accounts configured through macOS remain supported.

Settings → Meetings → Calendars adds **Manage accounts…** (macOS Internet Accounts), **Open Calendar…**, grouped calendar cards using the native Calendar app icon, and refresh on returning from System Settings. Existing visibility selections and stored history remain intact. Individual calendars are managed in Apple Calendar; accounts are managed in macOS.

Meeting onboarding now offers optional macOS Calendar access, account setup, and a path to Privacy settings after denial. Choosing **Not now** does not trigger a background permission prompt. Granting access immediately starts event monitoring when meeting features are enabled, without waiting for the fallback timer. Synchronous EventKit event reads run on a detached utility task. Generation checks reject outdated results, and cancellation or monitor shutdown prevents pending results from publishing. Existing date-window and calendar-selection checks remain in place. The README documents setup, account ownership, permissions, and EventKit integration.

Validation:
- 101 focused tests across seven calendar/onboarding suites passed, including off-main-thread execution, overlapping reads, delayed publication, and cancellation/invalidation; existing coverage includes including permission denial, grant, repeated starts, observer removal on stop, stale callback cancellation, and revocation during a pending access request. 93 tests passed for the preceding direct-Google removal.
- CI shard registration and git diff whitespace checks passed.
- Final MuesliDev build installed and launched using the reusable cache; installed signature and functional LocalVQE checks passed.
- No production release or preproduction build performed. Live account addition/removal and the first-run permission UI were not manually exercised.

Dormant Google API utility code and existing stored credentials are retained for possible future restoration; the app no longer initializes the direct client or fetches through it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791547038&installation_model_id=422865&pr_number=510&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F510&signature=062bdc7d10ce45dceffeb8ccd24b0c32cd78a73bf0455626e6dccb6952f1ec22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Calendar integration using EventKit.
  * Added onboarding and Settings controls for granting access, managing accounts, opening Calendar, and selecting calendars.
  * Added guidance for configuring calendars through macOS Internet Accounts.
* **Changes**
  * Replaced Google Calendar authentication and synchronization with macOS Calendar access.
  * Calendar events now come from configured macOS calendars.
  * Improved calendar permission handling, refresh reliability, and stale-result prevention.
* **Documentation**
  * Updated integration, permissions, setup, technology, and testing documentation for macOS Calendar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Contribution certification

- [x] DCO check passes. The original three commits are covered by remediation commit `7883ea13`; subsequent commits include author sign-off trailers.
- [ ] Author confirmation: I created this contribution or otherwise have the right to submit it under Muesli's MIT License.
- [ ] Author confirmation: I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] All third-party materials introduced by this PR are identified below.
- [x] Material AI assistance is disclosed below; the changes have been reviewed and tested as described in Validation.

The two author-rights declarations remain unchecked because the coding assistant cannot verify external ownership or permission arrangements.

### Third-party materials

No new third-party code, models, datasets, or bundled media. The Calendar app icon is resolved at runtime from the user's macOS installation via NSWorkspace; no Apple icon asset is copied into the repository or distributed with this change. Existing Apple EventKit/AppKit APIs are used for calendar access and account-management links.

### AI assistance

OpenAI Codex assisted with implementation, README updates, review triage, regression tests, and local build verification. OpenAI image generation produced the design mockup used as a reference; generated mockups are not included in this PR. Automated Claude and CodeRabbit reviews informed the follow-up changes. Live account addition/removal and first-run macOS permission dialogs have not been manually exercised.

