### PR TITLE
fix: restore re-transcription for failed meetings with saved audio

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -588,6 +588,13 @@ struct MeetingDetailView: View {
             } else {
                 let isManualNotesEditable = canEditManualNotes(for: meeting)
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                    if meeting.status == .failed || isRetranscribing {
+                        HStack {
+                            Spacer()
+                            retranscribeAction(for: meeting)
+                        }
+                    }
+
                     if !usesCompactQuickNotes {
                         manualNotesToolbar(for: meeting)
                             .disabled(!isManualNotesEditable)
@@ -806,7 +813,8 @@ struct MeetingDetailView: View {
 
     @ViewBuilder
     private func retranscribeAction(for meeting: MeetingRecord) -> some View {
-        if meeting.savedRecordingPath != nil {
+        if let savedRecordingPath = meeting.savedRecordingPath,
+           !savedRecordingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             if isRetranscribing {
                 HStack(spacing: 6) {
                     ProgressView()
@@ -816,10 +824,15 @@ struct MeetingDetailView: View {
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
                 .padding(.horizontal, MuesliTheme.spacing8)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Re-transcribing...")
+                .accessibilityIdentifier("meeting.retranscription.progress")
             } else {
                 iconButton("arrow.clockwise", label: "Re-transcribe") {
                     startRetranscription(for: meeting)
                 }
+                .accessibilityLabel("Re-transcribe")
+                .accessibilityIdentifier("meeting.retranscribe")
                 .disabled(meeting.status == .recording || meeting.status == .processing || isEditingNotes || isEditingTranscript)
             }
         }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -660,8 +660,8 @@ struct MeetingsNavigationTests {
         #expect(try store.meeting(id: meetingID) != nil)
     }
 
-    @Test("retranscribe missing recording preserves completed meeting status")
-    func retranscribeMissingRecordingPreservesCompletedStatus() async throws {
+    @Test("retranscribe missing recording preserves the original meeting", arguments: [MeetingStatus.completed, .failed])
+    func retranscribeMissingRecordingPreservesMeeting(status: MeetingStatus) async throws {
         let store = try makeStore()
         let missingRecordingURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("missing-meeting-recording-\(UUID().uuidString).wav")
@@ -677,6 +677,8 @@ struct MeetingsNavigationTests {
             systemAudioPath: nil,
             savedRecordingPath: missingRecordingURL.path
         )
+        try store.updateMeetingStatus(id: meetingID, status: status)
+        try store.updateMeetingManualNotes(id: meetingID, manualNotes: "Original manual notes")
         let controller = MuesliController(
             runtime: RuntimePaths(
                 repoRoot: FileManager.default.temporaryDirectory,
@@ -698,13 +700,21 @@ struct MeetingsNavigationTests {
         case .success:
             Issue.record("Expected re-transcription to fail when the retained recording is missing")
         case .failure(let error):
-            #expect(error is MeetingRetranscriptionError)
+            guard case MeetingRetranscriptionError.recordingUnavailable = error else {
+                Issue.record("Expected recordingUnavailable, got \(error)")
+                return
+            }
         }
 
         let updated = try #require(try store.meeting(id: meetingID))
-        #expect(updated.status == .completed)
+        #expect(updated.status == status)
+        #expect(updated.id == meeting.id)
+        #expect(updated.title == meeting.title)
         #expect(updated.rawTranscript == "Existing transcript")
         #expect(updated.formattedNotes == "## Existing notes")
+        #expect(updated.manualNotes == "Original manual notes")
+        #expect(updated.savedRecordingPath == missingRecordingURL.path)
+        #expect(try store.meetingCounts().total == 1)
     }
 
     @Test("retranscribe empty transcript restores original meeting status")

--- a/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WindowAppearanceTests.swift
@@ -172,6 +172,76 @@ struct WindowAppearanceTests {
         return lifecycle.appearanceCount > 0
     }
 
+    @Test("failed meetings retain an enabled recovery action and editable manual notes", arguments: [520.0, 900.0])
+    func failedMeetingRecoveryControls(width: Double) async throws {
+        let detail = try MeetingRecoveryDetailHost(width: width)
+        await detail.settle()
+
+        let buttons = detail.elements(identifier: "meeting.retranscribe")
+        #expect(buttons.count == 1)
+        let button = try #require(buttons.first)
+        #expect(button.accessibilityRole() == .button)
+        #expect(button.accessibilityLabel() == "Re-transcribe")
+        #expect(button.isAccessibilityEnabled())
+        #expect(detail.textViews.contains { $0.isEditable && $0.string == "Original manual notes" })
+    }
+
+    @Test("failed meetings without a saved audio path have no recovery action",
+          arguments: [520.0, 900.0], [nil, "", " \n\t "] as [String?])
+    func failedMeetingWithoutAudioHasNoRecovery(width: Double, path: String?) async throws {
+        let detail = try MeetingRecoveryDetailHost(width: width, savedRecordingPath: path)
+        await detail.settle()
+
+        #expect(detail.elements(identifier: "meeting.retranscribe").isEmpty)
+        #expect(detail.elements(identifier: "meeting.retranscription.progress").isEmpty)
+    }
+
+    @Test("completed meetings have one retry and other active or note-only meetings have none",
+          arguments: [520.0, 900.0], [MeetingStatus.completed, .recording, .processing, .noteOnly])
+    func meetingRecoveryDoesNotDuplicateExistingActions(width: Double, status: MeetingStatus) async throws {
+        let detail = try MeetingRecoveryDetailHost(width: width, status: status)
+        await detail.settle()
+
+        let buttons = detail.elements(identifier: "meeting.retranscribe")
+        #expect(buttons.count == (status == .completed ? 1 : 0))
+        #expect(detail.elements(identifier: "meeting.retranscription.progress").isEmpty)
+        if status == .completed {
+            #expect(try #require(buttons.first).isAccessibilityEnabled())
+            let edit = try #require(detail.accessibilityElements.first {
+                $0.accessibilityRole() == .button && $0.accessibilityLabel() == "Edit Notes"
+            })
+            #expect(edit.accessibilityPerformPress())
+            await detail.settle()
+            #expect(try #require(detail.elements(identifier: "meeting.retranscribe").first).isAccessibilityEnabled() == false)
+        }
+    }
+
+    @Test("retry keeps progress visible through processing and restores recovery after failure", arguments: [520.0, 900.0])
+    func meetingRecoveryBusyAndFailureStates(width: Double) async throws {
+        let detail = try MeetingRecoveryDetailHost(width: width)
+        await detail.settle()
+        let button = try #require(detail.elements(identifier: "meeting.retranscribe").first)
+        #expect(button.accessibilityPerformPress())
+
+        // Inspect the synchronous local busy state before the controller's MainActor task runs.
+        detail.hostingView.layoutSubtreeIfNeeded()
+        #expect(detail.elements(identifier: "meeting.retranscribe").isEmpty)
+        #expect(detail.elements(identifier: "meeting.retranscription.progress").count == 1)
+
+        // Publish the same status transition used by the controller without needing a downloaded model.
+        try detail.setStatus(.processing)
+        #expect(detail.elements(identifier: "meeting.retranscribe").isEmpty)
+        #expect(detail.elements(identifier: "meeting.retranscription.progress").count == 1)
+        #expect(detail.textViews.allSatisfy { !$0.isEditable })
+
+        try detail.setStatus(.failed)
+        await detail.settle()
+        #expect(detail.elements(identifier: "meeting.retranscription.progress").isEmpty)
+        #expect(detail.elements(identifier: "meeting.retranscribe").count == 1)
+        #expect(try #require(detail.elements(identifier: "meeting.retranscribe").first).isAccessibilityEnabled())
+        #expect(try detail.store.meeting(id: detail.meetingID)?.status == .failed)
+    }
+
     @Test("dashboard wires the production sidebar toggle and compact meeting header")
     func dashboardWiresProductionSidebarAndCompactMeetingComposition() {
         let supportDirectory = FileManager.default.temporaryDirectory
@@ -236,6 +306,97 @@ struct WindowAppearanceTests {
         #expect(image?.size.height == DashboardWindowLayout.minimumContentHeight)
     }
 
+}
+
+@MainActor
+private final class MeetingRecoveryDetailHost {
+    let store: DictationStore
+    let controller: MuesliController
+    let meetingID: Int64
+    let hostingView: NSHostingView<AnyView>
+    let window: NSWindow
+    private let width: Double
+
+    init(
+        width: Double,
+        status: MeetingStatus = .failed,
+        savedRecordingPath: String? = "/missing/retained-meeting.wav"
+    ) throws {
+        self.width = width
+        let supportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-recovery-view-test-\(UUID().uuidString)", isDirectory: true)
+        store = DictationStore(databaseURL: supportDirectory.appendingPathComponent("muesli.db"))
+        try store.migrateIfNeeded()
+        meetingID = try store.insertMeeting(
+            title: "Retry meeting",
+            calendarEventID: nil,
+            startTime: Date(),
+            endTime: Date(),
+            rawTranscript: "Original transcript",
+            formattedNotes: "## Original notes",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: savedRecordingPath
+        )
+        try store.updateMeetingStatus(id: meetingID, status: status)
+        try store.updateMeetingManualNotes(id: meetingID, manualNotes: "Original manual notes")
+        controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store,
+            configStore: ConfigStore(supportDirectory: supportDirectory)
+        )
+        hostingView = NSHostingView(rootView: AnyView(EmptyView()))
+        hostingView.frame = NSRect(x: 0, y: 0, width: width, height: 790)
+        window = NSWindow(contentRect: hostingView.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = hostingView
+        try setStatus(status)
+    }
+
+    func setStatus(_ status: MeetingStatus) throws {
+        try store.updateMeetingStatus(id: meetingID, status: status)
+        let meeting = try #require(try store.meeting(id: meetingID))
+        hostingView.rootView = AnyView(
+            MeetingDetailView(meeting: meeting, controller: controller, appState: controller.appState)
+                .environment(\.usesCompactQuickNotes, width == 520)
+        )
+        hostingView.layoutSubtreeIfNeeded()
+    }
+
+    func settle() async {
+        for _ in 0..<5 {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+            hostingView.layoutSubtreeIfNeeded()
+        }
+    }
+
+    var accessibilityElements: [any NSAccessibilityProtocol] {
+        var visited = Set<ObjectIdentifier>()
+        func descendants(_ element: any NSAccessibilityProtocol) -> [any NSAccessibilityProtocol] {
+            guard visited.insert(ObjectIdentifier(element)).inserted else { return [] }
+            return [element] + (element.accessibilityChildren() ?? []).flatMap { child in
+                guard let child = child as? any NSAccessibilityProtocol else { return [any NSAccessibilityProtocol]() }
+                return descendants(child)
+            }
+        }
+        return descendants(hostingView)
+    }
+
+    func elements(identifier: String) -> [any NSAccessibilityProtocol] {
+        accessibilityElements.filter { $0.accessibilityIdentifier() == identifier }
+    }
+
+    var textViews: [NSTextView] {
+        func descendants(_ view: NSView) -> [NSTextView] {
+            (view as? NSTextView).map { [$0] } ?? view.subviews.flatMap(descendants)
+        }
+        return descendants(hostingView)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

In `MeetingDetailView.content(for:)`, add an accessible recovery row in the non-recording manual-notes branch for failed meetings, reusing `retranscribeAction(for:)` and its existing `startRetranscription(for:)` callback; place it outside the `!usesCompactQuickNotes` condition so it remains visible at both standard and compact widths. Keep that row present while the local retranscription is in progress so the existing spinner remains visible as the meeting changes to processing, and preserve the existing recording/processing/editing disable rules and error alert; completed meetings retain their existing toolbar without a duplicate action. Align the action's saved-audio eligibility with the controller's nonempty-path check, allow stale nonempty paths to reach the existing actionable recording-unavailable error, and preserve the manual-notes editor rather than routing failed meetings through completed content.

A Qwen3-ASR re-transcription failure changes an existing meeting to `failed`, displayed as “Needs attention,” and removes the visible way to retry despite retained audio. The reporter confirms that changing to Whisper Large Turbo does not restore the action, while a standalone CLI transcription succeeds but creates a different artifact. On the inspected main checkout, `MeetingDetailView.showsManualNotesEditor(for:)` routes failed meetings through the manual-notes branch of `content(for:)`, which never renders `contentToolbar(for:)`, the only caller of `retranscribeAction(for:)`. The existing controller can already retry that meeting with the current configured meeting transcription backend and persist success on the same row.

Fixes #505

## Validation

Render a failed meeting with a retained recording in a normal-width detail view and a compact quick-notes view (520 points): the accessible Re-transcribe action is present and enabled, and manual notes remain editable before retry. Assert presence via the hosted view's accessibility tree or actual rendered controls, not just a non-nil image or source-text search; use the existing NSHostingView test pattern.
Check a failed meeting with nil, empty, or whitespace-only savedRecordingPath: do not offer an unusable recovery action. For a nonempty path whose file has disappeared, invoke the existing controller path and assert recordingUnavailable while status stays failed and the original content and path remain intact.
Check completed meetings still have exactly one Re-transcribe action, recording and unrelated processing meetings cannot start another transcription, and a pending retry shows the existing progress indicator without allowing duplicate activation. Note-only meetings must not acquire the new failure-specific row.
On a macOS test host with a downloaded Whisper model, open a failed meeting with saved audio, change Settings to Whisper Large Turbo, and retry: observe processing followed by completed, refreshed transcript/notes on the same meeting ID, retained manual notes and recording, and no extra meeting row. Retry from both compact and standard layouts.
Trigger another transcription failure: the existing alert explains the error, the busy state clears, and the failed meeting again exposes Re-transcribe. Successful transcription followed by summary-provider failure should continue using the existing transcript-preserving summary fallback.
Run focused native tests on Xcode 26.6 / Swift 6.3 / macOS 26: `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/issue-505/test" --filter 'WindowAppearanceTests|MeetingsNavigationTests'`. Then run the core and meetings CI shards with separate scratch paths if run concurrently. Linux checks (`./scripts/test_classify_changed_files.sh`, `./scripts/test_ci_test_shards.sh`, `./scripts/verify_update_flow.sh --skip-dmg`) cannot validate the SwiftUI behavior. Follow AGENTS.md LocalVQE requirements if packaging a dev app for the manual test.

## Contribution certification

- [ ] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [ ] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [ ] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

Not applicable to this change.

### AI assistance

Not applicable to this change.

AI was used for assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791708873&installation_model_id=422865&pr_number=514&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F514&signature=400ace216f668d75094fc717d293fc0e3b27165966578e1561263f90fafbf106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed meetings now offer a re-transcription action above the notes editor.
  * Re-transcription is available only when a saved recording is present.
  * Progress and action controls include improved accessibility labels and identifiers.

* **Bug Fixes**
  * Re-transcription preserves meeting details and status when the recording is unavailable.

* **Tests**
  * Added coverage for recovery controls across layouts, processing states, duplicate actions, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->