### PR TITLE
Update release metadata for v0.8.4

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -9,49 +9,16 @@
             <title>0.8.4</title>
             <pubDate>Thu, 10 Sep 2026 04:14:59 +0530</pubDate>
             <description><![CDATA[
-<h2>Muesli 0.8.4</h2>
-<p>Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, improved meeting workflows, and clearer macOS calendar setup. It also repairs private iCloud text sync for legacy libraries created by 0.8.2 or left unmatched after upgrading to 0.8.3.</p>
-<h2>Quill voice rewriting</h2>
+<h2>New in Muesli 0.8.4</h2>
 <ul>
-<li>Rewrite selected text with a spoken instruction, or generate text at the cursor without a selection.</li>
-<li>Choose a local or hosted model in the dedicated Models → Quill section, with prompts to download missing local models or sign in when needed.</li>
-<li>Improves ChatGPT compatibility and pasting into Google Docs.</li>
-<li>When dictation and Quill use the same compatible Gemma model, process the audio instruction in one model pass.</li>
+<li>Use Quill to rewrite selected text or generate text with spoken instructions.</li>
+<li>Adds Bodhan for Indic languages, improved Parakeet and Qwen3 options, English S1-mini cleanup, and optional OpenAI/OpenRouter dictation.</li>
+<li>Use Apple Speech live meeting transcription on macOS 26+, and re-summarize saved meetings with another model.</li>
+<li>Manage connected macOS calendars with clearer account links and optional onboarding access.</li>
+<li>Recover legacy iCloud sync connections with clearer setup and recovery controls.</li>
+<li>Enjoy more reliable audio capture, downloads, permissions, pasting, and refreshed interface layouts.</li>
 </ul>
-<h2>More transcription and cleanup choices</h2>
-<ul>
-<li>Adds Bodhan Core and Flex for Indic and English speech, with FP16 and INT8 downloads on macOS 15 or later.</li>
-<li>Adds Qwen3 ASR and optional hosted dictation through OpenAI or OpenRouter.</li>
-<li>Adds S1-mini as a local cleanup option and clearer setup for missing cleanup models.</li>
-<li>Improves model compatibility guidance and multilingual sentence spacing.</li>
-</ul>
-<h2>Meetings and everyday workflows</h2>
-<ul>
-<li>Adds Apple Speech live meeting transcription on macOS 26 or later. Live transcription remains off by default.</li>
-<li>Re-summarize a saved meeting using a different summary model.</li>
-<li>Improves microphone and system-audio capture reliability, recording attribution, and push-to-talk behavior around meetings.</li>
-<li>Adds Apple Shortcuts and Siri actions for dictation, meeting recording, and retrieving the latest text.</li>
-<li>Makes Check for Updates available from the application menu and adds a guided What’s New tour.</li>
-</ul>
-<h2>Calendar setup through macOS</h2>
-<ul>
-<li>Uses calendars connected to macOS, including iCloud, Google, and Exchange accounts. Direct Google Calendar sign-in in Muesli is unavailable for now.</li>
-<li>Adds Manage accounts and Open Calendar actions, grouped calendar cards, and per-calendar visibility controls.</li>
-<li>Offers optional Calendar access during onboarding. Choosing Not now does not trigger a background permission prompt.</li>
-<li>Refreshes account changes when returning to Muesli, with background event queries that keep the interface responsive.</li>
-</ul>
-<h2>Reliable iPhone sync recovery</h2>
-<ul>
-<li>Replaces the internal CloudKit error shown by 0.8.3 with a clear, actionable reconnection state.</li>
-<li>Reconnects detected legacy libraries to the current iCloud account while reserving the explicit “Reset iCloud sync” flow for manual recovery on the same iCloud account.</li>
-<li>Makes the sync switch respond on the first click and prevents repeated clicks from restarting iCloud setup.</li>
-<li>Waits for QR device confirmation before the first text transfer and keeps setup in a clear “finishing sync” state.</li>
-<li>Adds a one-click iCloud sync control to the Timeline, Dictations, and Meetings dashboards, with an animated in-progress state.</li>
-<li>Preserves local dictations, meeting transcripts, notes, timestamps, and audio while replacing only obsolete CloudKit state and requeueing eligible text.</li>
-<li>Keeps confirmed Production-account boundaries fail-closed. Reset rebuilds local sync state for the same iCloud account; it is not an account-migration or content-transfer flow. Local history and audio remain intact and CloudKit data is not deleted.</li>
-<li>Makes reconnection safe to retry if setup is interrupted.</li>
-</ul>
-<p>iCloud sync transfers only text records and their sync metadata; audio remains local to each device. Dictation and meeting transcription are local by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected.</p>
+<p>Dictation and meeting transcription remain local by default. Live meeting transcription is off by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected. iCloud sync transfers text and sync metadata, not audio.</p>
 ]]></description>
             <sparkle:version>0.8.4</sparkle:version>
             <sparkle:shortVersionString>0.8.4</sparkle:shortVersionString>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,60 @@
         <language>en</language>
         <!-- Items are added by generate_appcast or the release script -->
         <item>
+            <title>0.8.4</title>
+            <pubDate>Thu, 10 Sep 2026 04:14:59 +0530</pubDate>
+            <description><![CDATA[
+<h2>Muesli 0.8.4</h2>
+<p>Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, improved meeting workflows, and clearer macOS calendar setup. It also repairs private iCloud text sync for legacy libraries created by 0.8.2 or left unmatched after upgrading to 0.8.3.</p>
+<h2>Quill voice rewriting</h2>
+<ul>
+<li>Rewrite selected text with a spoken instruction, or generate text at the cursor without a selection.</li>
+<li>Choose a local or hosted model in the dedicated Models → Quill section, with prompts to download missing local models or sign in when needed.</li>
+<li>Improves ChatGPT compatibility and pasting into Google Docs.</li>
+<li>When dictation and Quill use the same compatible Gemma model, process the audio instruction in one model pass.</li>
+</ul>
+<h2>More transcription and cleanup choices</h2>
+<ul>
+<li>Adds Bodhan Core and Flex for Indic and English speech, with FP16 and INT8 downloads on macOS 15 or later.</li>
+<li>Adds Qwen3 ASR and optional hosted dictation through OpenAI or OpenRouter.</li>
+<li>Adds S1-mini as a local cleanup option and clearer setup for missing cleanup models.</li>
+<li>Improves model compatibility guidance and multilingual sentence spacing.</li>
+</ul>
+<h2>Meetings and everyday workflows</h2>
+<ul>
+<li>Adds Apple Speech live meeting transcription on macOS 26 or later. Live transcription remains off by default.</li>
+<li>Re-summarize a saved meeting using a different summary model.</li>
+<li>Improves microphone and system-audio capture reliability, recording attribution, and push-to-talk behavior around meetings.</li>
+<li>Adds Apple Shortcuts and Siri actions for dictation, meeting recording, and retrieving the latest text.</li>
+<li>Makes Check for Updates available from the application menu and adds a guided What’s New tour.</li>
+</ul>
+<h2>Calendar setup through macOS</h2>
+<ul>
+<li>Uses calendars connected to macOS, including iCloud, Google, and Exchange accounts. Direct Google Calendar sign-in in Muesli is unavailable for now.</li>
+<li>Adds Manage accounts and Open Calendar actions, grouped calendar cards, and per-calendar visibility controls.</li>
+<li>Offers optional Calendar access during onboarding. Choosing Not now does not trigger a background permission prompt.</li>
+<li>Refreshes account changes when returning to Muesli, with background event queries that keep the interface responsive.</li>
+</ul>
+<h2>Reliable iPhone sync recovery</h2>
+<ul>
+<li>Replaces the internal CloudKit error shown by 0.8.3 with a clear, actionable reconnection state.</li>
+<li>Reconnects detected legacy libraries to the current iCloud account while reserving the explicit “Reset iCloud sync” flow for manual recovery on the same iCloud account.</li>
+<li>Makes the sync switch respond on the first click and prevents repeated clicks from restarting iCloud setup.</li>
+<li>Waits for QR device confirmation before the first text transfer and keeps setup in a clear “finishing sync” state.</li>
+<li>Adds a one-click iCloud sync control to the Timeline, Dictations, and Meetings dashboards, with an animated in-progress state.</li>
+<li>Preserves local dictations, meeting transcripts, notes, timestamps, and audio while replacing only obsolete CloudKit state and requeueing eligible text.</li>
+<li>Keeps confirmed Production-account boundaries fail-closed. Reset rebuilds local sync state for the same iCloud account; it is not an account-migration or content-transfer flow. Local history and audio remain intact and CloudKit data is not deleted.</li>
+<li>Makes reconnection safe to retry if setup is interrupted.</li>
+</ul>
+<p>iCloud sync transfers only text records and their sync metadata; audio remains local to each device. Dictation and meeting transcription are local by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected.</p>
+]]></description>
+            <sparkle:version>0.8.4</sparkle:version>
+            <sparkle:shortVersionString>0.8.4</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.4/Muesli-0.8.4.dmg" length="102857825" type="application/octet-stream" sparkle:edSignature="qfyNtlV+JjouZRn7IlBrWd4MVt/6ZzVe/2WHiuf9gJDbTAh89+1TACbBs2eYt6j6YZYi2CESt0iTeNVBpERXDQ=="/>
+        </item>
+        <item>
             <title>0.8.3</title>
             <pubDate>Tue, 18 Aug 2026 18:44:18 +0530</pubDate>
             <description><![CDATA[

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > Local-first AI dictation and meeting transcriber for macOS.
 
-Muesli is a free, open-source macOS application that provides hold-to-talk dictation and meeting transcription powered by on-device AI inference. All speech-to-text runs locally on Apple Silicon — no cloud required for core functionality.
+Muesli is a free, open-source macOS application that provides hold-to-talk dictation and meeting transcription powered by on-device AI inference. Speech-to-text runs locally on Apple Silicon by default, with optional hosted dictation providers. No cloud is required for core functionality.
 
 ## Features
 
@@ -10,7 +10,7 @@ Muesli is a free, open-source macOS application that provides hold-to-talk dicta
 - **Meeting Transcription**: Records mic + system audio, merges into a timestamped transcript
 - **Meeting Notes**: Optional AI-generated structured summaries (BYOK OpenAI/OpenRouter)
 - **Local-First**: Core transcription runs entirely on-device via Fluid Audio / CoreML
-- **Privacy**: Audio never leaves your Mac unless you opt into cloud summarization
+- **Privacy**: Audio stays local by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected. iCloud sync transfers text and sync metadata, not audio
 - **Free & Open Source**: MIT licensed, no subscriptions, no usage limits
 
 ## Technical Details
@@ -33,11 +33,11 @@ Muesli is a free, open-source macOS application that provides hold-to-talk dicta
 
 Muesli is a menu bar app with two modes:
 
-1. **Dictation Mode**: User holds Left Cmd key → mic records → on release, audio is transcribed locally → text is pasted at the active cursor position via accessibility APIs.
+1. **Dictation Mode**: User holds Left Cmd key → mic records → on release, audio is transcribed locally by default or by the selected hosted provider → text is pasted at the active cursor position via accessibility APIs.
 
 2. **Meeting Mode**: User starts recording from menu bar → mic captures "You" audio, system audio captures "Others" → both are transcribed → segments are merged by timestamp → optional LLM summarization produces structured notes → everything stored in local SQLite.
 
-The app uses Fluid Audio's CoreML models running on the Apple Neural Engine for speech-to-text, minimizing CPU/GPU usage. Optional cloud integration (OpenAI, OpenRouter) is available for meeting note summarization only, using bring-your-own-key configuration.
+The app uses Fluid Audio's CoreML models running on the Apple Neural Engine for speech-to-text, minimizing CPU/GPU usage. Optional hosted providers are available for dictation, cleanup, Quill, and meeting summaries when configured by the user.
 
 ## Author
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -25,7 +25,7 @@ Muesli is a free, open-source macOS application that provides hold-to-talk dicta
 
 - Website: https://freedspeech.xyz
 - GitHub: https://github.com/Muesli-HQ/muesli
-- Download: https://github.com/Muesli-HQ/muesli/releases/download/v0.8.3/Muesli-0.8.3.dmg
+- Download: https://github.com/Muesli-HQ/muesli/releases/download/v0.8.4/Muesli-0.8.4.dmg
 - Support: https://buymeacoffee.com/phequals7
 - License: MIT
 

--- a/docs/release-notes/0.8.4.md
+++ b/docs/release-notes/0.8.4.md
@@ -11,9 +11,12 @@ Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, i
 
 ## More transcription and cleanup choices
 
-- Adds Bodhan Core and Flex for Indic and English speech, with FP16 and INT8 downloads on macOS 15 or later.
-- Adds Qwen3 ASR and optional hosted dictation through OpenAI or OpenRouter.
-- Adds S1-mini as a local cleanup option and clearer setup for missing cleanup models.
+- Adds Bodhan for Indic languages.
+- Improves Qwen3 language selection, downloads, and installation reliability.
+- Adds Parakeet Unified and a language/script filter.
+- Adds optional hosted dictation through OpenAI or OpenRouter.
+- Adds S1-mini for English cleanup and clearer setup for missing cleanup models.
+- Improves model-download fallback and recovery after interruptions.
 - Improves model compatibility guidance and multilingual sentence spacing.
 
 ## Meetings and everyday workflows
@@ -23,6 +26,14 @@ Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, i
 - Improves microphone and system-audio capture reliability, recording attribution, and push-to-talk behavior around meetings.
 - Adds Apple Shortcuts and Siri actions for dictation, meeting recording, and retrieving the latest text.
 - Makes Check for Updates available from the application menu and adds a guided What’s New tour.
+- Adds configurable meeting-join actions and recognition of Slack huddle links.
+- Retains meeting visual context across resumed sessions and makes it available through the CLI.
+
+## Easier setup and a refreshed interface
+
+- Adds guided Accessibility and Input Monitoring setup and fixes push-to-talk availability after meetings-only onboarding.
+- Improves ChatGPT and OpenRouter sign-in and model controls.
+- Refines dashboard layouts, compact meeting windows, floating-pill interactions, and light-theme window appearance.
 
 ## Calendar setup through macOS
 
@@ -33,13 +44,9 @@ Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, i
 
 ## Reliable iPhone sync recovery
 
-- Replaces the internal CloudKit error shown by 0.8.3 with a clear, actionable reconnection state.
-- Reconnects detected legacy libraries to the current iCloud account while reserving the explicit “Reset iCloud sync” flow for manual recovery on the same iCloud account.
-- Makes the sync switch respond on the first click and prevents repeated clicks from restarting iCloud setup.
-- Waits for QR device confirmation before the first text transfer and keeps setup in a clear “finishing sync” state.
-- Adds a one-click iCloud sync control to the Timeline, Dictations, and Meetings dashboards, with an animated in-progress state.
-- Preserves local dictations, meeting transcripts, notes, timestamps, and audio while replacing only obsolete CloudKit state and requeueing eligible text.
-- Keeps confirmed Production-account boundaries fail-closed. Reset rebuilds local sync state for the same iCloud account; it is not an account-migration or content-transfer flow. Local history and audio remain intact and CloudKit data is not deleted.
-- Makes reconnection safe to retry if setup is interrupted.
+- Repairs legacy iCloud reconnection with clearer setup, recovery, and progress states.
+- Adds one-click dashboard sync controls and coordinates the first transfer with device-pairing confirmation.
+- Makes interrupted setup and recovery safer to retry while preserving local history and audio.
+- Keeps recovery within the confirmed iCloud account boundary. Reset rebuilds local sync state for the same account; it does not migrate accounts or delete CloudKit data.
 
 iCloud sync transfers only text records and their sync metadata; audio remains local to each device. Dictation and meeting transcription are local by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected.

--- a/docs/release-notes/0.8.4.md
+++ b/docs/release-notes/0.8.4.md
@@ -47,6 +47,6 @@ Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, i
 - Repairs legacy iCloud reconnection with clearer setup, recovery, and progress states.
 - Adds one-click dashboard sync controls and coordinates the first transfer with device-pairing confirmation.
 - Makes interrupted setup and recovery safer to retry while preserving local history and audio.
-- Keeps recovery within the confirmed iCloud account boundary. Reset rebuilds local sync state for the same account; it does not migrate accounts or delete CloudKit data.
+- Automatic recovery respects the confirmed iCloud account boundary. After an explicit reset, setup can link the currently signed-in account, preserving local text and audio and re-queuing text for sync. This does not migrate or delete existing CloudKit data.
 
 iCloud sync transfers only text records and their sync metadata; audio remains local to each device. Dictation and meeting transcription are local by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected.

--- a/docs/release-notes/0.8.4.md
+++ b/docs/release-notes/0.8.4.md
@@ -1,6 +1,35 @@
 ## Muesli 0.8.4
 
-Muesli 0.8.4 repairs private iCloud text sync for legacy libraries created by 0.8.2 or left unmatched after upgrading to 0.8.3.
+Muesli 0.8.4 adds voice-driven writing with Quill, more transcription choices, improved meeting workflows, and clearer macOS calendar setup. It also repairs private iCloud text sync for legacy libraries created by 0.8.2 or left unmatched after upgrading to 0.8.3.
+
+## Quill voice rewriting
+
+- Rewrite selected text with a spoken instruction, or generate text at the cursor without a selection.
+- Choose a local or hosted model in the dedicated Models → Quill section, with prompts to download missing local models or sign in when needed.
+- Improves ChatGPT compatibility and pasting into Google Docs.
+- When dictation and Quill use the same compatible Gemma model, process the audio instruction in one model pass.
+
+## More transcription and cleanup choices
+
+- Adds Bodhan Core and Flex for Indic and English speech, with FP16 and INT8 downloads on macOS 15 or later.
+- Adds Qwen3 ASR and optional hosted dictation through OpenAI or OpenRouter.
+- Adds S1-mini as a local cleanup option and clearer setup for missing cleanup models.
+- Improves model compatibility guidance and multilingual sentence spacing.
+
+## Meetings and everyday workflows
+
+- Adds Apple Speech live meeting transcription on macOS 26 or later. Live transcription remains off by default.
+- Re-summarize a saved meeting using a different summary model.
+- Improves microphone and system-audio capture reliability, recording attribution, and push-to-talk behavior around meetings.
+- Adds Apple Shortcuts and Siri actions for dictation, meeting recording, and retrieving the latest text.
+- Makes Check for Updates available from the application menu and adds a guided What’s New tour.
+
+## Calendar setup through macOS
+
+- Uses calendars connected to macOS, including iCloud, Google, and Exchange accounts. Direct Google Calendar sign-in in Muesli is unavailable for now.
+- Adds Manage accounts and Open Calendar actions, grouped calendar cards, and per-calendar visibility controls.
+- Offers optional Calendar access during onboarding. Choosing Not now does not trigger a background permission prompt.
+- Refreshes account changes when returning to Muesli, with background event queries that keep the interface responsive.
 
 ## Reliable iPhone sync recovery
 
@@ -13,4 +42,4 @@ Muesli 0.8.4 repairs private iCloud text sync for legacy libraries created by 0.
 - Keeps confirmed Production-account boundaries fail-closed. Reset rebuilds local sync state for the same iCloud account; it is not an account-migration or content-transfer flow. Local history and audio remain intact and CloudKit data is not deleted.
 - Makes reconnection safe to retry if setup is interrupted.
 
-Audio remains local to each device. Only text records and their sync metadata use private iCloud.
+iCloud sync transfers only text records and their sync metadata; audio remains local to each device. Dictation and meeting transcription are local by default. Optional hosted dictation sends audio to the selected provider; hosted cleanup, Quill, and summaries send the input needed for those features when selected.

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -412,6 +412,9 @@ struct MeetingStreamingPartialSessionTests {
         await session.connect()
 
         for index in 0..<(MeetingStreamingPartialSession.maxFrozenSegments + 2) {
+            // Queued audio is processed only after the preceding restart finishes.
+            session.enqueue(samples(chunkCount: 1))
+            #expect(await waitUntil { engine.processCalls == index + 1 })
             engine.emit("[segment\(index)]")
             #expect(await waitUntil { collector.latest?.contains("[segment\(index)]") == true })
             session.markSegmentBoundary(id: UUID())

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
@@ -214,6 +214,8 @@ struct RouteAwareMeetingMicRecorderTests {
         try await waitUntil { recorder.activeRecorderKindForDebug() == .appScoped }
         try await waitUntil { samples == [[1], [2]] }
 
+        // Audio promotion precedes retirement on the separate cleanup queue.
+        try await waitUntil { system.stopCalls == 1 && system.cancelCalls == 1 }
         #expect(samples == [[1], [2]])
         #expect(system.stopCalls == 1)
         #expect(system.cancelCalls == 1)
@@ -677,6 +679,7 @@ struct RouteAwareMeetingMicRecorderTests {
 
         replacement.onRawPCMSamples?([4, 5, 6])
         try await waitUntil { samples == [[4, 5, 6]] }
+        try await waitUntil { degraded.stopCalls == 1 && degraded.cancelCalls == 1 }
         #expect(degraded.stopCalls == 1)
         #expect(recorder.activeRecorderKindForDebug() == .appScoped)
     }


### PR DESCRIPTION
## Summary

Publish the 0.8.4 Sparkle update entry and align the download links and release notes with the verified GitHub release. The production update feed remains on 0.8.3 until this PR is merged and GitHub Pages deploys it.

The release includes Quill and model setup improvements, additional transcription and cleanup options, meeting workflow fixes, macOS-only calendar management, and iCloud recovery improvements.

The microphone handoff tests now wait for asynchronous recorder retirement before checking cleanup counts; the original assertions remain intact. Release notes also clarify explicit iCloud reset behavior.

## Validation

- Caption segment-bound test waits for queued audio to reach the engine after restart before emitting text; timeout and retention assertions are unchanged. All 42 caption tests and all 558 meetings-shard tests passed.

- Focused microphone handoff suite: 28 tests passed after the cleanup-wait fix.

- Full canonical release suite: 2,115 tests in 194 suites passed.
- Source main CI passed, including release build and ci-gate.
- Final app and DMG accepted by Apple, stapled, and accepted by Gatekeeper.
- Downloaded GitHub DMG checksum matches the local release artifact.
- Signed app and embedded profile verified for com.muesli.app, Production CloudKit, iCloud.com.mueslihq.muesli, and production APNs.
- Complete LocalVQE runtime and packaged model validated, including context creation.
- Sparkle metadata, signature, notarization, and item release notes validated by verify_update_flow.sh.
- Live device-to-device iCloud sync and the interactive update smoke test remain to be performed after deployment. The user explicitly deferred sync testing until the release is running.

## Contribution certification

- [x] Every non-merge commit has a valid Signed-off-by trailer from its author.
- [ ] I created this contribution or otherwise have the right to submit it under Muesli’s MIT License.
- [ ] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party materials introduced by this PR.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None added by these metadata and release-note changes.

### AI assistance

Codex prepared release notes and metadata, supervised the release pipeline, and verified tests, packaged runtime, signing, notarization, and hosted artifacts. Ownership and external-permission declarations remain for the maintainer to confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Quill voice rewriting.
  - Expanded transcription and cleanup options, including hosted dictation and additional language support.
  - Improved meeting and everyday workflow tools.
  - Added macOS calendar integration and more reliable iPhone sync recovery.
  - Added interface updates.
- **Privacy**
  - Clarified that iCloud sync transfers text and metadata while audio remains local.
  - Optional hosted services send input only when selected.
- **Release**
  - Muesli 0.8.4 is available with updated download and automatic-update information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

